### PR TITLE
fix(web): use os.platform() instead of process.platform for runtime evaluation

### DIFF
--- a/src/presentation/web/app/actions/open-folder.ts
+++ b/src/presentation/web/app/actions/open-folder.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { existsSync } from 'node:fs';
+import { platform } from 'node:os';
 import { spawn } from 'node:child_process';
 
 export async function openFolder(
@@ -15,15 +16,15 @@ export async function openFolder(
       return { success: false, error: 'Directory not found' };
     }
 
-    const platform = process.platform;
+    const currentPlatform = platform();
 
-    if (platform === 'darwin') {
+    if (currentPlatform === 'darwin') {
       const child = spawn('open', [repositoryPath], {
         detached: true,
         stdio: 'ignore',
       });
       child.unref();
-    } else if (platform === 'linux') {
+    } else if (currentPlatform === 'linux') {
       const child = spawn('xdg-open', [repositoryPath], {
         detached: true,
         stdio: 'ignore',
@@ -32,7 +33,7 @@ export async function openFolder(
     } else {
       return {
         success: false,
-        error: `Unsupported platform: ${platform}. Folder open is supported on macOS and Linux only.`,
+        error: `Unsupported platform: ${currentPlatform}. Folder open is supported on macOS and Linux only.`,
       };
     }
 

--- a/src/presentation/web/app/actions/open-shell.ts
+++ b/src/presentation/web/app/actions/open-shell.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { existsSync } from 'node:fs';
+import { platform } from 'node:os';
 import { spawn } from 'node:child_process';
 import { getSettings } from '@shepai/core/infrastructure/services/settings.service';
 import { computeWorktreePath } from '@shepai/core/infrastructure/services/ide-launchers/compute-worktree-path';
@@ -28,15 +29,15 @@ export async function openShell(
       return { success: false, error: `Path does not exist: ${targetPath}` };
     }
 
-    const platform = process.platform;
+    const currentPlatform = platform();
 
-    if (platform === 'darwin') {
+    if (currentPlatform === 'darwin') {
       const child = spawn('open', ['-a', 'Terminal', targetPath], {
         detached: true,
         stdio: 'ignore',
       });
       child.unref();
-    } else if (platform === 'linux') {
+    } else if (currentPlatform === 'linux') {
       const child = spawn('x-terminal-emulator', [`--working-directory=${targetPath}`], {
         detached: true,
         stdio: 'ignore',
@@ -45,7 +46,7 @@ export async function openShell(
     } else {
       return {
         success: false,
-        error: `Unsupported platform: ${platform}. Shell launch is supported on macOS and Linux only.`,
+        error: `Unsupported platform: ${currentPlatform}. Shell launch is supported on macOS and Linux only.`,
       };
     }
 

--- a/src/presentation/web/lib/version.ts
+++ b/src/presentation/web/lib/version.ts
@@ -10,6 +10,8 @@
  * from the CLI domain layer.
  */
 
+import { arch, platform } from 'node:os';
+
 /** Version information for the package (mirrors domain VersionInfo) */
 export interface VersionInfo {
   version: string;
@@ -43,7 +45,7 @@ export function getVersionInfo(): VersionInfo {
 export function getSystemInfo(): SystemInfo {
   return {
     nodeVersion: process.version,
-    platform: process.platform,
-    arch: process.arch,
+    platform: platform(),
+    arch: arch(),
   };
 }


### PR DESCRIPTION
## Summary
- Replace `process.platform` and `process.arch` with `os.platform()` and `os.arch()` in Next.js server actions and lib
- Next.js webpack/turbopack statically inlines `process.platform` at build time, baking the build machine's platform into the bundle
- Using `os.platform()` (a function call) prevents static replacement and ensures correct runtime evaluation

## Changed files
- `src/presentation/web/app/actions/open-shell.ts`
- `src/presentation/web/app/actions/open-folder.ts`
- `src/presentation/web/lib/version.ts`

## Test plan
- [ ] Build the npm package on macOS
- [ ] Run `shep ui` on macOS — verify shell/folder open works and system info shows `darwin`
- [ ] Verify `process.platform` string does not appear in built server action bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)