### PR TITLE
fix(domain): add ajv-formats for date-time validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "@langchain/langgraph-checkpoint-sqlite": "^1.0.1",
     "@typespec-tools/emitter-typescript": "^0.3.0",
     "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
     "cli-table3": "^0.6.5",

--- a/packages/core/src/domain/factories/spec-yaml-parser.ts
+++ b/packages/core/src/domain/factories/spec-yaml-parser.ts
@@ -7,6 +7,7 @@
  */
 
 import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
 import yaml from 'js-yaml';
 import { readdirSync, readFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
@@ -30,6 +31,7 @@ function resolveSchemaDir(): string {
 
 function createValidator(): Ajv2020 {
   const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
   const schemaDir = resolveSchemaDir();
   const files = readdirSync(schemaDir).filter((f) => f.endsWith('.yaml'));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.18.0)
       better-sqlite3:
         specifier: ^12.6.2
         version: 12.6.2
@@ -3099,6 +3102,14 @@ packages:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
       ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -9622,6 +9633,10 @@ snapshots:
       indent-string: 5.0.0
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
 


### PR DESCRIPTION
## Summary
- AJV 8 dropped built-in format validation, causing "unknown format date-time ignored" warnings for `timestamp`, `createdAt`, and `updatedAt` fields in JSON Schema validation
- Installed `ajv-formats` and registered it with the AJV instance in `spec-yaml-parser.ts`
- Now `format: date-time` is properly recognized and validated instead of silently ignored

## Test plan
- [x] All 84 existing spec-yaml-parser tests pass
- [x] TypeScript typecheck passes
- [x] Pre-commit hooks (lint, format, typecheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)