### PR TITLE
fix(tsp): regenerate types and json schemas from current typespec models

### DIFF
--- a/packages/core/src/domain/generated/output.ts
+++ b/packages/core/src/domain/generated/output.ts
@@ -1687,6 +1687,92 @@ export type PhaseTiming = BaseEntity & {
 };
 
 /**
+ * Change to a question's selected option during PRD review
+ */
+export type QuestionSelectionChange = {
+  /**
+   * ID of the open question being changed (the question text)
+   */
+  questionId: string;
+  /**
+   * The option text that the user selected
+   */
+  selectedOption: string;
+};
+
+/**
+ * Payload sent when user approves a PRD with optional selection changes
+ */
+export type PrdApprovalPayload = {
+  /**
+   * Always true for approval payloads
+   */
+  approved: boolean;
+  /**
+   * List of selection changes the user made during review (empty if no changes)
+   */
+  changedSelections?: QuestionSelectionChange[];
+};
+
+/**
+ * Payload sent when user rejects a PRD with feedback for iteration
+ */
+export type PrdRejectionPayload = {
+  /**
+   * Always true for rejection payloads
+   */
+  rejected: boolean;
+  /**
+   * User's feedback explaining what needs to change
+   */
+  feedback: string;
+  /**
+   * Iteration number (1-based, derived from PhaseTiming row count)
+   */
+  iteration: number;
+};
+
+/**
+ * A single question with its options as presented in the review TUI
+ */
+export type ReviewQuestion = {
+  /**
+   * The question text
+   */
+  question: string;
+  /**
+   * Available options with selection state
+   */
+  options: QuestionOption[];
+  /**
+   * The option text that was selected by the user
+   */
+  selectedOption: string;
+  /**
+   * Whether the user changed the selection from the AI default
+   */
+  changed: boolean;
+};
+
+/**
+ * Result of the PRD review TUI interaction
+ */
+export type PrdReviewResult = {
+  /**
+   * All questions with their final selection state
+   */
+  questions: ReviewQuestion[];
+  /**
+   * User action: approve or reject
+   */
+  action: string;
+  /**
+   * Rejection feedback (only present when action is 'reject')
+   */
+  feedback?: string;
+};
+
+/**
  * A selectable option within a PRD questionnaire question
  */
 export type PrdOption = {
@@ -1772,92 +1858,6 @@ export type PrdQuestionnaireData = {
    * Configuration for the finalize/approve action button
    */
   finalAction: PrdFinalAction;
-};
-
-/**
- * Change to a question's selected option during PRD review
- */
-export type QuestionSelectionChange = {
-  /**
-   * ID of the open question being changed (the question text)
-   */
-  questionId: string;
-  /**
-   * The option text that the user selected
-   */
-  selectedOption: string;
-};
-
-/**
- * Payload sent when user approves a PRD with optional selection changes
- */
-export type PrdApprovalPayload = {
-  /**
-   * Always true for approval payloads
-   */
-  approved: boolean;
-  /**
-   * List of selection changes the user made during review (empty if no changes)
-   */
-  changedSelections?: QuestionSelectionChange[];
-};
-
-/**
- * Payload sent when user rejects a PRD with feedback for iteration
- */
-export type PrdRejectionPayload = {
-  /**
-   * Always true for rejection payloads
-   */
-  rejected: boolean;
-  /**
-   * User's feedback explaining what needs to change
-   */
-  feedback: string;
-  /**
-   * Iteration number (1-based, derived from PhaseTiming row count)
-   */
-  iteration: number;
-};
-
-/**
- * A single question with its options as presented in the review TUI
- */
-export type ReviewQuestion = {
-  /**
-   * The question text
-   */
-  question: string;
-  /**
-   * Available options with selection state
-   */
-  options: QuestionOption[];
-  /**
-   * The option text that was selected by the user
-   */
-  selectedOption: string;
-  /**
-   * Whether the user changed the selection from the AI default
-   */
-  changed: boolean;
-};
-
-/**
- * Result of the PRD review TUI interaction
- */
-export type PrdReviewResult = {
-  /**
-   * All questions with their final selection state
-   */
-  questions: ReviewQuestion[];
-  /**
-   * User action: approve or reject
-   */
-  action: string;
-  /**
-   * Rejection feedback (only present when action is 'reject')
-   */
-  feedback?: string;
 };
 export enum AgentFeature {
   sessionResume = 'session-resume',


### PR DESCRIPTION
## Summary

- Regenerated TypeSpec types and JSON schemas (`pnpm tsp:compile`) to fix stale generated output
- Fixes `ResearchArtifact.yaml` validation failures caused by outdated schema inheritance chain (was requiring `type`, `category`, `format`, `path`, `state`, `featureNumber`, `decisionCount`, `evaluatedTechnologies`, `selectedTechnology` from old `Artifact` → `BaseSpecArtifact` chain instead of current `SpecArtifactBase` → `BaseEntity` chain)
- Also fixed missing `ajv` package linking (`pnpm install`)

## Test plan

- [x] Verified `parseResearchYaml()` succeeds against actual `research.yaml` spec file
- [x] Verified `tsx src/presentation/cli/index.ts ui` starts without `ERR_MODULE_NOT_FOUND` for `ajv`
- [ ] CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)