### PR TITLE
fix(cli): correct Next.js route types import path

### DIFF
--- a/src/presentation/web/next-env.d.ts
+++ b/src/presentation/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Fix `next-env.d.ts` route types import path from `.next/dev/types/routes.d.ts` to `.next/types/routes.d.ts`, resolving type resolution issues when running the web UI via CLI

## Test plan
- [ ] Verify `pnpm typecheck:web` passes
- [ ] Verify `pnpm dev:web` starts without type errors
- [ ] Verify `pnpm build:web` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)