### PR TITLE
refactor(cli): redesign settings show output

### DIFF
--- a/src/presentation/cli/ui/index.ts
+++ b/src/presentation/cli/ui/index.ts
@@ -16,5 +16,5 @@ export { colors, type Colors } from './colors.js';
 export { symbols, type Symbols } from './symbols.js';
 export { fmt, type Formatters } from './formatters.js';
 export { messages, type Messages } from './messages.js';
-export { TableFormatter } from './tables.js';
+export { TableFormatter, type DatabaseMeta } from './tables.js';
 export { OutputFormatter, type OutputFormat } from './output.js';

--- a/src/presentation/cli/ui/output.ts
+++ b/src/presentation/cli/ui/output.ts
@@ -2,7 +2,7 @@
  * Output Format Utilities
  *
  * Provides utilities for formatting output in multiple formats:
- * - Table (default, using cli-table3)
+ * - Table (default, clean text-based layout)
  * - JSON (structured data)
  * - YAML (human-readable structured data)
  *
@@ -10,7 +10,7 @@
  */
 
 import yaml from 'js-yaml';
-import { TableFormatter } from './tables.js';
+import { TableFormatter, type DatabaseMeta } from './tables.js';
 
 export type OutputFormat = 'table' | 'json' | 'yaml';
 
@@ -21,10 +21,10 @@ export class OutputFormatter {
   /**
    * Formats data according to the specified output format
    */
-  static format(data: unknown, format: OutputFormat): string {
+  static format(data: unknown, format: OutputFormat, dbMeta?: DatabaseMeta): string {
     switch (format) {
       case 'table':
-        return OutputFormatter.formatAsTable(data);
+        return OutputFormatter.formatAsTable(data, dbMeta);
       case 'json':
         return OutputFormatter.formatAsJSON(data);
       case 'yaml':
@@ -33,11 +33,10 @@ export class OutputFormatter {
   }
 
   /**
-   * Formats data as a table
+   * Formats data as a clean text display
    */
-  static formatAsTable(data: unknown): string {
-    const table = TableFormatter.createSettingsTable(data);
-    return table.toString();
+  static formatAsTable(data: unknown, dbMeta?: DatabaseMeta): string {
+    return TableFormatter.createSettingsTable(data, dbMeta);
   }
 
   /**

--- a/tests/e2e/cli/settings-show.test.ts
+++ b/tests/e2e/cli/settings-show.test.ts
@@ -42,8 +42,7 @@ describe('CLI: settings show', () => {
       const result = runCli('settings show');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('Database'); // Metadata section
-      expect(result.stdout).toContain('Path:');
+      expect(result.stdout).toContain('Database');
       expect(result.stdout).toContain('.shep/data');
     });
   });

--- a/tests/unit/presentation/cli/ui/tables.test.ts
+++ b/tests/unit/presentation/cli/ui/tables.test.ts
@@ -1,11 +1,7 @@
 /**
  * TableFormatter Unit Tests
  *
- * Tests for the TableFormatter that creates formatted tables for CLI output.
- *
- * TDD Phase: RED
- * - These tests are written BEFORE implementation
- * - All tests should FAIL initially because formatter doesn't work yet
+ * Tests for the clean text-based settings display.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -17,43 +13,66 @@ describe('TableFormatter', () => {
   const sampleSettings = createDefaultSettings();
 
   describe('createSettingsTable()', () => {
-    it('should return a Table instance', () => {
-      // Act
+    it('should return a string', () => {
       const result = TableFormatter.createSettingsTable(sampleSettings);
 
-      // Assert
-      expect(result).toBeDefined();
-      expect(typeof result.toString).toBe('function'); // Tables have toString method
-    });
-
-    it('should create table with settings data', () => {
-      // Act
-      const table = TableFormatter.createSettingsTable(sampleSettings);
-      const tableString = table.toString();
-
-      // Assert
-      expect(tableString).toBeTypeOf('string');
-      expect(tableString.length).toBeGreaterThan(0);
+      expect(result).toBeTypeOf('string');
+      expect(result.length).toBeGreaterThan(0);
     });
 
     it('should include all settings sections', () => {
-      // Act
-      const table = TableFormatter.createSettingsTable(sampleSettings);
-      const tableString = table.toString();
+      const result = TableFormatter.createSettingsTable(sampleSettings);
 
-      // Assert
-      expect(tableString).toContain('Models');
-      expect(tableString).toContain('Environment');
-      expect(tableString).toContain('System');
+      expect(result).toContain('Models');
+      expect(result).toContain('User');
+      expect(result).toContain('Environment');
+      expect(result).toContain('System');
+      expect(result).toContain('Agent');
     });
 
-    it('should handle nested objects in settings', () => {
-      // Act
-      const table = TableFormatter.createSettingsTable(sampleSettings);
-      const tableString = table.toString();
+    it('should include model values', () => {
+      const result = TableFormatter.createSettingsTable(sampleSettings);
 
-      // Assert - Should include nested values (e.g., models.analyze)
-      expect(tableString).toContain('claude-sonnet-4-5'); // Default model name
+      expect(result).toContain('claude-sonnet-4-5');
+    });
+
+    it('should show (not set) for missing optional fields', () => {
+      const result = TableFormatter.createSettingsTable(sampleSettings);
+
+      expect(result).toContain('(not set)');
+    });
+
+    it('should include agent configuration', () => {
+      const result = TableFormatter.createSettingsTable(sampleSettings);
+
+      expect(result).toContain('claude-code');
+      expect(result).toContain('session');
+    });
+
+    it('should include database metadata when provided', () => {
+      const dbMeta = { path: '/home/test/.shep/data', size: '152.0 KB' };
+      const result = TableFormatter.createSettingsTable(sampleSettings, dbMeta);
+
+      expect(result).toContain('Database');
+      expect(result).toContain('/home/test/.shep/data');
+      expect(result).toContain('152.0 KB');
+    });
+
+    it('should omit database section when not provided', () => {
+      const result = TableFormatter.createSettingsTable(sampleSettings);
+
+      expect(result).not.toContain('Database');
+    });
+
+    it('should mask token when present', () => {
+      const settingsWithToken = {
+        ...sampleSettings,
+        agent: { ...sampleSettings.agent, token: 'sk-secret-key' },
+      };
+      const result = TableFormatter.createSettingsTable(settingsWithToken);
+
+      expect(result).not.toContain('sk-secret-key');
+      expect(result).toContain('••••••••');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace `cli-table3` box-drawing borders with clean text-based layout using whitespace, alignment, and semantic colors
- Merge Database metadata section into the unified settings display flow
- Add Agent section (type, auth, token masking with `••••••••`)

## Test plan
- [x] All 170 unit tests pass (8 updated table tests)
- [x] All 45 integration tests pass
- [x] All 57 E2E tests pass (updated database metadata assertion)
- [x] Typecheck clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)