### PR TITLE
feat(web): add optimistic feature creation with instant feedback

### DIFF
--- a/specs/024-optimistic-feature-creation/feature.yaml
+++ b/specs/024-optimistic-feature-creation/feature.yaml
@@ -1,0 +1,43 @@
+feature:
+  id: 024-optimistic-feature-creation
+  name: optimistic-feature-creation
+  number: 24
+  branch: feat/024-optimistic-feature-creation
+  lifecycle: review
+  createdAt: '2026-02-18T15:37:27Z'
+status:
+  phase: in-review
+  progress:
+    completed: 12
+    total: 12
+    percentage: 100
+  currentTask: null
+  lastUpdated: '2026-02-18T18:58:00.000Z'
+  lastUpdatedBy: shep-kit:commit-pr
+  completedPhases:
+    - analyze
+    - requirements
+    - research
+    - plan
+    - phase-1
+    - phase-2
+    - phase-3
+    - phase-4
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+tasks:
+  current: null
+  blocked: []
+  failed: []
+checkpoints:
+  - phase: feature-created
+    completedAt: '2026-02-18T15:37:27Z'
+    completedBy: feature-agent
+  - phase: pr-created
+    completedAt: '2026-02-18T18:58:00.000Z'
+    completedBy: shep-kit:commit-pr
+errors:
+  current: null
+  history: []

--- a/specs/024-optimistic-feature-creation/plan.yaml
+++ b/specs/024-optimistic-feature-creation/plan.yaml
@@ -1,0 +1,200 @@
+# Implementation Plan (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: optimistic-feature-creation
+summary: >
+  Implement optimistic feature creation by: (1) fixing the client→server payload mismatch as a prerequisite,
+  (2) adding a new 'creating' FeatureNodeState with dedicated visual treatment, (3) rewriting
+  handleCreateFeatureSubmit to insert an optimistic node instantly and fire the API call in the background,
+  (4) adding a useEffect to sync server prop changes into local React Flow state for reconciliation,
+  and (5) guarding non-interactivity for optimistic nodes in FeaturesCanvas. The implementation builds
+  entirely on existing patterns (state config record, createFeatureNode positioning, setNodes/setEdges,
+  toast, router.refresh) with no new dependencies.
+
+relatedFeatures: []
+
+technologies:
+  - React (useState, useCallback, useEffect)
+  - Next.js App Router (router.refresh for server reconciliation)
+  - React Flow (@xyflow/react — setNodes, setEdges, node types)
+  - shadcn/ui (Drawer, Toast via sonner)
+  - Dagre (@dagrejs/dagre for graph layout)
+  - TypeScript
+  - Vitest (unit testing)
+  - Storybook (component stories)
+  - Tailwind CSS v4 (motion-reduce, aria-busy)
+
+relatedLinks: []
+
+phases:
+  - id: phase-1
+    name: 'Payload Fix & Type Contract'
+    description: >
+      Fix the blocking client→server API payload mismatch. Define a new FeatureCreatePayload type
+      for the drawer→API contract, refactor the drawer to send structured {name, description, attachments,
+      repositoryPath, approvalGates} instead of composing a userInput blob, and update the onSubmit
+      type signature across all consumers (control-center-inner, stories, tests). This is a prerequisite
+      because the optimistic node needs structured name/description fields for display, and the current
+      flow would 400 on submission.
+    parallel: false
+
+  - id: phase-2
+    name: 'Creating State & Node Rendering'
+    description: >
+      Add the 'creating' FeatureNodeState to the state config record and implement its visual rendering
+      in the FeatureNode component. This includes the Loader2 icon, blue border, "Creating..." badge text,
+      indeterminate progress bar, no agent icon, aria-busy attribute, and motion-reduce accessibility.
+      Add Storybook stories for the new state. This phase is independent of the optimistic flow logic
+      and establishes the visual foundation.
+    parallel: false
+
+  - id: phase-3
+    name: 'Optimistic Insert, Reconciliation & Rollback'
+    description: >
+      The core of the feature. Modify createFeatureNode to accept state override and return the generated
+      node ID. Rewrite handleCreateFeatureSubmit to: insert optimistic node → close drawer → fire background
+      API call → on success call router.refresh() → on failure remove node/edge and show error toast. Add
+      a useEffect that syncs initialNodes/initialEdges prop changes into local state so router.refresh()
+      reconciliation works. Guard handleNodeClick to skip 'creating' nodes. This is the highest-risk phase.
+    parallel: false
+
+  - id: phase-4
+    name: 'Non-Interactive Guard & Integration'
+    description: >
+      Guard optimistic nodes from user interaction by filtering out onAction/onSettings callbacks in
+      FeaturesCanvas enrichedNodes for nodes with state === 'creating'. Remove the isSubmitting prop
+      from FeatureCreateDrawer usage since the drawer now closes immediately. Verify end-to-end flow
+      and update all remaining stories and tests for the new behavior.
+    parallel: false
+
+filesToCreate: []
+
+filesToModify:
+  - src/presentation/web/components/common/feature-node/feature-node-state-config.ts
+  - src/presentation/web/components/common/feature-node/feature-node.tsx
+  - src/presentation/web/components/common/feature-node/feature-node.stories.tsx
+  - src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
+  - src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.stories.tsx
+  - src/presentation/web/components/features/control-center/use-control-center-state.ts
+  - src/presentation/web/components/features/control-center/control-center-inner.tsx
+  - src/presentation/web/components/features/features-canvas/features-canvas.tsx
+  - tests/unit/presentation/web/features/control-center/use-control-center-state.test.tsx
+  - tests/unit/presentation/web/common/feature-node/feature-node.test.tsx
+  - tests/unit/presentation/web/components/common/feature-create-drawer/feature-create-drawer.test.tsx
+
+openQuestions: []
+
+content: |
+  ## Architecture Overview
+
+  This feature modifies the web presentation layer only — no changes to core domain, application use cases,
+  or infrastructure. The implementation follows the existing Clean Architecture boundary: the web API route
+  (`app/api/features/create/route.ts`) already expects structured `{name, description, repositoryPath,
+  attachments, approvalGates}` and translates to the core `CreateFeatureInput` format via its server-side
+  `composeUserInput()` function. No changes are needed to the API route or core packages.
+
+  The optimistic pattern fits naturally into the existing `useControlCenterState` hook, which already manages
+  canvas nodes/edges via React Flow's `setNodes`/`setEdges`, handles async API calls with `fetch`, shows
+  toasts via `sonner`, and triggers reconciliation via `router.refresh()`. The `createFeatureNode()` function
+  already implements sibling-aware positioning, edge creation, and temporary ID generation — the optimistic
+  node reuses this logic with a `{state: 'creating'}` data override.
+
+  The feature node's visual state system is config-driven via `featureNodeStateConfig` record
+  (`feature-node-state-config.ts:73-124`). Adding a new `'creating'` state follows the established pattern:
+  one new union member in `FeatureNodeState`, one new entry in the config record. The `FeatureNode` component
+  already branches on `data.state` for rendering, so the `'creating'` branch slots in alongside `'running'`.
+
+  ### Component Modification Flow
+
+  ```
+  FeatureCreateDrawer (payload fix)
+    → useControlCenterState (optimistic insert + reconciliation)
+      → createFeatureNode (state override + return ID)
+      → handleCreateFeatureSubmit (async background pattern)
+      → useEffect (initialNodes sync)
+    → FeaturesCanvas (non-interactive guard)
+    → FeatureNode (creating state rendering)
+    → feature-node-state-config (new state definition)
+  ```
+
+  ## Key Design Decisions
+
+  ### 1. Structured Payload over userInput Blob
+
+  The drawer currently composes a `userInput` string from name + description + attachments, but the API
+  route expects structured fields. Rather than parsing the blob server-side (fragile) or changing the API
+  route (it's already correct), the fix sends structured data from the drawer. This also provides the
+  optimistic node with `name` and `description` directly, avoiding the need to parse a composed string.
+
+  A new `FeatureCreatePayload` type is defined in the web layer for the drawer→API contract, keeping the
+  core `CreateFeatureInput` unchanged. This follows the existing architectural pattern where the web layer
+  maintains its own types distinct from core domain types (e.g., `FeatureNodeData`, `CanvasNodeType`).
+
+  ### 2. Inline Optimistic Logic in useControlCenterState
+
+  The optimistic insert/rollback logic lives directly in `handleCreateFeatureSubmit` rather than being
+  extracted to a separate hook. The logic is ~30 lines, tightly coupled to existing state
+  (`pendingRepoNodeId`, `createFeatureNode`, `setNodes`, `setEdges`, drawer state), and testable via the
+  existing `HookTestHarness` pattern in `use-control-center-state.test.tsx`. Extracting it would require
+  passing 5+ state setters for a single-use abstraction.
+
+  Alternatives rejected: React 19 `useOptimistic` (designed for server state/form actions, not React Flow
+  client state), zustand/jotai (premature for one feature), custom `useOptimisticNodes` hook (over-abstraction).
+
+  ### 3. useEffect for initialNodes Sync
+
+  `useState(initialNodes)` only uses its argument on mount — when `router.refresh()` delivers new server data,
+  the hook ignores the updated `initialNodes` prop. A `useEffect` keyed on a stable serialization of
+  `initialNodes` (e.g., JSON.stringify of node IDs + count) calls `setNodes(initialNodes)` /
+  `setEdges(initialEdges)` to re-sync. This is the standard Next.js pattern for syncing server props into
+  client state and also fixes a latent bug where server-side changes don't reflect until navigation.
+
+  ### 4. Non-Interactivity via Callback Filtering
+
+  Optimistic nodes are made non-interactive by not injecting `onAction`/`onSettings` callbacks in
+  `FeaturesCanvas.enrichedNodes` for nodes with `data.state === 'creating'`. Since the action button only
+  renders when `onAction` exists (`feature-node.tsx:162`), this naturally hides it. The settings button
+  similarly only renders when `onSettings` exists (`feature-node.tsx:72`). Click-to-select is guarded in
+  `handleNodeClick` by checking the node's data state.
+
+  ### 5. Reconciliation via Full State Replacement
+
+  On API success, `router.refresh()` causes `page.tsx` to re-fetch all features and rebuild nodes from
+  scratch via Dagre layout. The `useEffect` detects the prop change and replaces local state entirely.
+  The brief gap between the optimistic node and the server-rendered replacement is imperceptible (<100ms).
+  Position jumps from Dagre re-layout are accepted for V1 — the delta is small since `createFeatureNode()`
+  mimics Dagre-like placement.
+
+  ## Implementation Strategy
+
+  The phases are ordered by dependency and risk:
+
+  **Phase 1 (Payload Fix)** must come first because it's a blocking bug — the current drawer submission
+  would 400. It also establishes the structured data contract that the optimistic node depends on for
+  displaying name/description. This is the lowest-risk phase (type changes + form refactor).
+
+  **Phase 2 (Creating State)** is independent of the optimistic flow logic and establishes the visual
+  foundation. It can be fully tested in isolation via Storybook and unit tests before the state is wired
+  into the optimistic flow. Low risk — follows the established state config pattern exactly.
+
+  **Phase 3 (Optimistic Flow)** is the core and highest-risk phase. It modifies `createFeatureNode` (return
+  ID, accept state override), rewrites `handleCreateFeatureSubmit` (async background pattern), and adds the
+  `useEffect` for prop sync. Each modification has its own TDD cycle. The existing test harness and mock
+  infrastructure (fetch, router, toast) support comprehensive testing.
+
+  **Phase 4 (Non-Interactive Guard)** is a small integration phase that wires the creating state into
+  FeaturesCanvas callback filtering and cleans up the isSubmitting prop. Low risk — minimal code changes
+  with clear test assertions.
+
+  ## Risk Mitigation
+
+  | Risk | Mitigation |
+  | ---- | ---------- |
+  | useEffect initialNodes sync causes infinite re-render loop | Key the effect on a stable derived value (sorted node ID string or count), not the full object reference. Test explicitly for render stability. |
+  | Optimistic node persists after router.refresh() if sync fails | The useEffect compares a serialization of initialNodes; if it fires, it replaces state entirely. Add a test that verifies the optimistic node is gone after simulated prop update. |
+  | createFeatureNode return value change breaks existing callers | Currently returns void; no callers check the return value. handleAddFeatureToFeature calls it but ignores the result. Non-breaking change. |
+  | Multiple concurrent optimistic nodes cause edge/ID collisions | createFeatureNode already uses Date.now() + incrementing counter for unique IDs. Each edge ID includes the node ID. Test concurrent creation explicitly. |
+  | Stale closure in async fetch callback references old setNodes | setNodes with functional updater (`prev => prev.filter(...)`) avoids stale closure — the filter always operates on current state. Standard React pattern. |
+  | API payload type change breaks drawer stories/tests | Phase 1 explicitly updates all stories and tests for the new payload shape before any other changes. |
+  | User navigates away during in-flight optimistic creation | React 18+ ignores state updates on unmounted components. The API call completes server-side; the feature appears on next navigation. No cleanup needed. |
+  | Accessibility: animation disorienting for vestibular disorders | Use Tailwind motion-safe:/motion-reduce: variants on the progress bar animation. Add aria-busy="true" to the node card in creating state. |

--- a/specs/024-optimistic-feature-creation/research.yaml
+++ b/specs/024-optimistic-feature-creation/research.yaml
@@ -1,0 +1,415 @@
+# Research Artifact (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: optimistic-feature-creation
+summary: >
+  Research for implementing optimistic feature creation on the React Flow canvas. Key decisions: fix
+  the client→server payload mismatch by sending structured {name, description, attachments} from the
+  drawer (API route already expects this shape); add a new 'creating' FeatureNodeState using the existing
+  config pattern; implement the optimistic insert/rollback flow inline in useControlCenterState using
+  existing setNodes/setEdges + createFeatureNode logic; guard non-interactivity in FeaturesCanvas enrichedNodes.
+  No new libraries needed — the feature builds entirely on existing patterns and dependencies.
+
+relatedFeatures: []
+
+technologies:
+  - React (useState, useCallback)
+  - Next.js App Router (router.refresh for server reconciliation)
+  - React Flow (@xyflow/react — setNodes, setEdges, node types)
+  - shadcn/ui (Drawer, Toast via sonner)
+  - Dagre (@dagrejs/dagre for graph layout)
+  - TypeScript
+  - Vitest (unit testing)
+  - Storybook (component stories)
+
+relatedLinks: []
+
+decisions:
+  - title: 'Payload Mismatch Fix Strategy'
+    chosen: 'Update drawer to send structured {name, description, attachments, repositoryPath, approvalGates} — stop composing userInput client-side'
+    rejected:
+      - 'Update API route to accept {userInput, repositoryPath, approvalGates} directly — This would align the API to the drawer but loses structured data. The API route already has composeUserInput() server-side (route.ts:35-52) which properly composes from name+description+attachments. The optimistic node also needs separate name/description fields to display on the placeholder. Sending structured data is strictly better for both concerns.'
+      - 'Add a parsing layer in the API route to decompose userInput back into name/description/attachments — Fragile regex parsing of a composed string; violates the principle of sending structured data over the wire. Error-prone and unnecessary since the drawer already has the structured fields.'
+    rationale: >
+      The API route at app/api/features/create/route.ts (line 56) already destructures {name, description,
+      repositoryPath, attachments, approvalGates} from the request body and validates name is present (line 64).
+      The route's composeUserInput() function (lines 35-52) handles server-side composition before passing to
+      the core use case. The drawer (feature-create-drawer.tsx) has name, description, and attachments as separate
+      state variables — the client-side composeUserInput() (lines 48-65) that merges them into a single string
+      is the root of the mismatch. The fix is to remove the client-side composition and send structured fields
+      directly. This also gives the optimistic node access to name/description without parsing. The CreateFeatureInput
+      type in packages/core must either be updated to accept structured fields or kept as-is (since the API route
+      transforms to {userInput} before calling the use case). The cleanest approach: introduce a new
+      FeatureCreatePayload type for the client→API contract, distinct from the core CreateFeatureInput type.
+
+  - title: 'Client→API Type Contract'
+    chosen: 'Define a new FeatureCreatePayload interface in the web layer for the drawer→API contract, keep core CreateFeatureInput unchanged'
+    rejected:
+      - 'Modify core CreateFeatureInput to accept {name, description, attachments} — This would change the core domain contract for a presentation-layer concern. The core use case legitimately expects a composed userInput string. Changing it ripples into CLI and other consumers.'
+      - 'Use CreateFeatureInput directly and have the drawer compose userInput — This is the current broken approach. The drawer would still need to send structured data for the optimistic node display, creating a split responsibility.'
+    rationale: >
+      The core CreateFeatureInput type ({userInput, repositoryPath, approvalGates}) is the correct contract for
+      the use case layer — it represents the composed user message. The web API route is the translation boundary
+      that converts structured form data into the core format. A new FeatureCreatePayload type (or inline type
+      in the drawer/hook) keeps concerns separated: the drawer sends structured data matching what the API expects,
+      the API route translates to core format. This follows the existing architectural pattern where the web layer
+      has its own types (e.g., FeatureNodeData, CanvasNodeType) distinct from core domain types.
+
+  - title: 'Optimistic State Management Approach'
+    chosen: 'Inline optimistic logic in useControlCenterState using existing setNodes/setEdges and createFeatureNode pattern'
+    rejected:
+      - 'Extract a custom useOptimisticNodes hook — Adds an abstraction layer for a single use case. The optimistic insert/rollback logic is ~30 lines and tightly coupled to the existing createFeatureNode positioning logic, pendingRepoNodeId state, and drawer lifecycle. Extracting it would require passing 5+ state setters and would not simplify testing (the existing test harness already renders the full hook).'
+      - 'Use React useOptimistic hook — React 19 useOptimistic is designed for form actions and server state. Our canvas nodes are client-side React Flow state, not server component state. useOptimistic expects a reducer that merges optimistic state with server state, but our reconciliation happens via router.refresh() which replaces initialNodes entirely. The hook would add complexity without solving the actual problem.'
+      - 'Use a state management library (zustand, jotai) for optimistic state — Over-engineering for this scope. The existing useState pattern in useControlCenterState works well. Adding a state library for one optimistic feature would be premature. The hook already manages nodes/edges state with setNodes/setEdges from React Flow.'
+    rationale: >
+      The existing useControlCenterState hook (use-control-center-state.ts) already contains createFeatureNode()
+      (lines 106-218) which handles positioning, edge creation, and temporary IDs. The handleCreateFeatureSubmit
+      function (lines 225-252) already has the API call, error handling, and router.refresh() logic. The optimistic
+      pattern is a natural evolution: (1) call createFeatureNode to insert the optimistic node, (2) close drawer,
+      (3) fire API call, (4) on success call router.refresh(), (5) on failure remove the node. This keeps all
+      feature creation state management in one place, testable via the existing HookTestHarness pattern in
+      use-control-center-state.test.tsx. The pendingRepoNodeId state already tracks which repo node to connect to.
+
+  - title: 'New FeatureNodeState for Optimistic Nodes'
+    chosen: "Add a new 'creating' state to FeatureNodeState union and featureNodeStateConfig record"
+    rejected:
+      - "Reuse 'running' state with a flag — The 'running' state renders an AgentIcon and lifecycle verb (e.g., 'Analyzing'). An optimistic node has no agent running and no lifecycle activity. Reusing 'running' would show misleading information (agent icon, lifecycle verb) and require conditional logic scattered through the component to suppress these elements."
+      - "Use a separate 'isOptimistic' boolean flag on FeatureNodeData — This creates a parallel state dimension that must be checked alongside the existing state field. The state config pattern (featureNodeStateConfig record) already provides a clean extension point. Adding a boolean flag would require if/else checks throughout the component instead of leveraging the config-driven rendering."
+    rationale: >
+      The feature-node-state-config.ts pattern makes adding a new state trivial: one new entry in the
+      FeatureNodeState union type (line 5) and one new record entry in featureNodeStateConfig (lines 73-124).
+      The FeatureNode component (feature-node.tsx) already branches on state for rendering. A 'creating' state
+      gets its own icon (Loader2, same as 'running'), border color (blue, same as 'running'), and badge text
+      ('Creating...'). The key visual difference from 'running': no agent icon, no lifecycle verb, and the
+      component treats 'creating' like 'running' for the progress bar (indeterminate). This is clean, extensible,
+      and follows the established pattern exactly.
+
+  - title: 'Non-Interactive Optimistic Node Guard'
+    chosen: 'Filter out onAction/onSettings callbacks in FeaturesCanvas enrichedNodes for nodes with state === creating'
+    rejected:
+      - 'Add interactivity guards inside FeatureNode component — The FeatureNode component should remain a pure visual component that renders whatever data it receives. Guard logic belongs at the data injection layer (FeaturesCanvas), not inside the rendering component. This keeps FeatureNode testable in isolation.'
+      - 'Use a CSS pointer-events-none approach — This would visually disable the node but still inject callbacks. It would also prevent the user from seeing the node clearly. The correct approach is to not inject the callbacks at all, which naturally hides the action button (it only renders when onAction exists) and prevents click-to-select behavior.'
+    rationale: >
+      FeaturesCanvas.enrichedNodes (features-canvas.tsx:74-94) already conditionally injects callbacks via spread:
+      onAction is only set when onNodeAction prop exists. The guard adds a second condition: also check that the
+      node's data.state is not 'creating'. This is minimal (~3 characters of change per callback) and prevents
+      the action button from rendering (it only renders when onAction exists per feature-node.tsx:162) and the
+      settings button from rendering (feature-node.tsx:72). For click-to-select, the handleNodeClick callback
+      in use-control-center-state.ts (line 58-63) should skip nodes with state 'creating'. This approach
+      preserves the existing component architecture where FeatureNode is a dumb renderer.
+
+  - title: 'Optimistic Node Reconciliation Strategy'
+    chosen: 'Remove optimistic node from local state before router.refresh(), let server data fully replace canvas state'
+    rejected:
+      - 'Keep optimistic node and merge with server data by matching on name — Fragile matching (names could overlap). The server assigns a real ID (feat-{id}) that differs from the temp ID (feature-{timestamp}-{counter}). Merging would require complex reconciliation logic with edge cases (what if the server response is slow and the user has navigated away?).'
+      - 'Keep optimistic node and swap its ID when API returns the real feature ID — This would require updating both the node ID and all edge references. React Flow node IDs are keys that trigger full re-renders on change. The API already returns the created feature, but the page.tsx server component rebuilds all nodes from scratch on refresh. Swapping would create a brief period where two nodes exist for the same feature.'
+    rationale: >
+      The page.tsx server component (app/page.tsx:34-117) rebuilds all nodes from scratch on every render: it
+      fetches all features, derives node states, runs Dagre layout, and passes fresh initialNodes/initialEdges
+      to ControlCenter. When router.refresh() runs, React re-renders the server component with the new feature
+      included. The useControlCenterState hook receives new initialNodes via props. The simplest correct approach:
+      on API success, the optimistic node has served its purpose (instant visual feedback). We don't need to
+      explicitly remove it — router.refresh() triggers a full re-render with fresh server data. However, the hook
+      initializes state with useState(initialNodes), which doesn't re-sync on prop changes. We need to either
+      (a) add a useEffect that syncs initialNodes to state, or (b) explicitly remove the optimistic node then
+      call router.refresh(). Option (b) is simpler and avoids adding sync logic that could have side effects.
+      On success: remove optimistic node → router.refresh() → server data replaces everything. The brief gap
+      between removal and refresh is imperceptible (<100ms).
+
+  - title: 'Handling useState(initialNodes) Not Syncing on Server Refresh'
+    chosen: 'Use a useEffect keyed on serialized initialNodes to re-sync local state when server data changes'
+    rejected:
+      - 'Replace useState with useRef + forceUpdate — Breaks React Flow reactivity. setNodes/setEdges from React Flow expect proper React state. Using refs would bypass React rendering and create stale closure issues in callbacks.'
+      - 'Call setNodes(initialNodes) inside router.refresh() callback — router.refresh() does not take a callback. It returns a Promise in some Next.js versions but the behavior is not guaranteed. The re-render happens asynchronously when the server component re-renders.'
+      - 'Use key prop on ControlCenter to force remount — This would destroy all local state including viewport position, zoom, and any in-progress interactions. Overly aggressive for a data sync.'
+    rationale: >
+      The core issue: useState(initialNodes) (use-control-center-state.ts:42) only uses initialNodes as the
+      initial value. When router.refresh() causes page.tsx to re-render with new features, ControlCenter receives
+      new initialNodes but the hook ignores them. Currently this works because router.refresh() is called after
+      the drawer is closed and the user sees a full page load. With optimistic updates, we need the server data
+      to replace the optimistic node. A useEffect that watches initialNodes and calls setNodes(initialNodes) /
+      setEdges(initialEdges) when they change is the standard Next.js pattern for syncing server props into client
+      state. The effect should use a stable serialization (JSON.stringify or a length + id hash) to avoid infinite
+      loops. This also fixes the existing (latent) bug where server-side state changes (e.g., agent status updates)
+      don't reflect on the canvas until a full page navigation.
+
+  - title: 'Optimistic Node Positioning'
+    chosen: 'Reuse existing createFeatureNode() positioning logic with state override to creating'
+    rejected:
+      - 'Calculate position separately from createFeatureNode — Duplicates the sibling-aware positioning, group shifting, and parent re-centering logic (~100 lines). Maintenance burden and drift risk.'
+      - 'Place optimistic node at a fixed position (e.g., center of viewport) — Ignores existing graph layout. The node would appear disconnected from the repository it belongs to, creating visual confusion.'
+    rationale: >
+      createFeatureNode() (use-control-center-state.ts:106-218) already implements comprehensive positioning:
+      sibling detection, gap derivation, parent re-centering, and group shifting. It accepts a sourceNodeId
+      parameter (the repo node) and a dataOverride parameter for customizing node data. The optimistic node
+      can use this function directly by passing {state: 'creating', name, description, repositoryPath} as the
+      dataOverride. The only modification needed: createFeatureNode currently hardcodes state: 'running' (line 114).
+      Accepting state via dataOverride requires the function to spread dataOverride over the defaults, which it
+      already does for name, description, repositoryPath (lines 110-117). Adding state to the spread is trivial.
+      The function also currently calls setSelectedNode (line 215) which we should skip for optimistic nodes.
+
+  - title: 'Temporary ID Scheme for Optimistic Nodes'
+    chosen: 'Use existing feature-{Date.now()}-{counter} pattern from createFeatureNode, store temp IDs for rollback'
+    rejected:
+      - 'Use a UUID library (e.g., crypto.randomUUID()) — Adds unnecessary dependency. The existing timestamp+counter pattern (line 108) already guarantees uniqueness within a session. Optimistic nodes are ephemeral and never persisted.'
+      - 'Use a special prefix like optimistic-{id} — Adds a new ID namespace that must be handled throughout the codebase (edge filtering, node lookups). The existing feature-{timestamp} prefix already works with all node operations.'
+    rationale: >
+      The createFeatureNode function already generates unique IDs via `feature-${Date.now()}-${nextFeatureId++}`
+      (line 108). This is sufficient for optimistic nodes: they only exist in client state for seconds. The
+      handleCreateFeatureSubmit function needs to capture this ID so it can remove the optimistic node on failure.
+      The createFeatureNode function currently doesn't return the generated ID — it will need a small modification
+      to either return the ID or accept a pre-generated ID. Returning the ID is simpler and doesn't change the
+      function's internal logic.
+
+  - title: 'Error Toast Implementation'
+    chosen: 'Use existing sonner toast.error() pattern already in handleCreateFeatureSubmit'
+    rejected:
+      - 'Custom error component with retry button — Over-engineering for V1. The toast already shows the error message from the API response (use-control-center-state.ts:237). A retry button would require re-opening the drawer with pre-filled data, adding significant complexity.'
+    rationale: >
+      handleCreateFeatureSubmit already imports toast from sonner (line 5) and uses toast.error() for failure
+      cases (lines 237, 246). The optimistic pattern extends this: on API failure, remove the optimistic node
+      AND show toast.error(). The existing pattern handles both network errors (catch block) and API errors
+      (non-ok response with error body). No changes needed to the toast infrastructure.
+
+  - title: 'Accessibility for Creating State Animation'
+    chosen: 'Use Tailwind motion-reduce utility class and aria-busy attribute'
+    rejected:
+      - 'JavaScript matchMedia listener for prefers-reduced-motion — Over-engineering when Tailwind provides motion-reduce: and motion-safe: variants that compile to the correct @media query. The existing animation (animate-indeterminate-progress) is defined in globals.css and can be conditionally applied.'
+      - 'No accessibility handling — Violates NFR-7 from the spec. The creating state has a pulsing animation that could be disorienting for users with vestibular disorders.'
+    rationale: >
+      Tailwind CSS v4 provides motion-reduce: and motion-safe: variants that compile to
+      @media (prefers-reduced-motion: reduce). The existing indeterminate progress bar animation
+      (animate-indeterminate-progress in globals.css:73) does not currently respect reduced motion. For the
+      'creating' state, apply the animation conditionally: motion-safe:animate-indeterminate-progress. For
+      reduced-motion users, the progress bar remains static (a filled bar). Additionally, add aria-busy="true"
+      to the feature node card when state is 'creating' to announce the loading state to screen readers.
+      This is a minimal, standards-compliant approach.
+
+openQuestions:
+  - question: 'Should createFeatureNode return the generated node ID for rollback tracking?'
+    resolved: true
+    answer: >
+      Yes. Currently createFeatureNode (use-control-center-state.ts:106-218) generates the ID internally
+      (line 108) but does not return it. The optimistic pattern needs the ID to remove the node on failure.
+      The simplest change: have createFeatureNode return the generated ID string. This is a non-breaking
+      change since the return value was previously void/undefined and no callers check it.
+
+  - question: 'How does useState(initialNodes) behave when router.refresh() delivers new server data?'
+    resolved: true
+    answer: >
+      useState only uses its argument as the initial value on mount. When router.refresh() triggers a
+      server component re-render, ControlCenterInner receives new initialNodes/initialEdges props, but
+      the useState inside useControlCenterState ignores them (standard React behavior). This means the
+      optimistic node would persist even after router.refresh() unless explicitly removed. The fix: add a
+      useEffect that detects changes to initialNodes/initialEdges (via a stable comparison like JSON.stringify
+      or ID set comparison) and calls setNodes(initialNodes) / setEdges(initialEdges) to re-sync. This is a
+      standard pattern for syncing server props into client state in Next.js App Router.
+
+  - question: 'Does the drawer onSubmit callback need to change its type signature?'
+    resolved: true
+    answer: >
+      Yes. Currently the drawer's onSubmit expects (data: CreateFeatureInput) where CreateFeatureInput is
+      {userInput, repositoryPath, approvalGates}. It will change to accept a new type with structured fields:
+      {name, description, repositoryPath, attachments, approvalGates}. The onSubmit in useControlCenterState
+      will receive this structured data, use name/description for the optimistic node, and send the full payload
+      to the API. The FeatureCreateDrawerProps.onSubmit type changes from (data: CreateFeatureInput) => void
+      to (data: FeatureCreatePayload) => void. All consumers (control-center-inner.tsx, stories, tests) must
+      be updated.
+
+  - question: 'What happens if the user navigates away while an optimistic creation is in-flight?'
+    resolved: true
+    answer: >
+      If the user navigates to a different page, the ControlCenterInner component unmounts, destroying the
+      optimistic node state. The background fetch continues but its callbacks (setNodes, toast) operate on
+      stale state setters. React handles this gracefully — state updates on unmounted components are no-ops
+      in React 18+. The API call still completes server-side, so the feature is created. When the user
+      navigates back, page.tsx fetches fresh data and the feature appears. No cleanup needed.
+
+  - question: 'Will the pendingRepoNodeId correctly identify the source repository for the optimistic edge?'
+    resolved: true
+    answer: >
+      Yes. When the user clicks "Add Feature" from a repository node, handleAddFeatureToRepo (line 286-290)
+      stores the repo node ID in pendingRepoNodeId state. This ID (e.g., "repo-/Users/dev/my-project") is
+      available when handleCreateFeatureSubmit runs. The createFeatureNode function accepts sourceNodeId as
+      its first parameter and uses it for edge creation (lines 203-213) and positioning (lines 122-148).
+      For the "generic" add feature flow (no specific repo), pendingRepoNodeId is null and the node is
+      placed standalone — which matches the current behavior.
+
+content: |
+  ## Technology Decisions
+
+  ### 1. Payload Mismatch Fix Strategy
+
+  **Chosen:** Update drawer to send structured `{name, description, attachments, repositoryPath, approvalGates}` — stop composing `userInput` client-side
+
+  **Rejected:**
+  - Update API route to accept `{userInput}` directly — Loses structured data; API already has `composeUserInput()` server-side
+  - Add parsing layer in API to decompose `userInput` — Fragile regex; violates structured data principle
+
+  **Rationale:** The API route (`route.ts:56`) already destructures `{name, description, repositoryPath, attachments, approvalGates}` and validates `name` is present (`route.ts:64`). The route's `composeUserInput()` (`route.ts:35-52`) handles server-side composition. The drawer has `name`, `description`, `attachments` as separate state — the client-side `composeUserInput()` that merges them is the root of the mismatch. Fix: remove client-side composition, send structured fields. This also gives the optimistic node access to `name`/`description` without parsing.
+
+  ### 2. Client→API Type Contract
+
+  **Chosen:** Define a new `FeatureCreatePayload` interface in the web layer for the drawer→API contract, keep core `CreateFeatureInput` unchanged
+
+  **Rejected:**
+  - Modify core `CreateFeatureInput` — Changes core domain contract for a presentation concern; ripples into CLI
+  - Use `CreateFeatureInput` directly — This is the current broken approach
+
+  **Rationale:** The core `CreateFeatureInput` type (`{userInput, repositoryPath, approvalGates}`) is correct for the use case layer. The web API route is the translation boundary. A new `FeatureCreatePayload` type keeps concerns separated, following the existing pattern where the web layer has its own types (e.g., `FeatureNodeData`, `CanvasNodeType`).
+
+  ### 3. Optimistic State Management Approach
+
+  **Chosen:** Inline optimistic logic in `useControlCenterState` using existing `setNodes`/`setEdges` and `createFeatureNode` pattern
+
+  **Rejected:**
+  - Extract `useOptimisticNodes` hook — Over-abstraction for single use case; ~30 lines tightly coupled to existing state
+  - React `useOptimistic` hook — Designed for server state/form actions, not React Flow client state
+  - State management library (zustand/jotai) — Premature; existing `useState` pattern works well
+
+  **Rationale:** `useControlCenterState` already contains `createFeatureNode()` (positioning, edges, temp IDs) and `handleCreateFeatureSubmit` (API call, error handling, `router.refresh()`). The optimistic pattern is a natural evolution of the existing code, testable via the existing `HookTestHarness` pattern.
+
+  ### 4. New 'creating' FeatureNodeState
+
+  **Chosen:** Add `'creating'` to `FeatureNodeState` union and `featureNodeStateConfig` record
+
+  **Rejected:**
+  - Reuse `'running'` state — Shows misleading agent icon and lifecycle verb; semantically wrong
+  - Separate `isOptimistic` boolean flag — Creates parallel state dimension; bypasses config-driven rendering
+
+  **Rationale:** The state config pattern (`feature-node-state-config.ts`) makes this trivial: one new union member, one new config entry. The component already branches on state. A `'creating'` state gets its own visual treatment while following the established pattern exactly.
+
+  ### 5. Non-Interactive Optimistic Node Guard
+
+  **Chosen:** Filter out `onAction`/`onSettings` callbacks in `FeaturesCanvas.enrichedNodes` for nodes with `state === 'creating'`
+
+  **Rejected:**
+  - Guards inside `FeatureNode` component — Violates dumb-renderer pattern; FeatureNode should render what it receives
+  - CSS `pointer-events-none` — Still injects callbacks; doesn't prevent action button rendering
+
+  **Rationale:** `FeaturesCanvas.enrichedNodes` (`features-canvas.tsx:74-94`) already conditionally injects callbacks. Adding `&& data.state !== 'creating'` is minimal. The action button only renders when `onAction` exists (`feature-node.tsx:162`), so not injecting it naturally hides the button.
+
+  ### 6. Optimistic Node Reconciliation Strategy
+
+  **Chosen:** Let `router.refresh()` fully replace canvas state via a `useEffect` that syncs `initialNodes` prop changes to local state
+
+  **Rejected:**
+  - Merge optimistic with server data by name matching — Fragile; IDs differ between temp and server
+  - Swap node ID when API returns — Complex ID/edge updates; React Flow re-renders on key change
+  - Key prop to force remount — Destroys viewport position and zoom
+
+  **Rationale:** `page.tsx` rebuilds all nodes from scratch on every render. The issue: `useState(initialNodes)` ignores prop updates. A `useEffect` that detects `initialNodes` changes and calls `setNodes(initialNodes)` is the standard Next.js pattern. This also fixes a latent bug where server-side changes don't reflect until navigation.
+
+  ### 7. Optimistic Node Positioning
+
+  **Chosen:** Reuse existing `createFeatureNode()` with `{state: 'creating'}` in `dataOverride`
+
+  **Rejected:**
+  - Separate positioning logic — Duplicates ~100 lines; maintenance burden
+  - Fixed viewport position — Ignores graph layout; visually disconnected
+
+  **Rationale:** `createFeatureNode()` already implements sibling-aware positioning, gap derivation, parent re-centering, and group shifting. It accepts `dataOverride` for customizing node data. Passing `{state: 'creating', name, description}` is trivial.
+
+  ### 8. Temporary ID Scheme
+
+  **Chosen:** Use existing `feature-{Date.now()}-{counter}` pattern; modify `createFeatureNode` to return the generated ID
+
+  **Rejected:**
+  - UUID library — Unnecessary dependency for ephemeral client-side IDs
+  - Special `optimistic-` prefix — New ID namespace requires handling throughout codebase
+
+  **Rationale:** The existing pattern guarantees session-unique IDs. Returning the ID from `createFeatureNode` enables rollback tracking. Non-breaking change (return value was `void`).
+
+  ### 9. Accessibility for Creating State
+
+  **Chosen:** Tailwind `motion-reduce:` utility class + `aria-busy` attribute
+
+  **Rejected:**
+  - JavaScript `matchMedia` listener — Over-engineering; Tailwind provides declarative variants
+  - No accessibility handling — Violates NFR-7
+
+  **Rationale:** Tailwind CSS v4 `motion-reduce:` compiles to `@media (prefers-reduced-motion: reduce)`. Apply animation conditionally with `motion-safe:animate-indeterminate-progress`. Add `aria-busy="true"` when state is `'creating'`.
+
+  ## Library Analysis
+
+  | Library | Purpose | Decision | Reasoning |
+  | ------- | ------- | -------- | --------- |
+  | React (useState, useCallback) | State management for optimistic nodes | Use (existing) | Already used in `useControlCenterState`. No additional hooks needed. |
+  | @xyflow/react (React Flow) | Canvas node/edge management | Use (existing) | `setNodes`/`setEdges` provide the API for optimistic insert/rollback. Already the canvas foundation. |
+  | next/navigation (router.refresh) | Server data reconciliation | Use (existing) | Already used for post-create/delete refresh. The optimistic pattern extends this. |
+  | sonner (toast) | Error/success notifications | Use (existing) | Already imported and used in `useControlCenterState`. |
+  | lucide-react (Loader2) | Creating state icon | Use (existing) | Same icon used for 'running' state. Consistent with design system. |
+  | Tailwind CSS v4 | Styling, animation, reduced-motion | Use (existing) | `animate-indeterminate-progress` already defined in globals.css. `motion-reduce:` variant is built-in. |
+  | React 19 useOptimistic | Optimistic state management | Reject | Designed for server state/form actions, not React Flow client state. Would add complexity without benefit. |
+  | zustand/jotai/recoil | External state management | Reject | Premature for single feature. Existing useState pattern is sufficient. Would change architectural patterns. |
+  | framer-motion | Animated node transitions | Reject (V1) | Position jump at reconciliation is accepted for V1 per spec. Animation would add dependency and complexity. |
+  | react-spring | Animated node transitions | Reject (V1) | Same reasoning as framer-motion. Defer to follow-up if user testing reveals animation need. |
+
+  ## Security Considerations
+
+  - **No new attack surface**: The payload mismatch fix changes the shape of data sent from client to server but does not introduce new fields or bypass validation. The API route already validates `name` (required, trimmed), `repositoryPath` (required, trimmed), and `approvalGates` (type-checked).
+  - **No secrets in optimistic state**: Optimistic nodes contain only display data (name, description, repositoryPath) — no tokens, keys, or sensitive information.
+  - **Input sanitization**: The `name` and `description` fields are rendered via React JSX (`{data.name}`), which auto-escapes HTML. No XSS risk from user-provided feature names.
+  - **API error messages**: Error messages from the API are displayed via `toast.error()`. The API route already sanitizes error messages (returns generic "Failed to create feature" for unexpected errors, specific validation messages for known cases).
+  - **No CSRF concerns**: The existing `fetch()` call to `/api/features/create` uses same-origin requests. No new cross-origin requests introduced.
+
+  ## Performance Implications
+
+  - **100ms target (NFR-1)**: The optimistic insert is synchronous (React state update via `setNodes`). `createFeatureNode()` runs entirely in-memory with no async operations. The 100ms target is easily achievable — the bottleneck is React's render cycle (~16ms for a batch state update).
+  - **No additional network requests**: The API call pattern is identical to the current flow (one POST). `router.refresh()` is the same as before. No new polling or WebSocket connections.
+  - **Memory**: Optimistic nodes are ephemeral (seconds). Failed nodes are cleaned up immediately. No unbounded state growth per NFR-4.
+  - **Re-render scope**: `setNodes` triggers a React Flow re-render of all nodes. This is the existing behavior for any node change. The additional `useEffect` for initialNodes sync adds one comparison per server refresh, which is negligible.
+  - **Dagre layout on refresh**: `page.tsx` runs Dagre layout server-side before passing to the client. This is the existing pattern and is not affected by optimistic updates.
+
+  ## Architecture Notes
+
+  ### Component Modification Map
+
+  **Modified files (in implementation order):**
+
+  1. **`feature-node-state-config.ts`** — Add `'creating'` to `FeatureNodeState` union, add config entry to `featureNodeStateConfig` record. ~10 lines.
+
+  2. **`feature-node.tsx`** — Add rendering branch for `state === 'creating'` in the bottom section. Similar to 'running' but without `AgentIcon` and with "Creating..." text. Add `aria-busy`. ~15 lines.
+
+  3. **`feature-create-drawer.tsx`** — Remove client-side `composeUserInput()`, change `onSubmit` to pass `{name, description, attachments, repositoryPath, approvalGates}`. Update `FeatureCreateDrawerProps.onSubmit` type. ~20 lines changed.
+
+  4. **`use-control-center-state.ts`** — (a) Modify `createFeatureNode` to accept state override and return the generated ID. (b) Rewrite `handleCreateFeatureSubmit` for optimistic pattern: insert node → close drawer → background API → reconcile/rollback. (c) Add `useEffect` to sync `initialNodes`/`initialEdges` prop changes. (d) Update `handleNodeClick` to skip 'creating' nodes. ~50 lines changed.
+
+  5. **`features-canvas.tsx`** — Guard `onAction`/`onSettings` injection for nodes with `state !== 'creating'` in `enrichedNodes` memo. ~3 lines changed.
+
+  **No changes needed:**
+  - `app/api/features/create/route.ts` — Already expects `{name, description, repositoryPath, attachments, approvalGates}`
+  - `packages/core/` — Core `CreateFeatureInput` stays as-is; API route translates
+
+  ### Data Flow (After Implementation)
+
+  ```
+  User clicks "Create Feature"
+    → FeatureCreateDrawer.handleSubmit()
+      → Calls onSubmit({name, description, attachments, repositoryPath, approvalGates})
+    → useControlCenterState.handleCreateFeatureSubmit()
+      → createFeatureNode(pendingRepoNodeId, {state: 'creating', name, description, ...})
+        → setNodes() — optimistic node appears instantly
+        → setEdges() — edge connects to repo node
+        → Returns temp node ID
+      → setIsCreateDrawerOpen(false) — drawer closes
+      → setPendingRepoNodeId(null) — clear pending state
+      → fetch('/api/features/create', {name, description, ...}) — background
+        → On success: router.refresh()
+          → page.tsx re-renders with new feature
+          → useEffect detects initialNodes change
+          → setNodes(initialNodes) — replaces optimistic with real
+        → On failure:
+          → setNodes(prev => prev.filter(n => n.id !== tempId)) — remove optimistic
+          → setEdges(prev => prev.filter(e => e.target !== tempId)) — remove edge
+          → toast.error(message) — show error
+  ```
+
+  ### Testing Strategy
+
+  - **Unit tests** (`use-control-center-state.test.tsx`): Test optimistic insert (node appears in state), API success (router.refresh called), API failure (node removed, toast shown), concurrent creations, 'creating' state in node data.
+  - **Component tests** (`feature-node.test.tsx`): Test 'creating' state rendering (badge text, no agent icon, progress bar, aria-busy).
+  - **Component tests** (`feature-create-drawer.test.tsx`): Update tests for new onSubmit payload shape.
+  - **Stories** (`feature-node.stories.tsx`): Add 'Creating' story variant.
+  - **Stories** (`feature-create-drawer.stories.tsx`): Update for new payload shape.
+  - **Existing mocking patterns**: The test suite already mocks `fetch`, `router.refresh`, `toast`, and React Flow. No new mocking infrastructure needed.

--- a/specs/024-optimistic-feature-creation/spec.yaml
+++ b/specs/024-optimistic-feature-creation/spec.yaml
@@ -1,0 +1,322 @@
+# Feature Specification (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: optimistic-feature-creation
+number: 024
+branch: feat/024-optimistic-feature-creation
+oneLiner: Instantly render a placeholder feature node on the canvas when creating a feature, replacing it with real data once the API responds
+summary: >
+  When a user creates a new feature, immediately insert an optimistic feature node on the React Flow canvas
+  in a "creating" state (with a dedicated loading animation), close the drawer, and fire the API call in the background.
+  On success, reconcile the optimistic node with the real feature data via router.refresh(). On failure,
+  remove the optimistic node and show an error toast. Also fix the client→server API payload mismatch
+  (drawer sends userInput blob, route expects structured name/description) as a prerequisite.
+phase: Requirements
+sizeEstimate: M
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - React (useState, useCallback)
+  - Next.js App Router (router.refresh for server reconciliation)
+  - React Flow (@xyflow/react for canvas nodes and edges)
+  - shadcn/ui (Drawer, Toast via sonner)
+  - Dagre (@dagrejs/dagre for graph layout)
+  - TypeScript
+
+relatedLinks: []
+
+# Open questions — all resolved with AI-recommended defaults
+openQuestions:
+  - question: "Should we add a new FeatureNodeState (e.g. 'creating') or reuse the existing 'running' state for the optimistic node?"
+    context: "The existing 'running' state shows an indeterminate progress bar and agent icon, which is close but not identical to a 'creating/initializing' state. A dedicated state would allow a distinct visual treatment (e.g. pulsing skeleton, 'Creating...' text)."
+    resolved: true
+    answer: >
+      Recommend adding a new 'creating' FeatureNodeState. Rationale: (1) The 'running' state implies an agent is
+      actively working — it shows an agent type icon and lifecycle verb like "Analyzing" or "Implementing". A feature
+      that hasn't been persisted yet is not running; it's being created. (2) A dedicated state enables distinct UX:
+      a pulsing/skeleton animation with "Creating..." text that clearly communicates the node is provisional. (3) It
+      avoids confusing users who might think the agent has already started. (4) The feature-node-state-config pattern
+      makes adding a new state trivial — just one new entry in the config record. Alternative: reuse 'running' if
+      the team wants to minimize the visual surface area, but this sacrifices clarity.
+
+  - question: 'What should happen to the sidebar feature list during optimistic creation — should the new feature also appear there immediately?'
+    context: 'The sidebar (AppSidebar) renders features from the server component data via props. Optimistic updates would only affect the canvas unless the sidebar also participates.'
+    resolved: true
+    answer: >
+      Recommend NOT adding the feature to the sidebar optimistically. Rationale: (1) The sidebar is fed by server
+      component props (FeatureItem[]) passed from page.tsx — injecting optimistic data would require either lifting
+      state up or introducing a client-side overlay, adding complexity disproportionate to the value. (2) The canvas
+      is the user's primary focus during creation; the sidebar is secondary navigation. (3) router.refresh() will
+      populate the sidebar within 1-2 seconds of a successful creation anyway. (4) Keeping the optimistic scope to
+      the canvas minimizes risk and implementation surface. Alternative: add sidebar optimism in a follow-up if user
+      testing reveals it's confusing that the sidebar lags.
+
+  - question: 'Should the API payload mismatch between client (sends userInput) and server (expects name) be fixed as part of this feature or as a separate bug fix?'
+    context: >
+      The FeatureCreateDrawer composes a userInput string ('Feature: name\n\ndescription'), but the API route at
+      /api/features/create destructures { name, description, repositoryPath, attachments, approvalGates } from the
+      body and validates that name is present. The CreateFeatureInput type in core only has { userInput,
+      repositoryPath, approvalGates }. This means the current form submission will always fail validation
+      (name is undefined). This is a confirmed bug.
+    resolved: true
+    answer: >
+      Recommend fixing the mismatch as part of this feature. Rationale: (1) This is a blocking bug — the current
+      flow sends { userInput, repositoryPath, approvalGates } but the route expects { name } and returns 400 when
+      it's missing. The optimistic feature depends on a working create flow. (2) The optimistic node needs the
+      separate name and description fields anyway (to display on the placeholder node), so refactoring the drawer's
+      onSubmit callback to pass structured data is a natural prerequisite. (3) Fixing it separately would mean the
+      optimistic feature can't be tested against a working API. The fix is small: update the drawer to send
+      { name, description, repositoryPath, attachments, approvalGates } and update CreateFeatureInput accordingly,
+      or update the API route to accept userInput directly. Recommend the former (send structured data) since the
+      route's composeUserInput is the proper server-side concern.
+
+  - question: "Should the optimistic node be non-interactive (no hover actions, no click-to-select) while in 'creating' state?"
+    context: >
+      The feature node in normal states supports click-to-select (opens detail panel), hover to show '+' action
+      button, and a settings gear. During optimistic creation, the feature doesn't exist in the database yet, so
+      clicking it would show empty/broken details.
+    resolved: true
+    answer: >
+      Recommend making the optimistic node non-interactive while in 'creating' state. Rationale: (1) There is no
+      server data to display in a detail panel — clicking would show empty or error state. (2) The '+' action button
+      to add child features makes no sense for a feature that doesn't exist yet. (3) Visual cues (reduced opacity
+      or no hover effects) reinforce that this is a provisional placeholder. (4) Once router.refresh() reconciles
+      the node with real data, full interactivity is restored automatically. Implementation: skip injecting onAction,
+      onSettings, and click-to-select callbacks for nodes in 'creating' state in FeaturesCanvas.
+
+  - question: 'Should the user be prevented from creating another feature while one is being optimistically created?'
+    context: >
+      If the user opens the create drawer and submits again while the first optimistic node is still pending
+      its API response, there could be two optimistic nodes on the canvas simultaneously.
+    resolved: true
+    answer: >
+      Recommend allowing multiple concurrent optimistic creations. Rationale: (1) The existing createFeatureNode()
+      function uses Date.now() + counter for unique temp IDs, so multiple optimistic nodes won't collide. (2)
+      Blocking the user from creating feels unnecessarily restrictive — power users may want to queue up several
+      features quickly. (3) Each optimistic creation is independent: its own API call, its own success/failure
+      handling. (4) router.refresh() after each success will reconcile all pending nodes. Alternative: disable the
+      "New Feature" button while isSubmitting is true, but this adds friction for minimal benefit.
+
+  - question: 'How should the optimistic node handle the case where router.refresh() completes but the node position changes due to Dagre re-layout?'
+    context: >
+      The optimistic node is placed using createFeatureNode()'s sibling-aware positioning. When router.refresh()
+      runs, page.tsx re-fetches all features, rebuilds nodes, and runs Dagre layout from scratch. The real node
+      may end up at a different position than the optimistic one, causing a visual jump.
+    resolved: true
+    answer: >
+      Recommend accepting the position jump as-is for V1. Rationale: (1) The jump is brief and only occurs once
+      (at reconciliation). (2) The existing createFeatureNode() positioning logic already mimics Dagre-like placement
+      (sibling-aware, overlap avoidance), so the delta should be small in most cases. (3) Adding animated transitions
+      or position-preserving reconciliation would significantly increase complexity. (4) Users are accustomed to
+      layout shifts when the canvas re-renders (e.g., after delete). Alternative: in a follow-up, add a smooth
+      transition animation on node position changes using React Flow's built-in node animation support.
+
+content: |
+  ## Problem Statement
+
+  When a user creates a new feature via the FeatureCreateDrawer, the current flow is fully synchronous:
+  the form shows "Creating..." on the submit button, waits for the POST /api/features/create response,
+  then calls `router.refresh()` to re-render the entire page from the server. During this time, the
+  canvas shows no visual feedback — no new node appears. This creates a sluggish, unresponsive feel,
+  especially since feature creation involves backend processing that can take several seconds.
+
+  Additionally, there is a confirmed **API payload mismatch bug**: the drawer sends `{ userInput, repositoryPath,
+  approvalGates }` but the API route expects `{ name, description, repositoryPath, attachments, approvalGates }`
+  and validates that `name` is present. This means the current create flow may fail with a 400 error. This must
+  be fixed as a prerequisite.
+
+  The desired behavior is **optimistic rendering**: immediately insert a placeholder feature node on the
+  canvas in a dedicated "creating" state the moment the user clicks "Create Feature", close the drawer,
+  and let the API call complete in the background. Once the API responds successfully, reconcile the
+  optimistic node with the real data. On failure, remove the optimistic node and show an error.
+
+  ## Success Criteria
+
+  - [ ] **SC-1**: When user clicks "Create Feature", a feature node appears on the canvas within 100ms (before API response)
+  - [ ] **SC-2**: The optimistic node displays in a distinct "creating" visual state (pulsing animation, "Creating..." label, no agent icon)
+  - [ ] **SC-3**: The optimistic node shows the feature name entered in the form
+  - [ ] **SC-4**: The optimistic node is connected to the correct repository node via an edge
+  - [ ] **SC-5**: The optimistic node is positioned using existing sibling-aware layout logic (no overlaps)
+  - [ ] **SC-6**: The create drawer closes immediately on submit (does not wait for API response)
+  - [ ] **SC-7**: On API success, `router.refresh()` reconciles the optimistic node with the real feature node seamlessly
+  - [ ] **SC-8**: On API failure, the optimistic node and its edge are removed from the canvas
+  - [ ] **SC-9**: On API failure, an error toast is shown with the error message from the API
+  - [ ] **SC-10**: The optimistic node is non-interactive (no click-to-select, no hover actions) while in "creating" state
+  - [ ] **SC-11**: Multiple concurrent feature creations are supported (each gets its own optimistic node)
+  - [ ] **SC-12**: The client→server API payload mismatch is fixed (drawer sends structured data the route expects)
+  - [ ] **SC-13**: All existing feature creation tests continue to pass
+  - [ ] **SC-14**: New unit tests cover: optimistic node insertion, error rollback, success reconciliation, concurrent creations
+  - [ ] **SC-15**: Storybook stories cover the "creating" state of the feature node
+  - [ ] **SC-16**: The `isSubmitting` prop on the drawer is no longer used to show a blocking "Creating..." state (drawer closes immediately)
+
+  ## Functional Requirements
+
+  ### FR-1: Fix Client→Server API Payload Mismatch (Prerequisite)
+
+  Refactor the `FeatureCreateDrawer` to send structured data matching what the API route expects.
+  The drawer's `onSubmit` callback must provide `{ name, description, repositoryPath, attachments, approvalGates }`
+  as separate fields instead of composing them into a single `userInput` string. The API route already has
+  `composeUserInput()` server-side, so composing should happen there. Update the `CreateFeatureInput` type
+  accordingly, or adjust the API route to accept the current `userInput` format. Either approach is acceptable;
+  the key requirement is that client and server agree on the payload shape.
+
+  ### FR-2: Add 'creating' FeatureNodeState
+
+  Add a new `'creating'` value to the `FeatureNodeState` type union in `feature-node-state-config.ts`.
+  Define its visual configuration:
+  - **Icon**: a pulsing/spinning loader (e.g., `Loader2` with animation, same as 'running')
+  - **Border**: `border-l-blue-500` (same as 'running' — blue indicates in-progress)
+  - **Badge text**: "Creating..."
+  - **Progress bar**: indeterminate (same visual treatment as 'running')
+  - **Key difference from 'running'**: no agent type icon, badge says "Creating..." not lifecycle verb
+
+  ### FR-3: Render 'creating' State in Feature Node Component
+
+  Update `feature-node.tsx` to handle the `'creating'` state. When `state === 'creating'`:
+  - Show the feature name from form data
+  - Show an indeterminate progress bar with pulsing animation
+  - Show "Creating..." badge text
+  - Do NOT show agent type icon (no agent is running yet)
+  - Do NOT show lifecycle running verb (not yet in a lifecycle phase)
+  - Optionally apply a subtle visual indicator that the node is provisional (e.g., slightly reduced opacity or dashed border)
+
+  ### FR-4: Optimistic Node Insertion on Form Submit
+
+  When `handleCreateFeatureSubmit` is called:
+  1. Extract `name` (and optionally `description`) from the submit data
+  2. Determine the target repository node ID (from `pendingRepoNodeId` or default repo)
+  3. Call `createFeatureNode()` (or a similar function) to insert a new node with:
+     - `state: 'creating'`
+     - `lifecycle: 'requirements'`
+     - `name` from form data
+     - `description` from form data (if provided)
+     - `repositoryPath` from the pending repo context
+     - A temporary ID (e.g., `feature-{timestamp}-{counter}`)
+  4. Create an edge connecting the repository node to the new optimistic node
+  5. Close the create drawer immediately
+  6. Clear `pendingRepoNodeId`
+
+  ### FR-5: Background API Call with Reconciliation
+
+  After inserting the optimistic node and closing the drawer:
+  1. Fire `POST /api/features/create` in the background (no await blocking the UI)
+  2. On success: call `router.refresh()` to reconcile the canvas with server data. The server
+     component will re-fetch all features and rebuild the node list, replacing the temporary
+     optimistic node with the real `feat-{feature.id}` node.
+  3. On failure: remove the optimistic node and its edge from local state (`setNodes`, `setEdges`),
+     and show an error toast with the API error message.
+
+  ### FR-6: Non-Interactive Optimistic Nodes
+
+  Nodes in the `'creating'` state must not respond to user interactions:
+  - Click-to-select must be suppressed (do not set `selectedNode`)
+  - The `+` action button (add child feature) must not appear on hover
+  - The settings gear must not appear
+  - This is enforced by not injecting `onAction`, `onSettings`, or click handlers for nodes
+    with `state === 'creating'` in the `FeaturesCanvas` component
+
+  ### FR-7: Concurrent Optimistic Creations
+
+  Support multiple optimistic nodes existing simultaneously. Each optimistic creation must:
+  - Use a unique temporary ID (already handled by `Date.now()` + counter pattern)
+  - Have its own independent API call
+  - Handle its own success/failure independently
+  - Not block subsequent create drawer opens
+
+  ### FR-8: Storybook Story for 'creating' State
+
+  Add a Storybook story for the feature node in 'creating' state, following the existing pattern
+  in `feature-node.stories.tsx`. The story should demonstrate the pulsing animation, "Creating..."
+  badge, and the absence of action buttons.
+
+  ## Non-Functional Requirements
+
+  ### NFR-1: Perceived Performance
+
+  The optimistic node must appear on the canvas within 100ms of the user clicking "Create Feature".
+  The drawer must close within the same 100ms window. The user should perceive the action as instant.
+
+  ### NFR-2: Visual Consistency
+
+  The 'creating' state must be visually consistent with the existing feature node state system.
+  It must use the same card layout, typography, and spacing. The loading animation must feel
+  native to the design system (not jarring or out of place).
+
+  ### NFR-3: Error Recovery UX
+
+  On API failure, the optimistic node removal must feel clean — no flickering, no orphaned edges,
+  no stale state. The error toast must clearly communicate what went wrong. The canvas must return
+  to exactly the state it was in before the creation attempt.
+
+  ### NFR-4: No State Leaks
+
+  Optimistic nodes that fail must be fully cleaned up: removed from `nodes` state, their edges
+  removed from `edges` state, no references in `selectedNode` or other state. Memory and state
+  must not grow unboundedly with repeated create/fail cycles.
+
+  ### NFR-5: Test Coverage
+
+  All new code paths must have unit test coverage:
+  - Optimistic node insertion (node appears in state, edge created, drawer closes)
+  - API success reconciliation (router.refresh called)
+  - API failure rollback (node removed, edge removed, toast shown)
+  - Concurrent creations (multiple optimistic nodes coexist)
+  - 'creating' state rendering in feature node component
+
+  ### NFR-6: Backward Compatibility
+
+  The `FeatureCreateDrawerProps.onSubmit` callback signature change (structured data vs. userInput blob)
+  must be coordinated with all consumers. Existing Storybook stories for the drawer must be updated.
+  No breaking changes to the public component API without updating all call sites.
+
+  ### NFR-7: Accessibility
+
+  The 'creating' state animation must respect `prefers-reduced-motion`. The loading state must be
+  announced to screen readers (e.g., via `aria-busy` or `aria-label` on the node).
+
+  ## Product Questions & AI Recommendations
+
+  | # | Question | AI Recommendation | Rationale |
+  | - | -------- | ----------------- | --------- |
+  | 1 | New 'creating' state vs reuse 'running'? | Add new 'creating' state | Distinct semantics: 'running' = agent working, 'creating' = not yet persisted. Trivial to add via state config pattern. Clearer UX. |
+  | 2 | Sidebar optimistic update? | No — canvas only | Sidebar is server-driven; adding client overlay is disproportionate complexity. Canvas is the primary focus. router.refresh() fills sidebar within seconds. |
+  | 3 | Fix API payload mismatch here or separately? | Fix as part of this feature | It's a blocking bug — current flow may 400. The optimistic node needs structured data (name, description) anyway. Small, natural prerequisite. |
+  | 4 | Optimistic node interactive while creating? | Non-interactive | No server data to display. Action buttons don't make sense for un-persisted features. Full interactivity restored after reconciliation. |
+  | 5 | Allow concurrent optimistic creations? | Yes | Temp IDs are already unique. Independent API calls. No reason to block power users. Minimal additional complexity. |
+  | 6 | Handle Dagre re-layout position jump? | Accept for V1, animate later | Jump is brief and small (createFeatureNode mimics Dagre). Animated transitions would add significant complexity. Users are accustomed to layout shifts. |
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `components/features/control-center/use-control-center-state.ts` | High | Core of the change — `handleCreateFeatureSubmit` rewritten to optimistic pattern: insert node → close drawer → background API → reconcile/rollback |
+  | `components/common/feature-node/feature-node-state-config.ts` | Medium | New `'creating'` state added to `FeatureNodeState` union and `featureNodeStateConfig` record |
+  | `components/common/feature-node/feature-node.tsx` | Medium | Rendering logic for 'creating' state: "Creating..." badge, no agent icon, indeterminate progress bar |
+  | `components/common/feature-create-drawer/feature-create-drawer.tsx` | Medium | Refactor `handleSubmit` to pass structured data `{ name, description, repositoryPath, attachments, approvalGates }` instead of composing `userInput` |
+  | `components/features/features-canvas/features-canvas.tsx` | Low | Skip injecting `onAction`/`onSettings`/click handlers for nodes with `state === 'creating'` |
+  | `app/api/features/create/route.ts` | Low | No changes needed — already expects structured `{ name, description }` payload |
+  | `packages/core/.../create/types.ts` | Low | Update `CreateFeatureInput` to accept `{ name, description, ... }` OR keep `userInput` and update the route. One side must change. |
+  | `tests/unit/.../use-control-center-state.test.tsx` | High | New test cases: optimistic insert, error rollback, success reconciliation, concurrent creations. Existing tests updated for new onSubmit shape. |
+  | `tests/unit/.../feature-node.test.tsx` | Medium | Tests for 'creating' state rendering |
+  | `components/common/feature-node/feature-node.stories.tsx` | Low | New story for 'creating' state |
+  | `components/common/feature-create-drawer/feature-create-drawer.stories.tsx` | Low | Update stories for new onSubmit data shape |
+
+  ## Dependencies
+
+  - **Existing `createFeatureNode()` function** in `use-control-center-state.ts` — provides positioning and edge creation logic; needs minor adaptation to accept 'creating' state
+  - **`FeatureNodeData` type** — must include `'creating'` in its `state` union for the optimistic node data
+  - **`router.refresh()`** — Next.js mechanism for reconciling optimistic canvas state with server truth
+  - **`POST /api/features/create`** — Must return the created feature data (currently returns `{ feature, warning? }`) for potential future reconciliation enhancements
+  - **React Flow `setNodes`/`setEdges`** — For immediate local state manipulation (insert and rollback)
+  - **`toast` from sonner** — For success/error notifications during background processing
+  - **`CreateFeatureInput` type** — Must be updated to match the agreed client→server payload shape
+
+  ## Size Estimate
+
+  **M** — The core implementation has four parts: (1) payload mismatch fix (small, ~1 hour), (2) new 'creating' state
+  in feature node (small, ~2 hours with stories/tests), (3) optimistic pattern in handleCreateFeatureSubmit (medium,
+  ~4 hours with TDD), (4) non-interactive node guard in FeaturesCanvas (small, ~1 hour). The existing
+  `createFeatureNode()` function provides most of the positioning/edge logic. Main complexity is in the async
+  reconciliation/rollback flow and comprehensive test coverage. Total estimate: 2-3 days with TDD.

--- a/specs/024-optimistic-feature-creation/tasks.yaml
+++ b/specs/024-optimistic-feature-creation/tasks.yaml
@@ -1,0 +1,413 @@
+# Task Breakdown (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: optimistic-feature-creation
+summary: >
+  12 tasks across 4 phases. Phase 1 fixes the blocking payload mismatch (3 tasks). Phase 2 adds the
+  'creating' state visual foundation (3 tasks). Phase 3 implements the core optimistic insert/reconciliation/rollback
+  flow (4 tasks). Phase 4 adds the non-interactive guard and cleans up integration (2 tasks).
+
+relatedFeatures: []
+technologies:
+  - React (useState, useCallback, useEffect)
+  - Next.js App Router (router.refresh)
+  - React Flow (@xyflow/react)
+  - shadcn/ui (Drawer, Toast via sonner)
+  - TypeScript
+  - Vitest
+  - Storybook
+  - Tailwind CSS v4
+
+relatedLinks: []
+
+tasks:
+  # ── Phase 1: Payload Fix & Type Contract ──────────────────────────────────
+
+  - id: task-1
+    phaseId: phase-1
+    title: 'Define FeatureCreatePayload type and refactor drawer onSubmit'
+    description: >
+      Define a FeatureCreatePayload interface in the web layer with structured fields {name, description,
+      attachments, repositoryPath, approvalGates}. Remove the client-side composeUserInput() function from
+      feature-create-drawer.tsx. Update handleSubmit to pass structured data via onSubmit. Update
+      FeatureCreateDrawerProps.onSubmit type signature from CreateFeatureInput to FeatureCreatePayload.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'FeatureCreatePayload interface is defined with {name: string, description?: string, attachments: FileAttachment[], repositoryPath: string, approvalGates: ApprovalGates}'
+      - 'Client-side composeUserInput() function is removed from feature-create-drawer.tsx'
+      - 'FeatureCreateDrawerProps.onSubmit type is (data: FeatureCreatePayload) => void'
+      - 'handleSubmit passes {name, description, attachments, repositoryPath, approvalGates} directly'
+      - 'No import of CreateFeatureInput in feature-create-drawer.tsx'
+    tdd:
+      red:
+        - 'Update feature-create-drawer.test.tsx: change the assertion on onSubmit call to expect structured {name, description, attachments, repositoryPath, approvalGates} instead of {userInput, repositoryPath, approvalGates}'
+        - 'Add test: submitted data has separate name and description fields (not composed userInput)'
+        - 'Add test: submitted data includes attachments array with file paths'
+      green:
+        - 'Define FeatureCreatePayload interface in feature-create-drawer.tsx (co-located with props)'
+        - 'Remove composeUserInput() function'
+        - 'Update handleSubmit to pass structured fields'
+        - 'Update FeatureCreateDrawerProps.onSubmit type'
+      refactor:
+        - 'Export FeatureCreatePayload type for consumers'
+        - 'Remove unused CreateFeatureInput import'
+    estimatedEffort: '1.5h'
+
+  - id: task-2
+    phaseId: phase-1
+    title: 'Update handleCreateFeatureSubmit to accept FeatureCreatePayload'
+    description: >
+      Update the handleCreateFeatureSubmit callback in useControlCenterState to accept FeatureCreatePayload
+      instead of CreateFeatureInput. Update the fetch body to send the structured payload directly (the API
+      route already expects {name, description, repositoryPath, attachments, approvalGates}). Update the
+      ControlCenterState interface type for handleCreateFeatureSubmit.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'handleCreateFeatureSubmit accepts FeatureCreatePayload parameter'
+      - 'fetch body sends structured {name, description, repositoryPath, attachments, approvalGates}'
+      - 'ControlCenterState.handleCreateFeatureSubmit type matches new signature'
+      - 'Existing test for successful creation still passes (with updated mock data)'
+      - 'Existing test for creation failure still passes'
+    tdd:
+      red:
+        - 'Update use-control-center-state.test.tsx: change mock submit data from {userInput, repositoryPath, approvalGates} to {name, description, attachments, repositoryPath, approvalGates}'
+        - 'Verify existing submit success/failure tests fail due to type mismatch'
+      green:
+        - 'Change handleCreateFeatureSubmit parameter type to FeatureCreatePayload'
+        - 'Update JSON.stringify(data) in fetch body (already structured, just passes through)'
+        - 'Update ControlCenterState interface'
+        - 'Update import to use FeatureCreatePayload from feature-create-drawer'
+      refactor:
+        - 'Remove unused CreateFeatureInput import from use-control-center-state.ts'
+    estimatedEffort: '1h'
+
+  - id: task-3
+    phaseId: phase-1
+    title: 'Update drawer stories for new payload shape'
+    description: >
+      Update feature-create-drawer.stories.tsx to reflect the new FeatureCreatePayload type. The Interactive
+      story displays submitted data in a JSON panel — update it to show structured fields. Update any story
+      args that reference the old CreateFeatureInput type.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'All feature-create-drawer stories render without errors'
+      - 'Interactive story displays structured {name, description, attachments, repositoryPath, approvalGates}'
+      - 'No references to CreateFeatureInput or userInput in stories'
+    tdd: null
+    estimatedEffort: '30min'
+
+  # ── Phase 2: Creating State & Node Rendering ─────────────────────────────
+
+  - id: task-4
+    phaseId: phase-2
+    title: "Add 'creating' FeatureNodeState to state config"
+    description: >
+      Add 'creating' to the FeatureNodeState union type in feature-node-state-config.ts. Add a new entry
+      in the featureNodeStateConfig record with: Loader2 icon, blue border (border-l-blue-500), blue badge
+      classes, label "Creating...", showProgressBar false. This follows the exact pattern of the existing
+      5 states.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - "'creating' is a valid FeatureNodeState value"
+      - 'featureNodeStateConfig.creating has icon: Loader2, borderClass: border-l-blue-500, label: "Creating..."'
+      - 'TypeScript compiles without errors'
+      - 'Existing state config entries are unchanged'
+    tdd:
+      red:
+        - "Add test in feature-node.test.tsx: render a node with state 'creating' — assert it does not throw and the card renders"
+        - "Add test: node with state 'creating' shows 'Creating...' badge text"
+      green:
+        - "Add 'creating' to FeatureNodeState union type"
+        - 'Add creating entry to featureNodeStateConfig record'
+      refactor:
+        - 'Verify alphabetical or logical ordering of config entries is consistent'
+    estimatedEffort: '30min'
+
+  - id: task-5
+    phaseId: phase-2
+    title: "Implement 'creating' state rendering in FeatureNode component"
+    description: >
+      Update feature-node.tsx to handle the 'creating' state in the bottom section. When state === 'creating':
+      show "Creating..." text with Loader2 icon (no AgentIcon), show indeterminate progress bar with
+      motion-safe animation, add aria-busy="true" to the card, do NOT show lifecycle running verb. The
+      rendering is similar to 'running' but without the agent icon and with static "Creating..." text.
+      Also update getBadgeText to return "Creating..." for the creating state.
+    state: Todo
+    dependencies:
+      - task-4
+    acceptanceCriteria:
+      - "Node with state 'creating' shows 'Creating...' text (not a lifecycle verb)"
+      - "Node with state 'creating' shows indeterminate progress bar"
+      - "Node with state 'creating' does NOT show AgentIcon"
+      - "Node with state 'creating' has aria-busy='true' on the card element"
+      - 'Progress bar animation uses motion-safe: variant for accessibility'
+      - 'Node displays the feature name from data'
+    tdd:
+      red:
+        - "Add test: state 'creating' renders 'Creating...' text"
+        - "Add test: state 'creating' does not render agent icon element"
+        - "Add test: state 'creating' renders indeterminate progress bar"
+        - "Add test: state 'creating' has aria-busy='true' on the card"
+        - "Add test: state 'creating' renders the feature name"
+      green:
+        - "Add 'creating' branch in the bottom section alongside 'running' (both show indeterminate bar)"
+        - 'Add aria-busy attribute conditional on state === creating'
+        - "Update getBadgeText to handle 'creating' state"
+        - 'Use motion-safe: variant on progress bar animation class'
+      refactor:
+        - "Consider extracting the indeterminate progress bar into a shared fragment since 'running' and 'creating' both use it"
+    estimatedEffort: '1.5h'
+
+  - id: task-6
+    phaseId: phase-2
+    title: "Add Storybook story for 'creating' state"
+    description: >
+      Add a 'Creating' story variant to feature-node.stories.tsx following the existing pattern. The story
+      should show a node with state 'creating', a sample feature name, no agent icon, indeterminate progress
+      bar with pulsing animation. Also add the creating state to the AllStates story grid.
+    state: Todo
+    dependencies:
+      - task-5
+    acceptanceCriteria:
+      - "A 'Creating' story exists in feature-node.stories.tsx"
+      - "The AllStates story includes the 'creating' state"
+      - 'Story renders without errors in Storybook'
+      - "Story visually demonstrates: 'Creating...' badge, indeterminate progress, no agent icon"
+    tdd: null
+    estimatedEffort: '30min'
+
+  # ── Phase 3: Optimistic Insert, Reconciliation & Rollback ────────────────
+
+  - id: task-7
+    phaseId: phase-3
+    title: 'Modify createFeatureNode to support state override and return node ID'
+    description: >
+      Modify createFeatureNode in use-control-center-state.ts to: (1) spread dataOverride over the default
+      state so callers can pass {state: 'creating'} to override the default 'running', (2) return the
+      generated node ID string so callers can track it for rollback, (3) skip calling setSelectedNode for
+      nodes in 'creating' state (optimistic nodes should not be auto-selected). The function currently
+      hardcodes state: 'running' at line 114 and does not return the ID.
+    state: Todo
+    dependencies:
+      - task-4
+    acceptanceCriteria:
+      - 'createFeatureNode returns the generated node ID string'
+      - "createFeatureNode({state: 'creating'}) produces a node with state 'creating' (not 'running')"
+      - "createFeatureNode with default args still produces state 'running' (backward compatible)"
+      - "createFeatureNode does not call setSelectedNode when state is 'creating'"
+      - 'Existing handleAddFeatureToFeature still works (ignores return value)'
+    tdd:
+      red:
+        - 'Add test: createFeatureNode with dataOverride {state: creating} produces a node in creating state'
+        - 'Add test: createFeatureNode returns a string matching the feature-{timestamp}-{counter} pattern'
+        - "Add test: node with state 'creating' is not set as selectedNode"
+        - 'Verify existing test for handleAddFeatureToFeature still passes'
+      green:
+        - 'Spread dataOverride.state over default state in newFeatureData (line 114: state: dataOverride?.state ?? running)'
+        - 'Return the generated id string from createFeatureNode'
+        - "Add conditional: if (newFeatureData.state !== 'creating') setSelectedNode(newFeatureData)"
+      refactor:
+        - 'Ensure the return type annotation is explicit (string)'
+    estimatedEffort: '1h'
+
+  - id: task-8
+    phaseId: phase-3
+    title: 'Add useEffect for initialNodes/initialEdges prop sync'
+    description: >
+      Add a useEffect in useControlCenterState that detects when initialNodes or initialEdges props change
+      (from router.refresh() triggering a server component re-render) and syncs them to local state via
+      setNodes(initialNodes) / setEdges(initialEdges). Use a stable derived key (e.g., sorted node IDs
+      joined as a string, or node count + IDs hash) to avoid infinite re-render loops. This is required
+      for the optimistic node to be replaced by real server data after router.refresh().
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'When initialNodes prop changes (different node IDs), local nodes state is updated to match'
+      - 'When initialEdges prop changes, local edges state is updated to match'
+      - 'The effect does NOT fire on every render (stable comparison key prevents loops)'
+      - 'Viewport position/zoom is not affected by the sync'
+      - 'Existing tests continue to pass'
+    tdd:
+      red:
+        - 'Add test: when HookTestHarness re-renders with new initialNodes, the hook state reflects the new nodes'
+        - 'Add test: when initialNodes are identical (same IDs), no state update occurs (verify setNodes not called unnecessarily)'
+        - 'Add test: optimistic node is replaced when initialNodes changes to include the real feature'
+      green:
+        - 'Compute a stable key from initialNodes (e.g., initialNodes.map(n => n.id).sort().join(","))'
+        - 'Add useEffect with the key as dependency that calls setNodes(initialNodes) and setEdges(initialEdges)'
+      refactor:
+        - 'Extract the key computation to a named constant for clarity'
+        - 'Consider whether useMemo for the key is needed (likely not — string concatenation is cheap)'
+    estimatedEffort: '1.5h'
+
+  - id: task-9
+    phaseId: phase-3
+    title: 'Rewrite handleCreateFeatureSubmit for optimistic pattern'
+    description: >
+      Rewrite handleCreateFeatureSubmit to implement the optimistic creation flow: (1) call createFeatureNode
+      with pendingRepoNodeId and {state: 'creating', name, description, repositoryPath} to insert the
+      optimistic node instantly, (2) capture the returned temp node ID, (3) close the drawer and clear
+      pendingRepoNodeId immediately, (4) fire the fetch POST in the background (no await blocking the UI),
+      (5) on success call router.refresh() for reconciliation, (6) on failure remove the optimistic node
+      and its edge via setNodes/setEdges filters and show toast.error(). Remove the isSubmitting state
+      since the drawer closes immediately.
+    state: Todo
+    dependencies:
+      - task-1
+      - task-2
+      - task-7
+      - task-8
+    acceptanceCriteria:
+      - 'Optimistic node appears in nodes state immediately (before API response)'
+      - 'Optimistic node has state creating, correct name and description'
+      - 'Optimistic node has edge connecting to pendingRepoNodeId'
+      - 'Drawer closes immediately (isCreateDrawerOpen becomes false before API resolves)'
+      - 'pendingRepoNodeId is cleared immediately'
+      - 'On API success: router.refresh() is called'
+      - 'On API failure: optimistic node is removed from nodes state'
+      - 'On API failure: optimistic edge is removed from edges state'
+      - 'On API failure: toast.error() shows the error message'
+      - 'isSubmitting state variable is removed (no longer needed)'
+    tdd:
+      red:
+        - 'Add test: on submit, a node with state creating appears in nodes before fetch resolves'
+        - 'Add test: on submit, drawer closes immediately (isCreateDrawerOpen false before fetch resolves)'
+        - 'Add test: on fetch success, router.refresh() is called'
+        - 'Add test: on fetch failure, the optimistic node is removed from nodes'
+        - 'Add test: on fetch failure, the optimistic edge is removed from edges'
+        - 'Add test: on fetch failure, toast.error() is called with error message'
+        - 'Add test: concurrent creations produce multiple optimistic nodes with unique IDs'
+      green:
+        - 'Rewrite handleCreateFeatureSubmit: insert node → close drawer → background fetch → reconcile/rollback'
+        - 'Remove isSubmitting state and setIsSubmitting calls'
+        - 'Update ControlCenterState interface to remove isSubmitting'
+      refactor:
+        - 'Verify all existing submit-related tests are updated or replaced'
+        - 'Ensure error handling covers both fetch network errors and non-ok responses'
+    estimatedEffort: '3h'
+
+  - id: task-10
+    phaseId: phase-3
+    title: "Guard handleNodeClick for 'creating' state nodes"
+    description: >
+      Update handleNodeClick in useControlCenterState to skip setting selectedNode for nodes with
+      data.state === 'creating'. An optimistic node has no server data to display in the detail panel,
+      so clicking it should be a no-op.
+    state: Todo
+    dependencies:
+      - task-4
+    acceptanceCriteria:
+      - "Clicking a node with state 'creating' does not set selectedNode"
+      - "Clicking a node with state 'running' still sets selectedNode (existing behavior)"
+      - 'Clicking a node with any other state still sets selectedNode (existing behavior)'
+    tdd:
+      red:
+        - "Add test: clicking a feature node with state 'creating' does not update selectedNode"
+        - "Add test: clicking a feature node with state 'running' still updates selectedNode"
+      green:
+        - "Add guard in handleNodeClick: check node.data.state !== 'creating' before setSelectedNode"
+      refactor:
+        - 'Consider whether the guard should also close the create drawer (likely no — drawer is already closed in optimistic flow)'
+    estimatedEffort: '30min'
+
+  # ── Phase 4: Non-Interactive Guard & Integration ─────────────────────────
+
+  - id: task-11
+    phaseId: phase-4
+    title: "Filter onAction/onSettings callbacks for 'creating' nodes in FeaturesCanvas"
+    description: >
+      Update the enrichedNodes useMemo in features-canvas.tsx to conditionally inject onAction and onSettings
+      callbacks only for feature nodes whose data.state is NOT 'creating'. This prevents the + action button
+      and settings gear from appearing on optimistic nodes. The guard is minimal: add
+      && (node.data as FeatureNodeData).state !== 'creating' to the existing conditional spread.
+    state: Todo
+    dependencies:
+      - task-4
+    acceptanceCriteria:
+      - "Feature nodes with state 'creating' do not receive onAction callback in enriched data"
+      - "Feature nodes with state 'creating' do not receive onSettings callback in enriched data"
+      - 'Feature nodes with other states still receive onAction/onSettings callbacks'
+      - 'Repository nodes and addRepository nodes are unaffected'
+    tdd:
+      red:
+        - "Add test: enrichedNodes for a feature node with state 'creating' has onAction undefined"
+        - "Add test: enrichedNodes for a feature node with state 'creating' has onSettings undefined"
+        - "Add test: enrichedNodes for a feature node with state 'running' still has onAction defined"
+      green:
+        - "Add state check to the featureNode spread in enrichedNodes: only inject callbacks when state !== 'creating'"
+      refactor:
+        - 'Import FeatureNodeData type if not already imported for the type assertion'
+    estimatedEffort: '1h'
+
+  - id: task-12
+    phaseId: phase-4
+    title: 'Remove isSubmitting prop usage and update control-center-inner'
+    description: >
+      Remove the isSubmitting prop from the FeatureCreateDrawer usage in control-center-inner.tsx since the
+      drawer now closes immediately on submit (no loading state needed). Update FeatureCreateDrawerProps to
+      make isSubmitting optional or remove it entirely if no other consumers use it. Update drawer stories
+      that showcase the Submitting state. Clean up the ControlCenterState interface if isSubmitting was
+      removed in task-9.
+    state: Todo
+    dependencies:
+      - task-9
+    acceptanceCriteria:
+      - 'control-center-inner.tsx does not pass isSubmitting to FeatureCreateDrawer'
+      - 'isSubmitting is removed from ControlCenterState interface'
+      - 'FeatureCreateDrawer still accepts optional isSubmitting prop (backward compat for stories) OR prop is removed'
+      - 'Drawer stories for Submitting state are updated or removed'
+      - 'All existing tests pass'
+      - 'TypeScript compiles without errors'
+    tdd:
+      red:
+        - 'Verify that removing isSubmitting from useControlCenterState return causes a type error in control-center-inner (confirming the dependency exists)'
+      green:
+        - 'Remove isSubmitting from useControlCenterState return value and ControlCenterState interface'
+        - 'Remove isSubmitting prop from FeatureCreateDrawer in control-center-inner.tsx'
+        - 'Update or remove Submitting story in feature-create-drawer.stories.tsx'
+      refactor:
+        - 'Clean up any remaining references to isSubmitting in test files'
+        - 'Verify no other components depend on isSubmitting from ControlCenterState'
+    estimatedEffort: '1h'
+
+totalEstimate: '12h'
+
+openQuestions: []
+
+content: |
+  ## Summary
+
+  The implementation is broken into 12 tasks across 4 phases, totaling approximately 12 hours of work
+  following strict TDD (Red-Green-Refactor) cycles.
+
+  **Phase 1 (Payload Fix, ~3h)** establishes the correct data contract between the drawer and API. The
+  drawer stops composing a userInput blob and instead sends structured {name, description, attachments,
+  repositoryPath, approvalGates}. This unblocks the feature creation flow (currently broken with a 400
+  error) and provides the structured data the optimistic node needs for display. All consumers —
+  useControlCenterState, stories, and tests — are updated to the new type.
+
+  **Phase 2 (Creating State, ~2.5h)** builds the visual foundation: a new 'creating' FeatureNodeState
+  in the config record, its rendering logic in the FeatureNode component (indeterminate progress bar,
+  "Creating..." text, no agent icon, aria-busy), and Storybook coverage. This can be developed and
+  verified independently of the optimistic flow.
+
+  **Phase 3 (Optimistic Flow, ~6h)** is the core implementation. It modifies createFeatureNode to return
+  the node ID and accept state overrides, adds a useEffect for syncing server props into local state
+  (enabling router.refresh() reconciliation), rewrites handleCreateFeatureSubmit for the
+  insert→close→background-fetch→reconcile/rollback pattern, and guards handleNodeClick for creating nodes.
+  Each piece has comprehensive TDD coverage using the existing test harness and mock infrastructure.
+
+  **Phase 4 (Integration, ~2h)** wires the non-interactive guard into FeaturesCanvas callback filtering
+  and removes the now-unnecessary isSubmitting prop from the drawer integration. This is a cleanup and
+  integration phase that ties everything together.
+
+  Tasks within each phase are ordered by dependency. Phase 1 must complete before Phase 3 (the optimistic
+  flow depends on the structured payload). Phase 2 tasks can technically run in parallel with Phase 1
+  since they modify different files, but are sequenced for simplicity. Phase 4 depends on Phase 3
+  completion.

--- a/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.stories.tsx
+++ b/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { within, userEvent, fn } from '@storybook/test';
 import { FeatureCreateDrawer } from './feature-create-drawer';
-import type { CreateFeatureInput } from '@shepai/core/application/use-cases/features/create/types';
+import type { FeatureCreatePayload } from './feature-create-drawer';
 import { Button } from '@/components/ui/button';
 
 /* ---------------------------------------------------------------------------
@@ -27,13 +27,12 @@ import { Button } from '@/components/ui/button';
  * |------|------|-------------|
  * | `open` | `boolean` | Controls drawer visibility |
  * | `onClose` | `() => void` | Called on dismiss (close button, cancel, or backdrop) |
- * | `onSubmit` | `(data: CreateFeatureInput) => void` | Called with `{ userInput, repositoryPath, approvalGates }` |
+ * | `onSubmit` | `(data: FeatureCreatePayload) => void` | Called with `{ name, description, attachments, repositoryPath, approvalGates }` |
  * | `repositoryPath` | `string` | Repository path (mandatory) included in the submitted data |
- * | `isSubmitting` | `boolean` | Disables all fields and shows "Creating..." on submit button |
  *
  * ### Behavior
  * - Form resets (name, description, attachments, checkboxes) when the drawer closes
- * - Submit button is disabled when name is empty OR `isSubmitting` is true
+ * - Submit button is disabled when name is empty
  * - `approvalGates` always included: `{ allowPrd, allowPlan, allowMerge }` (all false by default)
  * - Non-modal (`modal={false}`) — canvas stays interactive behind the drawer
  * - Fixed width: 384px (`w-96`)
@@ -58,16 +57,11 @@ const meta: Meta<typeof FeatureCreateDrawer> = {
     },
     onSubmit: {
       description:
-        'Callback fired with `CreateFeatureInput` when the form is submitted. Receives `{ userInput, repositoryPath, approvalGates }`.',
+        'Callback fired with `FeatureCreatePayload` when the form is submitted. Receives `{ name, description, attachments, repositoryPath, approvalGates }`.',
     },
     repositoryPath: {
       control: 'text',
       description: 'Repository path (mandatory) included in the submitted data.',
-    },
-    isSubmitting: {
-      control: 'boolean',
-      description:
-        'When true, all form fields and buttons are disabled, and the submit button shows "Creating...".',
     },
   },
 };
@@ -87,13 +81,7 @@ const logClose = fn().mockName('onClose');
  * ------------------------------------------------------------------------- */
 
 /** Starts closed — click button to open. Actions are logged. */
-function CreateDrawerTrigger({
-  isSubmitting = false,
-  label = 'Open Create Feature',
-}: {
-  isSubmitting?: boolean;
-  label?: string;
-}) {
+function CreateDrawerTrigger({ label = 'Open Create Feature' }: { label?: string }) {
   const [open, setOpen] = useState(false);
 
   return (
@@ -112,7 +100,6 @@ function CreateDrawerTrigger({
           setOpen(false);
         }}
         repositoryPath="/Users/dev/my-repo"
-        isSubmitting={isSubmitting}
       />
     </div>
   );
@@ -148,14 +135,6 @@ export const PreFilled: Story = {
       'Implement OAuth2 authentication with GitHub as the identity provider. Includes login, callback handling, and token refresh.'
     );
   },
-};
-
-/**
- * Submitting/loading state — all form fields are disabled, submit button shows "Creating...".
- * Click the trigger to open and observe the disabled form.
- */
-export const Submitting: Story = {
-  render: () => <CreateDrawerTrigger isSubmitting label="Open (Submitting)" />,
 };
 
 /**
@@ -251,8 +230,8 @@ export const MergeOnly: Story = {
  * Fully interactive story — open the drawer, fill the form, toggle checkboxes,
  * and click "Add Files" to attach files via the native OS file picker.
  *
- * **Submitted data** is displayed in a styled panel showing `CreateFeatureInput`
- * with `approvalGates: { allowPrd, allowPlan, allowMerge }`.
+ * **Submitted data** is displayed in a styled panel showing `FeatureCreatePayload`
+ * with `{ name, description, attachments, repositoryPath, approvalGates }`.
  *
  * In Storybook, the native picker won't work (no backend), but submitted data
  * would show the paths if files were attached programmatically.
@@ -260,7 +239,7 @@ export const MergeOnly: Story = {
 export const Interactive: Story = {
   render: function InteractiveRender() {
     const [open, setOpen] = useState(false);
-    const [submitted, setSubmitted] = useState<CreateFeatureInput | null>(null);
+    const [submitted, setSubmitted] = useState<FeatureCreatePayload | null>(null);
 
     return (
       <div className="flex h-screen items-start gap-4 p-4">

--- a/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
+++ b/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
@@ -28,10 +28,21 @@ import { CheckboxGroup } from '@/components/ui/checkbox-group';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
 import type { FileAttachment } from '@shepai/core/infrastructure/services/file-dialog.service';
-import type { CreateFeatureInput } from '@shepai/core/application/use-cases/features/create/types';
 import { pickFiles } from './pick-files';
 
 export type { FileAttachment } from '@shepai/core/infrastructure/services/file-dialog.service';
+
+export interface FeatureCreatePayload {
+  name: string;
+  description?: string;
+  attachments: FileAttachment[];
+  repositoryPath: string;
+  approvalGates: {
+    allowPrd: boolean;
+    allowPlan: boolean;
+    allowMerge: boolean;
+  };
+}
 
 const AUTO_APPROVE_OPTIONS = [
   { id: 'allowPrd', label: 'PRD', description: 'Auto-approve requirements move to planning.' },
@@ -45,29 +56,10 @@ const EMPTY_GATES: Record<string, boolean> = {
   allowMerge: false,
 };
 
-function composeUserInput(
-  name: string,
-  description: string | undefined,
-  attachments: FileAttachment[]
-): string {
-  let userInput = `Feature: ${name}`;
-
-  if (description) {
-    userInput += `\n\n${description}`;
-  }
-
-  if (attachments.length > 0) {
-    const paths = attachments.map((a) => `- ${a.path}`).join('\n');
-    userInput += `\n\nAttached files:\n${paths}`;
-  }
-
-  return userInput;
-}
-
 export interface FeatureCreateDrawerProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (data: CreateFeatureInput) => void;
+  onSubmit: (data: FeatureCreatePayload) => void;
   repositoryPath: string;
   isSubmitting?: boolean;
 }
@@ -105,9 +97,11 @@ export function FeatureCreateDrawer({
     (e: React.FormEvent) => {
       e.preventDefault();
       if (!name.trim()) return;
-      const userInput = composeUserInput(name.trim(), description.trim() || undefined, attachments);
+      const trimmedDescription = description.trim() || undefined;
       onSubmit({
-        userInput,
+        name: name.trim(),
+        description: trimmedDescription,
+        attachments,
         repositoryPath,
         approvalGates: {
           allowPrd: approvalGates.allowPrd ?? false,

--- a/src/presentation/web/components/common/feature-create-drawer/index.ts
+++ b/src/presentation/web/components/common/feature-create-drawer/index.ts
@@ -1,5 +1,6 @@
 export {
   FeatureCreateDrawer,
   type FeatureCreateDrawerProps,
+  type FeatureCreatePayload,
   type FileAttachment,
 } from './feature-create-drawer';

--- a/src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx
+++ b/src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx
@@ -168,7 +168,19 @@ export const AllFields: Story = {
  * Matrix stories — interactive state/lifecycle switcher
  * ------------------------------------------------------------------------- */
 
+const creatingData: FeatureNodeData = {
+  name: 'User Onboarding',
+  description: 'Implement guided onboarding wizard',
+  featureId: '',
+  lifecycle: 'requirements',
+  state: 'creating',
+  progress: 0,
+  repositoryPath: '/home/user/my-repo',
+  branch: '',
+};
+
 const stateFixtures: Record<FeatureNodeState, FeatureNodeData> = {
+  creating: creatingData,
   running: runningData,
   'action-required': actionRequiredData,
   done: doneData,

--- a/src/presentation/web/components/common/feature-node/feature-node-state-config.ts
+++ b/src/presentation/web/components/common/feature-node/feature-node-state-config.ts
@@ -2,7 +2,13 @@ import { Loader2, CircleAlert, CircleCheck, Ban, CircleX, type LucideIcon } from
 import type { Node } from '@xyflow/react';
 import type { AgentTypeValue } from './agent-type-icons';
 
-export type FeatureNodeState = 'running' | 'action-required' | 'done' | 'blocked' | 'error';
+export type FeatureNodeState =
+  | 'creating'
+  | 'running'
+  | 'action-required'
+  | 'done'
+  | 'blocked'
+  | 'error';
 
 export type FeatureLifecyclePhase =
   | 'requirements'
@@ -71,6 +77,16 @@ export interface FeatureNodeStateConfig {
 }
 
 export const featureNodeStateConfig: Record<FeatureNodeState, FeatureNodeStateConfig> = {
+  creating: {
+    icon: Loader2,
+    borderClass: 'border-l-blue-500',
+    labelClass: 'text-blue-500',
+    progressClass: 'bg-blue-500',
+    badgeClass: 'text-blue-700',
+    badgeBgClass: 'bg-blue-50',
+    label: 'Creating...',
+    showProgressBar: false,
+  },
   running: {
     icon: Loader2,
     borderClass: 'border-l-blue-500',

--- a/src/presentation/web/components/common/feature-node/feature-node.stories.tsx
+++ b/src/presentation/web/components/common/feature-node/feature-node.stories.tsx
@@ -71,6 +71,16 @@ export const Default: Story = {
 
 const allStatesData: FeatureNodeData[] = [
   {
+    name: 'User Onboarding',
+    description: 'Implement guided onboarding wizard',
+    featureId: '',
+    lifecycle: 'requirements' as FeatureLifecyclePhase,
+    state: 'creating',
+    progress: 0,
+    repositoryPath: '/home/user/my-repo',
+    branch: '',
+  },
+  {
     name: 'Auth Module',
     description: 'Implement OAuth2 authentication flow',
     featureId: '#f1',
@@ -208,6 +218,18 @@ export const BlockedByFeature: Story = {
     state: 'blocked',
     progress: 20,
     blockedBy: 'Auth Module',
+  },
+  render: (args) => <FeatureNodeCanvas data={args} />,
+};
+
+export const Creating: Story = {
+  args: {
+    name: 'User Onboarding',
+    description: 'Implement guided onboarding wizard',
+    featureId: '',
+    lifecycle: 'requirements',
+    state: 'creating',
+    progress: 0,
   },
   render: (args) => <FeatureNodeCanvas data={args} />,
 };

--- a/src/presentation/web/components/common/feature-node/feature-node.tsx
+++ b/src/presentation/web/components/common/feature-node/feature-node.tsx
@@ -19,6 +19,8 @@ function AgentIcon({ agentType, className }: { agentType?: string; className?: s
 function getBadgeText(data: FeatureNodeData): string {
   const config = featureNodeStateConfig[data.state];
   switch (data.state) {
+    case 'creating':
+      return 'Creating...';
     case 'running':
       return lifecycleRunningVerbs[data.lifecycle];
     case 'done':
@@ -56,6 +58,7 @@ export function FeatureNode({
 
       <div
         data-testid="feature-node-card"
+        aria-busy={data.state === 'creating' ? 'true' : undefined}
         className={cn(
           'bg-card flex min-h-35 w-72 flex-col rounded-lg border p-3 shadow-sm',
           selected && 'ring-primary ring-2'
@@ -100,7 +103,23 @@ export function FeatureNode({
 
         {/* Bottom section — pushed to bottom for consistent card height */}
         <div className="mt-auto pt-2">
-          {data.state === 'running' ? (
+          {data.state === 'creating' ? (
+            <>
+              {/* Creating status: loader icon + "Creating..." text */}
+              <div className="mt-1.5 flex items-center gap-1.5 text-xs">
+                <Icon className="h-3.5 w-3.5 shrink-0 animate-spin" />
+                <span className="text-muted-foreground">{getBadgeText(data)}</span>
+              </div>
+
+              {/* Indeterminate progress bar */}
+              <div
+                data-testid="feature-node-progress-bar"
+                className="bg-muted mt-1.5 h-1 w-full overflow-hidden rounded-full"
+              >
+                <div className="motion-safe:animate-indeterminate-progress bg-foreground/30 h-full w-1/3 rounded-full" />
+              </div>
+            </>
+          ) : data.state === 'running' ? (
             <>
               {/* Running status: agent icon + verb */}
               <div className="mt-1.5 flex items-center gap-1.5 text-xs">

--- a/src/presentation/web/components/common/index.ts
+++ b/src/presentation/web/components/common/index.ts
@@ -5,7 +5,11 @@ export {
 } from './add-repository-node';
 export { ElapsedTime, formatElapsed } from './elapsed-time';
 export { EmptyState, type EmptyStateProps } from './empty-state';
-export { FeatureCreateDrawer, type FeatureCreateDrawerProps } from './feature-create-drawer';
+export {
+  FeatureCreateDrawer,
+  type FeatureCreateDrawerProps,
+  type FeatureCreatePayload,
+} from './feature-create-drawer';
 export { FeatureDrawer, type FeatureDrawerProps } from './feature-drawer';
 export { FeatureListItem, type FeatureListItemProps } from './feature-list-item';
 export {

--- a/src/presentation/web/components/features/control-center/control-center-inner.tsx
+++ b/src/presentation/web/components/features/control-center/control-center-inner.tsx
@@ -19,7 +19,6 @@ export function ControlCenterInner({ initialNodes, initialEdges }: ControlCenter
     edges,
     selectedNode,
     isCreateDrawerOpen,
-    isSubmitting,
     isDeleting,
     pendingRepositoryPath,
     onNodesChange,
@@ -68,7 +67,6 @@ export function ControlCenterInner({ initialNodes, initialEdges }: ControlCenter
         onClose={closeCreateDrawer}
         onSubmit={handleCreateFeatureSubmit}
         repositoryPath={pendingRepositoryPath}
-        isSubmitting={isSubmitting}
       />
     </>
   );

--- a/src/presentation/web/components/features/features-canvas/features-canvas.tsx
+++ b/src/presentation/web/components/features/features-canvas/features-canvas.tsx
@@ -7,7 +7,7 @@ import { Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/common/empty-state';
 import { FeatureNode } from '@/components/common/feature-node';
-import type { FeatureNodeType } from '@/components/common/feature-node';
+import type { FeatureNodeType, FeatureNodeData } from '@/components/common/feature-node';
 import { RepositoryNode } from '@/components/common/repository-node';
 import type { RepositoryNodeType } from '@/components/common/repository-node';
 import { AddRepositoryNode } from '@/components/common/add-repository-node';
@@ -78,10 +78,11 @@ export function FeaturesCanvas({
         data: {
           ...node.data,
           showHandles: edges.length > 0,
-          ...(node.type === 'featureNode' && {
-            onAction: onNodeAction ? () => onNodeAction(node.id) : undefined,
-            onSettings: onNodeSettings ? () => onNodeSettings(node.id) : undefined,
-          }),
+          ...(node.type === 'featureNode' &&
+            (node.data as FeatureNodeData).state !== 'creating' && {
+              onAction: onNodeAction ? () => onNodeAction(node.id) : undefined,
+              onSettings: onNodeSettings ? () => onNodeSettings(node.id) : undefined,
+            }),
           ...(node.type === 'repositoryNode' && {
             onAdd: onRepositoryAdd ? () => onRepositoryAdd(node.id) : undefined,
           }),

--- a/tests/unit/presentation/web/common/feature-node/feature-node.test.tsx
+++ b/tests/unit/presentation/web/common/feature-node/feature-node.test.tsx
@@ -212,6 +212,45 @@ describe('FeatureNode', () => {
     });
   });
 
+  describe('creating state', () => {
+    it('renders without throwing when state is creating', () => {
+      renderFeatureNode({ state: 'creating' });
+      expect(screen.getByTestId('feature-node-card')).toBeInTheDocument();
+    });
+
+    it('shows "Creating..." badge text', () => {
+      renderFeatureNode({ state: 'creating' });
+      expect(screen.getByText('Creating...')).toBeInTheDocument();
+    });
+
+    it('renders the feature name', () => {
+      renderFeatureNode({ state: 'creating', name: 'New Feature' });
+      expect(screen.getByText('New Feature')).toBeInTheDocument();
+    });
+
+    it('shows indeterminate progress bar', () => {
+      renderFeatureNode({ state: 'creating' });
+      expect(screen.getByTestId('feature-node-progress-bar')).toBeInTheDocument();
+      expect(screen.queryByTestId('feature-node-badge')).not.toBeInTheDocument();
+    });
+
+    it('does not render agent icon element', () => {
+      renderFeatureNode({ state: 'creating', agentType: 'claude-code' });
+      // In 'running' state, the agent icon renders with a specific icon component.
+      // In 'creating' state, there should be no agent icon — only "Creating..." text.
+      const creatingText = screen.getByText('Creating...');
+      expect(creatingText).toBeInTheDocument();
+      // The running state renders AgentIcon; creating state should not
+      expect(screen.queryByText('Analyzing')).not.toBeInTheDocument();
+    });
+
+    it('has aria-busy="true" on the card element', () => {
+      renderFeatureNode({ state: 'creating' });
+      const card = screen.getByTestId('feature-node-card');
+      expect(card).toHaveAttribute('aria-busy', 'true');
+    });
+  });
+
   describe('selected highlight', () => {
     it('applies ring classes when selected is true', () => {
       renderFeatureNode(undefined, { selected: true });

--- a/tests/unit/presentation/web/features/features-canvas/features-canvas.test.tsx
+++ b/tests/unit/presentation/web/features/features-canvas/features-canvas.test.tsx
@@ -93,4 +93,47 @@ describe('FeaturesCanvas', () => {
     );
     expect(screen.getByTestId('custom-toolbar')).toBeInTheDocument();
   });
+
+  describe('non-interactive guard for creating state', () => {
+    const creatingNode: FeatureNodeType = {
+      id: 'creating-1',
+      type: 'featureNode',
+      position: { x: 0, y: 0 },
+      data: {
+        name: 'Optimistic Feature',
+        featureId: '#c1',
+        lifecycle: 'requirements',
+        state: 'creating',
+        progress: 0,
+        repositoryPath: '/home/user/repo',
+        branch: '',
+      },
+    };
+
+    it('does not inject onAction for feature nodes with state "creating"', () => {
+      const onNodeAction = vi.fn();
+      render(<FeaturesCanvas nodes={[creatingNode]} edges={[]} onNodeAction={onNodeAction} />);
+      // The action button should not be rendered because onAction is not injected
+      expect(screen.queryByTestId('feature-node-action-button')).not.toBeInTheDocument();
+    });
+
+    it('does not inject onSettings for feature nodes with state "creating"', () => {
+      const onNodeSettings = vi.fn();
+      render(<FeaturesCanvas nodes={[creatingNode]} edges={[]} onNodeSettings={onNodeSettings} />);
+      // The settings button should not be rendered because onSettings is not injected
+      expect(screen.queryByTestId('feature-node-settings-button')).not.toBeInTheDocument();
+    });
+
+    it('still injects onAction for feature nodes with state "running"', () => {
+      const onNodeAction = vi.fn();
+      render(<FeaturesCanvas nodes={[mockNode]} edges={[]} onNodeAction={onNodeAction} />);
+      expect(screen.getByTestId('feature-node-action-button')).toBeInTheDocument();
+    });
+
+    it('still injects onSettings for feature nodes with state "running"', () => {
+      const onNodeSettings = vi.fn();
+      render(<FeaturesCanvas nodes={[mockNode]} edges={[]} onNodeSettings={onNodeSettings} />);
+      expect(screen.getByTestId('feature-node-settings-button')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Replace blocking async submit flow with optimistic rendering — insert a "creating" node instantly on submit and fire the API in background
- Add new `creating` state to `FeatureNodeState` with animated indeterminate progress bar, spinner icon, and `aria-busy` attribute
- Introduce `FeatureCreatePayload` interface replacing `CreateFeatureInput`, sending structured fields (`name`, `description`, `attachments`) instead of composed `userInput` string
- Merge server-provided positions with client positions on `router.refresh()` so the real feature node appears exactly where the optimistic node was (no jump to top)
- Guard creating nodes from interaction: no click selection, no action/settings buttons, no drawer open
- Add comprehensive test coverage for optimistic flow, rollback on error, concurrent creations, and position-preserving prop sync

## Test plan

- [x] Unit tests for `creating` state rendering (badge text, progress bar, aria-busy, no agent icon)
- [x] Unit tests for optimistic submit flow (instant node insertion, drawer close, edge creation)
- [x] Unit tests for rollback on API error and network failure (node + edge removal, toast)
- [x] Unit tests for `FeatureCreatePayload` structured fields
- [x] Unit tests for position-preserving `initialNodes` sync (merge strategy replaces optimistic → real)
- [x] Unit tests for non-interactive guards on creating nodes (no onAction/onSettings injection)
- [x] Unit tests for concurrent optimistic creations with unique IDs
- [ ] Manual: create a feature, observe instant "Creating..." node, verify it stays in place after API completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)