### PR TITLE
fix(agents): correct approval wait timing attribution and bar overflow

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -25,11 +25,7 @@ import { AgentRunStatus } from '@/domain/generated/output.js';
 import { initializeSettings } from '@/infrastructure/services/settings.service.js';
 import { InitializeSettingsUseCase } from '@/application/use-cases/settings/initialize-settings.use-case.js';
 import { setHeartbeatContext } from './heartbeat.js';
-import {
-  setPhaseTimingContext,
-  recordApprovalWaitStart,
-  getLastTimingId,
-} from './phase-timing-context.js';
+import { setPhaseTimingContext } from './phase-timing-context.js';
 import { setLifecycleContext } from './lifecycle-context.js';
 import type { IPhaseTimingRepository } from '@/application/ports/output/agents/phase-timing-repository.interface.js';
 import { generatePrYaml } from './nodes/pr-yaml-generator.js';
@@ -250,9 +246,6 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
     // Check if graph was interrupted (human-in-the-loop approval needed)
     const interruptPayload = result.__interrupt__ as { value: unknown }[] | undefined;
     if (interruptPayload && interruptPayload.length > 0) {
-      // Record approval wait start on the last phase timing
-      await recordApprovalWaitStart(getLastTimingId());
-
       const now = new Date();
       await runRepository.updateStatus(args.runId, AgentRunStatus.waitingApproval, {
         updatedAt: now,

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/implement.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/implement.node.ts
@@ -24,7 +24,11 @@ import {
   markPhaseComplete,
 } from './node-helpers.js';
 import { reportNodeStart } from '../heartbeat.js';
-import { recordPhaseStart, recordPhaseEnd } from '../phase-timing-context.js';
+import {
+  recordPhaseStart,
+  recordPhaseEnd,
+  recordApprovalWaitStart,
+} from '../phase-timing-context.js';
 import { updateNodeLifecycle } from '../lifecycle-context.js';
 import {
   buildImplementPhasePrompt,
@@ -232,6 +236,7 @@ export function createImplementNode(executor: IAgentExecutor) {
 
       if (shouldInterrupt('implement', state.approvalGates)) {
         log.info('Interrupting for human approval');
+        await recordApprovalWaitStart(implementTimingId);
         interrupt({
           node: 'implement',
           message: `Implementation complete: ${totalTasks} tasks across ${totalPhases} phases. Approve to finish.`,

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
@@ -17,7 +17,11 @@ import type {
 import type { ApprovalGates } from '@/domain/generated/output.js';
 import type { FeatureAgentState } from '../state.js';
 import { reportNodeStart } from '../heartbeat.js';
-import { recordPhaseStart, recordPhaseEnd } from '../phase-timing-context.js';
+import {
+  recordPhaseStart,
+  recordPhaseEnd,
+  recordApprovalWaitStart,
+} from '../phase-timing-context.js';
 import { updateNodeLifecycle } from '../lifecycle-context.js';
 
 /**
@@ -302,6 +306,7 @@ export function executeNode(
       // Human-in-the-loop: interrupt after node execution for review
       if (shouldInterrupt(nodeName, state.approvalGates)) {
         log.info('Interrupting for human approval');
+        await recordApprovalWaitStart(timingId);
         interrupt({
           node: nodeName,
           result: result.result.slice(0, 500),

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
@@ -16,14 +16,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 
-const { mockInterrupt, mockShouldInterrupt, mockRecordPhaseStart, mockRecordPhaseEnd } = vi.hoisted(
-  () => ({
-    mockInterrupt: vi.fn(),
-    mockShouldInterrupt: vi.fn().mockReturnValue(false),
-    mockRecordPhaseStart: vi.fn().mockResolvedValue('timing-123'),
-    mockRecordPhaseEnd: vi.fn().mockResolvedValue(undefined),
-  })
-);
+const {
+  mockInterrupt,
+  mockShouldInterrupt,
+  mockRecordPhaseStart,
+  mockRecordPhaseEnd,
+  mockRecordApprovalWaitStart,
+} = vi.hoisted(() => ({
+  mockInterrupt: vi.fn(),
+  mockShouldInterrupt: vi.fn().mockReturnValue(false),
+  mockRecordPhaseStart: vi.fn().mockResolvedValue('timing-123'),
+  mockRecordPhaseEnd: vi.fn().mockResolvedValue(undefined),
+  mockRecordApprovalWaitStart: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Mock LangGraph interrupt
 vi.mock('@langchain/langgraph', () => ({
@@ -50,6 +55,7 @@ vi.mock('@/infrastructure/services/agents/feature-agent/heartbeat.js', () => ({
 vi.mock('@/infrastructure/services/agents/feature-agent/phase-timing-context.js', () => ({
   recordPhaseStart: mockRecordPhaseStart,
   recordPhaseEnd: mockRecordPhaseEnd,
+  recordApprovalWaitStart: mockRecordApprovalWaitStart,
 }));
 
 // Mock lifecycle context


### PR DESCRIPTION
## Summary
- Fix `shep feat show` crash (`Invalid count value: -179`) when approval wait time exceeds max execution time — bar length now capped with `Math.min`
- Show live `↳ approval` row with `(waiting)` suffix and elapsed timer during approval review
- Move approval wait stamping from worker to individual nodes so each records wait on its own timing ID — fixes wrong attribution to sub-phases (e.g. `implement:phase-2` instead of `implement`)
- Close merge timing before `interrupt()` so pre-approval work gets a `completed_at` — fixes zombie timing records with null completion

## Test plan
- [x] All 1827 unit tests pass
- [x] All 201 integration tests pass
- [x] TypeScript typecheck clean
- [x] Verified `shep feat show` no longer crashes with approval timings
- [x] Verified live approval wait row renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)