### PR TITLE
fix(cli): include feature short id in approve/reject hints

### DIFF
--- a/src/presentation/cli/commands/feat/show.command.ts
+++ b/src/presentation/cli/commands/feat/show.command.ts
@@ -375,8 +375,8 @@ export function createShowCommand(): Command {
             content: [
               `${phase} is waiting for your review.`,
               '',
-              `  ${colors.accent('shep feat approve')}  Resume the agent`,
-              `  ${colors.accent('shep feat reject')}   Cancel with feedback`,
+              `  ${colors.accent(`shep feat approve ${feature.id.slice(0, 8)}`)}  Resume the agent`,
+              `  ${colors.accent(`shep feat reject ${feature.id.slice(0, 8)}`)}   Cancel with feedback`,
             ].join('\n'),
           });
         }


### PR DESCRIPTION
## Summary
- `shep feat show` now includes the feature's short ID in the `shep feat approve` and `shep feat reject` hint commands, making them copy-pasteable

## Test plan
- [ ] Run `shep feat show <id>` on a feature waiting for approval and verify the approve/reject hints include the short ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)