### PR TITLE
fix(ci): use release_token for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,8 +445,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Use PAT token to allow pushing to protected main branch
           # persist-credentials must be true for semantic-release to push commits
           persist-credentials: true
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -470,7 +472,7 @@ jobs:
       - name: Run semantic-release
         id: semantic
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 


### PR DESCRIPTION
## Summary

Configures semantic-release to use a Personal Access Token (PAT) that can bypass repository rules, allowing automated releases to push to main while regular users still require PRs.

## Problem

- Repository rules block ALL pushes to main (requires 14 status checks)
- Default `GITHUB_TOKEN` cannot bypass these rules
- semantic-release needs to push version bumps back to main

## Solution

Use a **Personal Access Token** with admin permissions:
- PAT has permissions to bypass repository rules
- GitHub Actions uses PAT instead of default `GITHUB_TOKEN`
- Regular users still blocked (they don't have the PAT)

## Changes

**Workflow Updates** ([.github/workflows/ci.yml](.github/workflows/ci.yml)):
```yaml
# Checkout with PAT
- uses: actions/checkout@v4
  with:
    token: ${{ secrets.RELEASE_TOKEN }}  # <-- Changed from GITHUB_TOKEN
    
# semantic-release with PAT
- name: Run semantic-release
  env:
    GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}  # <-- Changed from GITHUB_TOKEN
```

## Setup Instructions

### 1. Create Personal Access Token

Go to: https://github.com/settings/tokens/new

**Settings:**
- Name: `semantic-release-token`
- Expiration: No expiration (or custom)
- Scopes: ✅ `repo` (Full control of private repositories)

Click "Generate token" and **COPY THE TOKEN** (you won't see it again)

### 2. Add Token as Repository Secret

```bash
# Option 1: Using gh CLI (recommended)
gh secret set RELEASE_TOKEN --body "ghp_your_token_here"

# Option 2: Via GitHub UI
# Go to: https://github.com/shep-ai/cli/settings/secrets/actions
# Click "New repository secret"
# Name: RELEASE_TOKEN
# Value: ghp_your_token_here
```

### 3. Verify Setup

After merging this PR and adding the token:

1. Make a commit with `feat:` or `fix:` to trigger a release
2. Push to main (via merged PR)
3. Watch CI/CD Release job
4. semantic-release should successfully push version bump commits

## Security Notes

✅ **Token is secret** - Stored encrypted, never exposed in logs  
✅ **Users blocked** - Only GitHub Actions workflow has access  
✅ **Scope limited** - Only `repo` scope, no org-wide access  
⚠️ **Token owner** - Must have admin/write access to repository

## Impact

- ✅ semantic-release can push to main
- ✅ Version bumps committed automatically
- ✅ CHANGELOG.md updated in repository
- ✅ Users still required to use PRs
- ✅ All repository rules still enforced for users

## Alternative: GitHub App

If you prefer not to use a PAT, you can create a GitHub App with bypass permissions. This is more complex but more secure for organizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)