### PR TITLE
fix(agents): record phase timing on failure and update lifecycle per node

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -26,6 +26,7 @@ import { initializeSettings } from '@/infrastructure/services/settings.service.j
 import { InitializeSettingsUseCase } from '@/application/use-cases/settings/initialize-settings.use-case.js';
 import { setHeartbeatContext } from './heartbeat.js';
 import { setPhaseTimingContext } from './phase-timing-context.js';
+import { setLifecycleContext } from './lifecycle-context.js';
 import type { IPhaseTimingRepository } from '@/application/ports/output/agents/phase-timing-repository.interface.js';
 import { generatePrYaml } from './nodes/pr-yaml-generator.js';
 
@@ -194,6 +195,9 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
   // Set phase timing context so executeNode() records per-phase durations
   const timingRepository = container.resolve<IPhaseTimingRepository>('IPhaseTimingRepository');
   setPhaseTimingContext(args.runId, timingRepository);
+
+  // Set lifecycle context so nodes update the feature lifecycle as they execute
+  setLifecycleContext(args.featureId, featureRepository);
 
   try {
     const graphConfig = { configurable: { thread_id: checkpointId } };

--- a/packages/core/src/infrastructure/services/agents/feature-agent/lifecycle-context.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/lifecycle-context.ts
@@ -1,0 +1,67 @@
+/**
+ * Lifecycle Context
+ *
+ * Module-level singleton that allows graph nodes to update the feature's
+ * SDLC lifecycle as they execute, following the same pattern as
+ * phase-timing-context.ts.
+ *
+ * The worker calls setLifecycleContext() once after DI init.
+ * Nodes call updateNodeLifecycle() at the start of execution.
+ * Errors are swallowed so lifecycle updates never block graph execution.
+ */
+
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import { SdlcLifecycle } from '@/domain/generated/output.js';
+
+let contextFeatureId: string | undefined;
+let contextRepository: IFeatureRepository | undefined;
+
+/** Map graph node names to their corresponding SDLC lifecycle stage. */
+const NODE_TO_LIFECYCLE: Record<string, SdlcLifecycle> = {
+  analyze: SdlcLifecycle.Analyze,
+  requirements: SdlcLifecycle.Requirements,
+  research: SdlcLifecycle.Research,
+  plan: SdlcLifecycle.Planning,
+  implement: SdlcLifecycle.Implementation,
+  merge: SdlcLifecycle.Review,
+};
+
+/**
+ * Set the lifecycle context. Called once by the worker after DI init.
+ */
+export function setLifecycleContext(featureId: string, repository: IFeatureRepository): void {
+  contextFeatureId = featureId;
+  contextRepository = repository;
+}
+
+/**
+ * Clear the lifecycle context. Useful for testing.
+ */
+export function clearLifecycleContext(): void {
+  contextFeatureId = undefined;
+  contextRepository = undefined;
+}
+
+/**
+ * Update the feature's lifecycle to match the current graph node.
+ * No-op if context is not set or the node name has no lifecycle mapping.
+ */
+export async function updateNodeLifecycle(nodeName: string): Promise<void> {
+  if (!contextFeatureId || !contextRepository) return;
+
+  const lifecycle = NODE_TO_LIFECYCLE[nodeName];
+  if (!lifecycle) return;
+
+  try {
+    const feature = await contextRepository.findById(contextFeatureId);
+    if (!feature) return;
+
+    await contextRepository.update({
+      ...feature,
+      lifecycle,
+      updatedAt: new Date(),
+    });
+  } catch {
+    // Swallow — lifecycle update failure is non-fatal
+  }
+}

--- a/tests/unit/infrastructure/services/agents/lifecycle-context.test.ts
+++ b/tests/unit/infrastructure/services/agents/lifecycle-context.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Lifecycle Context Unit Tests
+ *
+ * Tests for the module-level singleton that allows graph nodes
+ * to update the feature's SDLC lifecycle as they execute.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  setLifecycleContext,
+  clearLifecycleContext,
+  updateNodeLifecycle,
+} from '@/infrastructure/services/agents/feature-agent/lifecycle-context.js';
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import { SdlcLifecycle } from '@/domain/generated/output.js';
+
+function createMockFeatureRepo(feature: Record<string, unknown> | null = null): IFeatureRepository {
+  return {
+    findById: vi.fn().mockResolvedValue(
+      feature ?? {
+        id: 'feat-1',
+        lifecycle: SdlcLifecycle.Requirements,
+        updatedAt: new Date(),
+      }
+    ),
+    update: vi.fn().mockResolvedValue(undefined),
+    save: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(undefined),
+    findBySlug: vi.fn().mockResolvedValue(null),
+  } as unknown as IFeatureRepository;
+}
+
+describe('LifecycleContext', () => {
+  beforeEach(() => {
+    clearLifecycleContext();
+  });
+
+  describe('setLifecycleContext / clearLifecycleContext', () => {
+    it('should allow setting and clearing context', () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+      clearLifecycleContext();
+    });
+  });
+
+  describe('updateNodeLifecycle', () => {
+    it('should update feature lifecycle to Analyze for analyze node', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('analyze');
+
+      expect(repo.findById).toHaveBeenCalledWith('feat-1');
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lifecycle: SdlcLifecycle.Analyze,
+          updatedAt: expect.any(Date),
+        })
+      );
+    });
+
+    it('should update feature lifecycle to Requirements for requirements node', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('requirements');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ lifecycle: SdlcLifecycle.Requirements })
+      );
+    });
+
+    it('should update feature lifecycle to Research for research node', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('research');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ lifecycle: SdlcLifecycle.Research })
+      );
+    });
+
+    it('should update feature lifecycle to Planning for plan node', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('plan');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ lifecycle: SdlcLifecycle.Planning })
+      );
+    });
+
+    it('should update feature lifecycle to Implementation for implement node', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('implement');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ lifecycle: SdlcLifecycle.Implementation })
+      );
+    });
+
+    it('should update feature lifecycle to Review for merge node', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('merge');
+
+      expect(repo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ lifecycle: SdlcLifecycle.Review })
+      );
+    });
+
+    it('should be a no-op when context is not set', async () => {
+      // No context set — should not throw
+      await updateNodeLifecycle('analyze');
+    });
+
+    it('should be a no-op for unknown node names', async () => {
+      const repo = createMockFeatureRepo();
+      setLifecycleContext('feat-1', repo);
+
+      await updateNodeLifecycle('validate_spec_analyze');
+
+      expect(repo.findById).not.toHaveBeenCalled();
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('should be a no-op when feature is not found', async () => {
+      const repo = createMockFeatureRepo(null);
+      (repo.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      setLifecycleContext('feat-missing', repo);
+
+      await updateNodeLifecycle('analyze');
+
+      expect(repo.findById).toHaveBeenCalledWith('feat-missing');
+      expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when repository update fails', async () => {
+      const repo = createMockFeatureRepo();
+      (repo.update as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('DB error'));
+      setLifecycleContext('feat-1', repo);
+
+      // Should not throw
+      await updateNodeLifecycle('analyze');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Phase timing on failure**: All graph nodes (`executeNode`, `implement`, `merge`) now call `recordPhaseEnd()` in their catch blocks, so failed phases show actual elapsed time instead of "(running)" in `feat show`
- **Lifecycle per node**: New `lifecycle-context.ts` module (same pattern as `phase-timing-context.ts`) updates the feature's SDLC lifecycle at the start of each graph node, fixing the bug where lifecycle stayed at "Requirements" through the entire pipeline
- **Node-to-lifecycle mapping**: analyze→Analyze, requirements→Requirements, research→Research, plan→Planning, implement→Implementation, merge→Review

## Test plan
- [x] New `lifecycle-context.test.ts` covers all node mappings, no-op cases, and error swallowing
- [x] Updated `merge.node.test.ts` verifies `recordPhaseEnd` is called even when merge fails
- [x] All 1816 unit tests pass
- [x] Pre-commit hooks pass (lint, format, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)