### PR TITLE
feat(cli): auto-open browser when `shep ui` starts

### DIFF
--- a/packages/core/src/infrastructure/services/browser-opener.service.ts
+++ b/packages/core/src/infrastructure/services/browser-opener.service.ts
@@ -1,0 +1,44 @@
+import { execFile as cpExecFile, type ChildProcess } from 'node:child_process';
+
+export interface BrowserOpenerDeps {
+  platform: NodeJS.Platform;
+  execFile: (
+    cmd: string,
+    args: readonly string[],
+    callback: (error: Error | null) => void
+  ) => ChildProcess;
+  warn: (msg: string) => void;
+}
+
+const defaultDeps: BrowserOpenerDeps = {
+  platform: process.platform,
+  execFile: cpExecFile as unknown as BrowserOpenerDeps['execFile'],
+  // eslint-disable-next-line no-console
+  warn: (msg) => console.warn(msg),
+};
+
+const PLATFORM_COMMANDS: Record<string, { cmd: string; args: (url: string) => string[] }> = {
+  darwin: { cmd: 'open', args: (url) => [url] },
+  linux: { cmd: 'xdg-open', args: (url) => [url] },
+  win32: { cmd: 'cmd', args: (url) => ['/c', 'start', '', url] },
+};
+
+export class BrowserOpenerService {
+  private deps: BrowserOpenerDeps;
+
+  constructor(deps: Partial<BrowserOpenerDeps> = {}) {
+    this.deps = { ...defaultDeps, ...deps };
+  }
+
+  open(url: string): void {
+    const entry = PLATFORM_COMMANDS[this.deps.platform];
+    if (!entry) return;
+
+    const child = this.deps.execFile(entry.cmd, entry.args(url), (error) => {
+      if (error) {
+        this.deps.warn(`Failed to open browser: ${error.message}`);
+      }
+    });
+    child.unref();
+  }
+}

--- a/specs/037-auto-open-browser/feature.yaml
+++ b/specs/037-auto-open-browser/feature.yaml
@@ -1,0 +1,38 @@
+feature:
+  id: 037-auto-open-browser
+  name: auto-open-browser
+  number: 37
+  branch: feat/037-auto-open-browser
+  lifecycle: research
+  createdAt: '2026-02-23T13:51:01Z'
+status:
+  phase: implementation-complete
+  progress:
+    completed: 4
+    total: 4
+    percentage: 100
+  currentTask: null
+  lastUpdated: '2026-02-23T14:08:59.501Z'
+  lastUpdatedBy: feature-agent:implement
+  completedPhases:
+    - analyze
+    - requirements
+    - research
+    - plan
+    - phase-1
+    - phase-2
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+tasks:
+  current: null
+  blocked: []
+  failed: []
+checkpoints:
+  - phase: feature-created
+    completedAt: '2026-02-23T13:51:01Z'
+    completedBy: feature-agent
+errors:
+  current: null
+  history: []

--- a/specs/037-auto-open-browser/plan.yaml
+++ b/specs/037-auto-open-browser/plan.yaml
@@ -1,0 +1,104 @@
+# Implementation Plan (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: auto-open-browser
+summary: >
+  Implement auto-open browser for `shep ui` using a BrowserOpenerService following the
+  existing FileDialogService injectable-deps pattern. Two phases: (1) build and test the
+  service, (2) integrate into ui.command.ts with --no-open flag. Zero new dependencies.
+
+relatedFeatures: []
+technologies:
+  - Node.js child_process.execFile (cross-platform browser open)
+  - Commander.js (--no-open flag)
+  - Vitest (unit testing with injectable mocks)
+relatedLinks: []
+
+phases:
+  - id: phase-1
+    name: 'BrowserOpenerService — build and test'
+    description: >
+      Create the BrowserOpenerService in packages/core/src/infrastructure/services/
+      following the FileDialogService pattern (Deps interface, defaultDeps, Partial<Deps>
+      constructor). TDD: write tests first for all three platforms, unsupported platform,
+      and error handling, then implement the minimal service to pass.
+    parallel: false
+
+  - id: phase-2
+    name: 'UI command integration — --no-open flag and wiring'
+    description: >
+      Add the --no-open Commander flag to createUiCommand(), instantiate BrowserOpenerService
+      after the "Server ready" message, and call opener.open(url) when --no-open is not set.
+      TDD: extend ui.command.test.ts with tests for auto-open default, --no-open suppression,
+      and error resilience, then wire the integration code.
+    parallel: false
+
+filesToCreate:
+  - packages/core/src/infrastructure/services/browser-opener.service.ts
+  - tests/unit/infrastructure/services/browser-opener.service.test.ts
+
+filesToModify:
+  - src/presentation/cli/commands/ui.command.ts
+  - tests/unit/presentation/cli/commands/ui.command.test.ts
+
+openQuestions: []
+
+content: |
+  ## Architecture Overview
+
+  The feature adds a single leaf service (`BrowserOpenerService`) to the infrastructure
+  layer and wires it into the existing `ui.command.ts` presentation command. This follows
+  the established pattern where platform-specific OS utilities live as injectable-deps
+  classes in `packages/core/src/infrastructure/services/` (see `FileDialogService`,
+  `FolderDialogService`).
+
+  ```
+  presentation/cli/commands/ui.command.ts
+    └─ new BrowserOpenerService()  ← direct instantiation, no DI container
+         └─ child_process.execFile(platformCmd, args)  ← fire-and-forget, unref'd
+  ```
+
+  The service is NOT registered in the DI container — matching the pattern of its sibling
+  dialog services which are also instantiated directly by consumers.
+
+  ## Key Design Decisions
+
+  ### 1. Injectable Deps Pattern (from research)
+  The service uses `BrowserOpenerDeps { platform, execFile, warn }` with `defaultDeps`
+  and a `Partial<Deps>` constructor. This mirrors `FileDialogService` exactly and enables
+  deterministic unit tests without global mocking.
+
+  ### 2. Fire-and-Forget with execFile (from research)
+  The `open(url)` method is synchronous void. It calls `execFile` with a callback that
+  catches errors and calls `deps.warn()`. The child process is unref'd so it doesn't
+  prevent CLI exit. No Promise, no await — the caller just calls and moves on.
+
+  ### 3. Platform Command Map
+  A simple `Record<string, { cmd, args }>` maps `darwin → open`, `linux → xdg-open`,
+  `win32 → cmd /c start`. Unsupported platforms silently skip (no error, no warning).
+
+  ### 4. --no-open Flag (from research)
+  Commander `.option('--no-open', ...)` creates `options.open` which is `undefined` by
+  default and `false` when passed. The action checks `options.open !== false` to trigger
+  browser opening.
+
+  ### 5. Direct Instantiation (from research)
+  No DI registration needed. The service has no dependencies that require singleton lifecycle.
+  Instantiated as `new BrowserOpenerService()` in production, `new BrowserOpenerService({ ... })`
+  with mock deps in tests.
+
+  ## Implementation Strategy
+
+  Phase 1 comes first because the service is a standalone unit with no dependencies on
+  the command layer. Building it in isolation with full test coverage ensures correctness
+  before integration. Phase 2 then wires the tested service into the command with minimal
+  risk — the integration is just 4-5 lines of code plus a flag definition.
+
+  ## Risk Mitigation
+
+  | Risk | Mitigation |
+  | ---- | ---------- |
+  | Windows `start` is a shell built-in | Use `execFile('cmd', ['/c', 'start', '', url])` — passes args as array, no shell injection |
+  | Browser open fails in CI/headless | Fire-and-forget with warning log. Tests use mock execFile, no real subprocess. |
+  | Existing ui.command tests break | Mock the BrowserOpenerService module in test file. Existing tests unchanged. |
+  | URL contains special characters | URL is always `http://localhost:<port>` with validated integer port. No user input reaches execFile args. |

--- a/specs/037-auto-open-browser/research.yaml
+++ b/specs/037-auto-open-browser/research.yaml
@@ -1,0 +1,270 @@
+# Research Artifact (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: auto-open-browser
+summary: >
+  Technical research for auto-opening the default browser when `shep ui` starts.
+  Key decisions: use a BrowserOpenerService with injectable deps (matching FileDialogService pattern),
+  Node.js child_process.execFile for security, fire-and-forget spawning, and no new npm dependencies.
+
+relatedFeatures: []
+
+technologies:
+  - Node.js child_process (execFile for secure subprocess spawning)
+  - Commander.js (--no-open negatable boolean flag)
+  - process.platform (platform detection for xdg-open/open/cmd)
+
+relatedLinks:
+  - https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback
+
+decisions:
+  - title: 'Service Architecture — BrowserOpenerService class vs utility function'
+    chosen: 'BrowserOpenerService class with injectable deps pattern'
+    rejected:
+      - 'Standalone utility function (like port.service.ts) — simpler but inconsistent with how the codebase handles platform-specific OS interaction. FileDialogService and FolderDialogService both use the class + deps pattern for exactly this kind of service. A plain function would require passing deps as arguments on every call or mocking globals in tests.'
+      - 'Third-party library (e.g., open npm package) — adds an external dependency for ~15 lines of code. The spec explicitly requires no new npm dependencies. The Node.js built-in child_process.execFile is sufficient and avoids supply chain risk.'
+    rationale: >
+      The codebase establishes a clear pattern for platform-specific OS utilities:
+      FileDialogService (file-dialog.service.ts) and FolderDialogService (folder-dialog.service.ts)
+      both use a class with a Deps interface, defaultDeps object, and Partial<Deps> constructor.
+      BrowserOpenerService follows this exact pattern for consistency and testability. The service
+      lives in packages/core/src/infrastructure/services/browser-opener.service.ts alongside
+      its siblings.
+
+  - title: 'Execution Method — execFile (no shell) vs spawn'
+    chosen: 'child_process.execFile (callback-based, fire-and-forget)'
+    rejected:
+      - 'child_process.spawn — more control over streams but unnecessary for fire-and-forget browser opening. We do not need stdout/stderr streaming. execFile is simpler: call it, ignore the result, catch errors in the callback.'
+      - 'Shell-based execution — introduces shell injection risk if the URL contains special characters. The spec explicitly requires no shell execution for security (NFR-1). While the URL is internally constructed (http://localhost:<port>), defense-in-depth favors execFile.'
+    rationale: >
+      execFile avoids shell injection by passing arguments as an array rather than
+      interpolating into a shell string. For Windows where "start" is a shell built-in,
+      we use execFile('cmd', ['/c', 'start', '', url]) which still avoids injection since
+      arguments are passed as an array to cmd.exe. The callback catches errors; on error
+      the warn function is called. The child process is unref'd so it doesn't keep the CLI alive.
+
+  - title: 'DI Registration — container-registered vs direct instantiation'
+    chosen: 'Direct instantiation in ui.command.ts (no DI registration)'
+    rejected:
+      - 'Register in DI container as singleton — adds complexity (interface, token, container registration) for a service with no injected dependencies of its own. FileDialogService and FolderDialogService are NOT registered in the DI container either; they are instantiated directly by their consumers. Adding DI registration for a leaf service with no dependencies is over-engineering.'
+      - 'Import as module-level function — loses the injectable deps pattern needed for testing. Cannot override platform/execFile in tests without mocking globals.'
+    rationale: >
+      Following the existing pattern: FileDialogService is NOT in the DI container. It is
+      instantiated directly by consumers (new FileDialogService() or new FileDialogService({ platform: 'linux' })
+      for tests). BrowserOpenerService follows the same approach — instantiated in ui.command.ts
+      with default deps in production, and with mock deps in tests. This keeps the DI container
+      focused on cross-cutting services that need singleton lifecycle management.
+
+  - title: 'Commander Flag Design — --no-open vs --open/--no-open pair'
+    chosen: '--no-open as a standalone negatable flag (default: browser opens)'
+    rejected:
+      - '--open with --no-open negatable pair — Commander supports .option("--no-open") which creates options.open defaulting to undefined. However, .option("--open/--no-open") creates a true/false toggle. Since auto-open should be the default (on), a standalone --no-open flag is cleaner. Users only need to opt out, not opt in.'
+      - 'Environment variable SHEP_NO_OPEN — adds indirection. CLI flags are the standard pattern in this codebase. An env var could be added later if CI/headless use cases demand it, but YAGNI for now.'
+    rationale: >
+      Commander.js supports boolean flags natively. Adding .option('--no-open', 'Do not auto-open browser')
+      creates options.open which is undefined by default (treated as true/auto-open) and false
+      when --no-open is passed. This matches common CLI patterns (e.g., npm's --no-fund, git's --no-edit).
+      The action callback checks if (options.open !== false) to trigger browser opening.
+
+  - title: 'Error Handling Strategy — warning log vs silent ignore'
+    chosen: 'Log warning via messages.warn() and continue'
+    rejected:
+      - 'Silent ignore — user gets no feedback if their browser fails to open. They might wait indefinitely not knowing they need to manually open the URL. A brief warning is more helpful.'
+      - 'Throw error and set exitCode — disproportionate response. Browser open is a convenience feature, not core functionality. Failing to open a browser should never cause shep ui to exit with error status.'
+    rationale: >
+      The spec requires non-fatal error handling (FR-6, NFR-2). Using messages.warn() from
+      the existing CLI message system (src/presentation/cli/ui/) provides consistent formatting.
+      The warning appears after the "Server ready" message so the user knows the server is running
+      and can manually open the URL. The execFile callback catches errors; on unsupported platforms,
+      the open is silently skipped (no command to run = no error to catch).
+
+openQuestions:
+  - question: 'Should the service method be synchronous (fire-and-forget) or return a Promise?'
+    resolved: true
+    options:
+      - option: 'Synchronous void method (fire-and-forget)'
+        description: >
+          The method calls execFile (callback-based) and returns immediately. No Promise,
+          no await. The caller just calls service.open(url) and moves on. This is the simplest
+          approach and matches the fire-and-forget requirement. Error handling happens in the
+          execFile callback which calls the injected warn function.
+        selected: true
+      - option: 'Async method returning Promise<void>'
+        description: >
+          Returns a Promise that resolves after spawning (not after browser opens).
+          Adds async/await ceremony for no benefit since the caller does not await the result.
+          Misleading — suggests the caller should await something.
+        selected: false
+      - option: 'Async method returning Promise<boolean>'
+        description: >
+          Returns whether the browser was opened successfully. Requires awaiting the child
+          process which contradicts the fire-and-forget design. Adds latency to CLI startup.
+        selected: false
+    selectionRationale: >
+      A synchronous void method is the most honest API for fire-and-forget. execFile with
+      a callback is already non-blocking. Making the method async would mislead callers into
+      thinking they should await the result. The error callback logs warnings internally,
+      so the caller has no reason to inspect the result.
+
+  - question: 'How should the service accept the warning logger — as a deps parameter or method parameter?'
+    resolved: true
+    options:
+      - option: 'Deps parameter (constructor injection)'
+        description: >
+          Add a warn function to the BrowserOpenerDeps interface, defaulting to console.warn.
+          The command passes messages.warn as the implementation. Tests can verify warnings
+          were called. Follows the deps pattern consistently.
+        selected: true
+      - option: 'Method parameter'
+        description: >
+          Pass warn as a parameter to the open() method: service.open(url, { onError: fn }).
+          Mixes configuration and invocation concerns. Less clean than the deps pattern.
+        selected: false
+      - option: 'No warning — just swallow errors'
+        description: >
+          Catch and ignore all errors silently. Simplest but violates NFR-2 which requires
+          errors to be logged as a warning via the CLI message system.
+        selected: false
+    selectionRationale: >
+      Constructor injection via deps is consistent with how FileDialogService handles its
+      dependencies. The warn function is a dependency of the service, not a per-call option.
+      Default to console.warn for production; tests inject a vi.fn() mock to assert warning behavior.
+
+  - question: 'Should the BrowserOpenerService be placed directly in services/ or in a subdirectory?'
+    resolved: true
+    options:
+      - option: 'Directly in services/ as browser-opener.service.ts'
+        description: >
+          Single file alongside file-dialog.service.ts and folder-dialog.service.ts.
+          The service is ~25-30 lines — no need for a subdirectory. Matches the pattern
+          of its sibling services which are also single files.
+        selected: true
+      - option: 'In services/browser/ subdirectory'
+        description: >
+          Creates a subdirectory for a single file. Over-organized for a simple utility.
+          The codebase only uses subdirectories when there are multiple related files
+          (e.g., agents/common/, agents/feature-agent/nodes/).
+        selected: false
+      - option: 'In services/os-utils/ shared subdirectory'
+        description: >
+          Group browser-opener with file-dialog and folder-dialog. Would require moving
+          existing files which is out of scope and adds unnecessary churn.
+        selected: false
+    selectionRationale: >
+      FileDialogService and FolderDialogService both live as single files directly in
+      packages/core/src/infrastructure/services/. BrowserOpenerService is a similarly
+      simple, single-file service (~25-30 lines). Placing it alongside its siblings
+      maintains the existing flat structure for leaf services.
+
+content: |
+  ## Technology Decisions
+
+  ### 1. Service Architecture — BrowserOpenerService class vs utility function
+
+  **Chosen:** BrowserOpenerService class with injectable deps pattern
+
+  **Rejected:**
+  - Standalone utility function (like port.service.ts) — inconsistent with how FileDialogService and FolderDialogService handle platform-specific OS interaction. Would require passing deps on every call or mocking globals in tests.
+  - Third-party library (e.g., `open` npm package) — adds an external dependency for ~15 lines of code. Spec explicitly requires no new npm dependencies.
+
+  **Rationale:** The codebase has a clear pattern for platform-specific OS utilities: class + Deps interface + defaultDeps + Partial<Deps> constructor. BrowserOpenerService at `packages/core/src/infrastructure/services/browser-opener.service.ts` follows this pattern exactly.
+
+  ### 2. Execution Method — execFile (no shell) vs spawn
+
+  **Chosen:** child_process.execFile (callback-based, fire-and-forget)
+
+  **Rejected:**
+  - child_process.spawn — unnecessary complexity for fire-and-forget; no need for stream control
+  - Shell-based execution — introduces injection risk per NFR-1
+
+  **Rationale:** execFile passes arguments as array (no shell interpolation). Windows uses `execFile('cmd', ['/c', 'start', '', url])`. Callback catches errors for warning logging. Child process is unref'd.
+
+  ### 3. DI Registration — container-registered vs direct instantiation
+
+  **Chosen:** Direct instantiation in ui.command.ts (no DI registration)
+
+  **Rejected:**
+  - Register in DI container — over-engineering for a leaf service with no injected dependencies. FileDialogService/FolderDialogService are also NOT in the DI container.
+  - Module-level function — loses injectable deps pattern needed for testing.
+
+  **Rationale:** Match the existing pattern where FileDialogService is instantiated directly by consumers with optional deps override for testing.
+
+  ### 4. Commander Flag Design
+
+  **Chosen:** `--no-open` as standalone negatable flag (default: auto-open)
+
+  **Rejected:**
+  - `--open/--no-open` pair — unnecessary since auto-open is the default. Users only need opt-out.
+  - Environment variable — YAGNI; CLI flags are the standard pattern in this codebase.
+
+  **Rationale:** `.option('--no-open', 'Do not auto-open browser')` creates `options.open` which is `undefined` by default (auto-open) and `false` when `--no-open` is passed.
+
+  ### 5. Error Handling Strategy
+
+  **Chosen:** Log warning via `messages.warn()` and continue
+
+  **Rejected:**
+  - Silent ignore — user gets no feedback when browser fails to open
+  - Throw error — disproportionate; browser open is convenience, not core functionality
+
+  **Rationale:** NFR-2 requires non-fatal warning logging. `messages.warn()` provides consistent CLI formatting.
+
+  ## Library Analysis
+
+  | Library | Purpose | Decision | Reasoning |
+  | ------- | ------- | -------- | --------- |
+  | `open` (npm) | Cross-platform browser opening | **Reject** | Adds external dependency for ~15 lines of code. Supply chain risk for trivial functionality. Spec requires no new deps. |
+  | `node:child_process` (built-in) | Subprocess spawning via `execFile` | **Use** | Built-in, no installation needed. `execFile` avoids shell injection. |
+  | `commander` (existing) | `--no-open` flag parsing | **Use** | Already the CLI framework. Native boolean flag support. |
+
+  ## Security Considerations
+
+  - **Shell injection prevention**: Using `execFile` (not shell-based execution) ensures the URL is passed as an argument array element, never interpolated into a shell string. Even on Windows where `cmd /c start` is needed, arguments go through the array: `execFile('cmd', ['/c', 'start', '', url])`.
+  - **URL construction**: The URL is always `http://localhost:<port>` where port is an integer validated by `parsePort()`. No user-supplied string reaches the execFile arguments.
+  - **No new attack surface**: The feature only opens a browser to localhost. No external network calls, no data exfiltration risk.
+
+  ## Performance Implications
+
+  - **Zero latency impact**: `execFile` is callback-based and non-blocking. The browser process is spawned and the callback handles errors asynchronously. The CLI event loop is never blocked.
+  - **Process cleanup**: The child process is unref'd (`child.unref()`) so it doesn't prevent the CLI from exiting on Ctrl+C. The spawned browser process is independent of the CLI process tree.
+
+  ## Architecture Notes
+
+  ### Service Design
+
+  ```typescript
+  // BrowserOpenerDeps — injectable dependencies
+  interface BrowserOpenerDeps {
+    platform: NodeJS.Platform;
+    execFile: typeof import('node:child_process').execFile;
+    warn: (msg: string) => void;
+  }
+
+  // Platform command mapping
+  const PLATFORM_COMMANDS: Record<string, { cmd: string; args: (url: string) => string[] }> = {
+    darwin:  { cmd: 'open',      args: (url) => [url] },
+    linux:   { cmd: 'xdg-open',  args: (url) => [url] },
+    win32:   { cmd: 'cmd',       args: (url) => ['/c', 'start', '', url] },
+  };
+  ```
+
+  ### Integration Point
+
+  In `ui.command.ts`, after line 81 (`messages.success(...)`):
+
+  ```typescript
+  // Auto-open browser (unless --no-open)
+  if (options.open !== false) {
+    const opener = new BrowserOpenerService();
+    opener.open(`http://localhost:${port}`);
+  }
+  ```
+
+  ### Test Strategy
+
+  - **BrowserOpenerService tests**: Inject mock `execFile` and `platform`. Verify correct command/args per platform. Verify `warn` called on error. Verify no-op on unsupported platform.
+  - **ui.command.ts tests**: Mock BrowserOpenerService module. Verify it's called after server start. Verify `--no-open` suppresses the call.
+
+  ---
+
+  _Research complete — proceed with planning phase_

--- a/specs/037-auto-open-browser/spec.yaml
+++ b/specs/037-auto-open-browser/spec.yaml
@@ -1,0 +1,239 @@
+# Feature Specification (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: auto-open-browser
+number: 037
+branch: feat/037-auto-open-browser
+oneLiner: Auto-open default browser when `shep ui` starts, with --no-open flag to disable
+userQuery: >
+  we have 'shep ui' command, i want it to automatically open default browser (generic cross platform), we also need flag to disable auto open
+summary: >
+  After the web server starts in `shep ui`, automatically open the user's default browser
+  to the server URL. Uses Node.js child_process.execFile with platform-specific commands
+  (xdg-open, open, start) for cross-platform support. Adds a --no-open flag to suppress auto-opening.
+phase: Requirements
+sizeEstimate: S
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - Commander.js (CLI option/flag parsing)
+  - Node.js child_process.execFile (cross-platform browser open via xdg-open/open/start)
+
+relatedLinks: []
+
+# Open questions (must be resolved before implementation)
+openQuestions:
+  - question: 'Where should the browser-open utility live — presentation layer or infrastructure service?'
+    resolved: true
+    options:
+      - option: 'Infrastructure service'
+        description: >
+          Place in packages/core/src/infrastructure/services/ as a standalone service class
+          with injectable deps (like FileDialogService). Follows Clean Architecture for
+          OS-interaction utilities and matches the existing pattern for platform-specific services.
+        selected: true
+      - option: 'Presentation utility'
+        description: >
+          Place in src/presentation/cli/utils/ as a simple function. Keeps it close to the
+          only consumer (ui.command.ts) but breaks the convention that OS-interaction code
+          lives in infrastructure/services/.
+        selected: false
+    selectionRationale: >
+      Infrastructure service is recommended because the codebase already places platform-specific
+      OS interaction utilities (FileDialogService, FolderDialogService) in
+      packages/core/src/infrastructure/services/. A BrowserOpenerService with injectable deps
+      follows the same testable pattern and keeps the presentation layer thin.
+    answer: 'Infrastructure service'
+
+  - question: 'Should the browser open be fire-and-forget or should we wait for the child process?'
+    resolved: true
+    options:
+      - option: 'Fire-and-forget'
+        description: >
+          Spawn the process detached/unref so it does not block the CLI. If the command fails,
+          catch the error and log a warning. The CLI continues regardless. This is the standard
+          pattern for "open URL in browser" across CLIs (e.g., npm, vite, next dev).
+        selected: true
+      - option: 'Await with timeout'
+        description: >
+          Wait for the child process to exit (with a short timeout like 5s). Provides certainty
+          about success/failure but adds latency and complexity for no user-visible benefit —
+          the browser opens asynchronously either way.
+        selected: false
+    selectionRationale: >
+      Fire-and-forget is recommended because the user sees the browser open immediately regardless.
+      Waiting adds latency to the CLI startup for no benefit. Errors are caught via the callback
+      and logged as warnings. This matches how Vite, Next.js dev, and other CLIs handle it.
+    answer: 'Fire-and-forget'
+
+  - question: 'Should we use execFile (no shell) for launching the browser?'
+    resolved: true
+    options:
+      - option: 'execFile (no shell)'
+        description: >
+          Safer — no shell injection risk. Works well for macOS (open) and Linux (xdg-open).
+          Windows "start" is a shell built-in and requires special handling (use cmd /c start).
+          The codebase already uses execFile via the safe wrapper pattern.
+        selected: true
+      - option: 'Shell-based execution'
+        description: >
+          Simpler for Windows since "start" is a shell built-in. But introduces shell injection
+          risk if the URL is ever user-controlled. Less safe by default.
+        selected: false
+    selectionRationale: >
+      execFile is recommended for security (no shell injection). For Windows, use
+      execFile with cmd /c start which avoids shell injection while supporting the shell
+      built-in "start" command. This matches the security-conscious approach used in the codebase.
+    answer: 'execFile (no shell)'
+
+  - question: 'How should platform detection work — direct process.platform or injectable dependency?'
+    resolved: true
+    options:
+      - option: 'Injectable dependency'
+        description: >
+          Pass platform as a constructor/function parameter with a default of process.platform.
+          Makes the utility fully testable without mocking globals. Matches the FileDialogService
+          pattern which uses injectable deps ({ platform }).
+        selected: true
+      - option: 'Direct process.platform'
+        description: >
+          Read process.platform directly inside the function. Simpler but requires mocking
+          the global in tests, which is fragile and can leak across test cases.
+        selected: false
+    selectionRationale: >
+      Injectable dependency is recommended because it follows the established FileDialogService
+      pattern in the codebase, which uses a deps object with platform as an injectable parameter.
+      This makes unit tests deterministic without global mocking.
+    answer: 'Injectable dependency'
+
+# Markdown content (the actual spec)
+content: |
+  ## Problem Statement
+
+  The `shep ui` command starts a Next.js web server and prints the URL to the console,
+  but requires users to manually copy/paste or click the URL to open it in a browser.
+  This adds unnecessary friction — the command should automatically open the default
+  browser after the server is ready, with an opt-out flag for headless/CI environments.
+
+  ## Codebase Analysis
+
+  ### Project Structure
+
+  The feature touches the CLI presentation layer and a small utility:
+
+  - `src/presentation/cli/commands/ui.command.ts` — The `shep ui` command implementation.
+    Creates Commander command with `--port` option, starts the web server service, sets up
+    signal handlers for graceful shutdown. The browser open call goes here after the
+    "Server ready" message (line 81).
+  - `tests/unit/presentation/cli/commands/ui.command.test.ts` — Existing unit tests for
+    the ui command. New tests for auto-open behavior and --no-open flag go here.
+
+  ### Architecture Patterns
+
+  - **Clean Architecture**: CLI commands live in `src/presentation/cli/commands/`. They
+    resolve services from the DI container and orchestrate behavior.
+  - **Commander.js pattern**: Commands use `.option()` for flags and the action callback
+    receives parsed options.
+  - **Test pattern**: Tests mock the DI container, port service, and web server service.
+    The browser-open utility should be similarly mockable.
+
+  ### Relevant Technologies
+
+  - **Commander.js**: Already used for the `--port` option. Adding `--no-open` is a
+    boolean negatable option via `.option('--no-open', ...)`.
+  - **Node.js child_process.execFile**: Uses `execFile` (not shell-based execution) with
+    platform detection to invoke `xdg-open` (Linux), `open` (macOS), or `cmd /c start`
+    (Windows). This avoids shell injection risks.
+
+  ## Success Criteria
+
+  - [ ] `shep ui` automatically opens default browser to `http://localhost:<port>` after server starts
+  - [ ] Works on macOS (`open`), Linux (`xdg-open`), and Windows (`cmd /c start`)
+  - [ ] `shep ui --no-open` suppresses auto-open behavior
+  - [ ] Browser open failure is non-fatal — logged as a warning, does not crash the CLI
+  - [ ] Unit tests cover: auto-open default behavior, --no-open suppression, all three platforms, error handling
+  - [ ] Service follows injectable-deps pattern (like FileDialogService) for testability
+  - [ ] No new npm dependencies introduced
+
+  ## Functional Requirements
+
+  - **FR-1**: When `shep ui` starts and the web server is ready, the CLI SHALL automatically
+    open the user's default browser to `http://localhost:<port>` where `<port>` is the resolved
+    port number.
+
+  - **FR-2**: The browser open SHALL occur immediately after the "Server ready" success message
+    is printed (line 81 of ui.command.ts), so the user sees feedback before the browser opens.
+
+  - **FR-3**: The CLI SHALL support a `--no-open` flag that suppresses automatic browser opening.
+    When `--no-open` is passed, the command SHALL behave identically to today (no browser open).
+
+  - **FR-4**: The browser open utility SHALL support three platforms:
+    - **macOS** (`darwin`): execFile with `open` command and `[url]` args
+    - **Linux** (`linux`): execFile with `xdg-open` command and `[url]` args
+    - **Windows** (`win32`): execFile with `cmd` command and `['/c', 'start', '', url]` args
+
+  - **FR-5**: On unsupported platforms, the browser open SHALL be silently skipped (no error,
+    no warning). The user can still manually open the printed URL.
+
+  - **FR-6**: The browser open SHALL be fire-and-forget — the child process is spawned and
+    not awaited. The CLI does not block waiting for the browser to open.
+
+  ## Non-Functional Requirements
+
+  - **NFR-1 (Security)**: The utility SHALL use `execFile` (not shell-based execution) to
+    avoid shell injection. The URL is passed as an argument array element, never interpolated
+    into a shell string.
+
+  - **NFR-2 (Resilience)**: If the browser open child process fails (e.g., `xdg-open` not
+    installed, display server unavailable), the error SHALL be caught and logged as a warning
+    via the CLI message system. The CLI SHALL continue running normally.
+
+  - **NFR-3 (Testability)**: The browser open service SHALL accept injectable dependencies
+    (platform, execFile function) with sensible defaults, following the FileDialogService
+    pattern. This allows unit tests to verify behavior without mocking globals.
+
+  - **NFR-4 (Performance)**: The browser open SHALL not add perceptible latency to CLI
+    startup. The child process is spawned asynchronously and does not block the event loop.
+
+  - **NFR-5 (Maintainability)**: The browser open logic SHALL be a standalone service in
+    `packages/core/src/infrastructure/services/`, not inline in the command file. This
+    keeps the command thin and the utility reusable/testable independently.
+
+  ## Product Questions & AI Recommendations
+
+  | # | Question | AI Recommendation | Rationale |
+  | - | -------- | ----------------- | --------- |
+  | 1 | Where should the browser-open utility live? | Infrastructure service | Matches FileDialogService/FolderDialogService pattern for OS interaction utilities |
+  | 2 | Fire-and-forget or await the browser process? | Fire-and-forget | Standard CLI pattern (Vite, Next.js). No user benefit to waiting. |
+  | 3 | Use execFile (no shell) for launching browser? | Yes, execFile | Security — no shell injection. Windows handled via cmd /c start. |
+  | 4 | Direct process.platform or injectable? | Injectable dependency | Follows existing FileDialogService pattern. Makes tests deterministic. |
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `src/presentation/cli/commands/ui.command.ts` | High | Add --no-open flag, call browser open after server ready |
+  | `packages/core/src/infrastructure/services/` | Medium | New BrowserOpenerService with injectable deps |
+  | `tests/unit/presentation/cli/commands/ui.command.test.ts` | High | New tests for auto-open and --no-open flag |
+  | `tests/unit/infrastructure/services/` | Medium | Unit tests for BrowserOpenerService |
+
+  ## Dependencies
+
+  - **Node.js `child_process.execFile`**: Built-in module, no external dependency needed.
+    Uses execFile for security (no shell injection).
+  - **`process.platform`**: For OS detection (darwin/linux/win32).
+  - No new npm packages required.
+
+  ## Size Estimate
+
+  **S** — Small, well-scoped change:
+  - One new service class (~25 lines) for cross-platform browser open
+  - One flag addition to existing command (~3 lines)
+  - One call site after server ready message (~5 lines)
+  - Unit tests for the service (~50 lines) and command integration (~30 lines)
+
+  ---
+
+  _Requirements complete — proceed with research_

--- a/specs/037-auto-open-browser/tasks.yaml
+++ b/specs/037-auto-open-browser/tasks.yaml
@@ -1,0 +1,148 @@
+# Task Breakdown (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: auto-open-browser
+summary: >
+  4 tasks across 2 phases. Phase 1 builds the BrowserOpenerService with full test
+  coverage (TDD). Phase 2 integrates the service into ui.command.ts with --no-open flag.
+
+relatedFeatures: []
+technologies: []
+relatedLinks: []
+
+tasks:
+  - id: task-1
+    phaseId: phase-1
+    title: 'Write BrowserOpenerService unit tests (RED)'
+    description: >
+      Create the test file for BrowserOpenerService covering all platforms (darwin, linux,
+      win32), unsupported platform silent skip, error handling with warn callback, and
+      child process unref. Tests use injectable mock deps — no global mocking.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'Test file exists at tests/unit/infrastructure/services/browser-opener.service.test.ts'
+      - 'Tests cover darwin platform: execFile called with "open" and [url]'
+      - 'Tests cover linux platform: execFile called with "xdg-open" and [url]'
+      - 'Tests cover win32 platform: execFile called with "cmd" and ["/c", "start", "", url]'
+      - 'Tests cover unsupported platform: no execFile call, no warn call'
+      - 'Tests cover execFile error: warn function called with error message'
+      - 'Tests cover child.unref() is called'
+      - 'All tests fail (RED phase — service not yet implemented)'
+    tdd:
+      red:
+        - 'Create test file with describe("BrowserOpenerService")'
+        - 'Write test: opens browser on darwin with "open" command'
+        - 'Write test: opens browser on linux with "xdg-open" command'
+        - 'Write test: opens browser on win32 with "cmd /c start" command'
+        - 'Write test: silently skips on unsupported platform (e.g., "freebsd")'
+        - 'Write test: calls warn on execFile error'
+        - 'Write test: calls child.unref() to detach process'
+      green: []
+      refactor: []
+    estimatedEffort: '30min'
+
+  - id: task-2
+    phaseId: phase-1
+    title: 'Implement BrowserOpenerService (GREEN + REFACTOR)'
+    description: >
+      Create the BrowserOpenerService class following the FileDialogService pattern with
+      BrowserOpenerDeps interface, defaultDeps, and Partial<Deps> constructor. Implement
+      the open(url) method with platform command map and fire-and-forget execFile.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'Service file exists at packages/core/src/infrastructure/services/browser-opener.service.ts'
+      - 'Exports BrowserOpenerService class and BrowserOpenerDeps interface'
+      - 'Has defaultDeps with process.platform, child_process.execFile, and console.warn'
+      - 'Constructor accepts Partial<BrowserOpenerDeps> with spread over defaultDeps'
+      - 'open(url) method maps platform to correct command and args'
+      - 'execFile callback catches errors and calls deps.warn()'
+      - 'Child process is unref()d'
+      - 'Unsupported platforms silently return (no error)'
+      - 'All tests from task-1 pass (GREEN)'
+    tdd:
+      red: []
+      green:
+        - 'Create browser-opener.service.ts with BrowserOpenerDeps interface'
+        - 'Define defaultDeps: { platform: process.platform, execFile: cp.execFile, warn: console.warn }'
+        - 'Implement PLATFORM_COMMANDS record for darwin, linux, win32'
+        - 'Implement open(url) method: lookup platform, call execFile, catch errors, unref child'
+        - 'Run tests — all pass'
+      refactor:
+        - 'Ensure naming consistency with FileDialogService pattern'
+        - 'Verify exports are clean (class + interface + deps type)'
+    estimatedEffort: '20min'
+
+  - id: task-3
+    phaseId: phase-2
+    title: 'Write ui.command integration tests (RED)'
+    description: >
+      Extend the existing ui.command.test.ts with tests for auto-open behavior and --no-open
+      flag. Mock the BrowserOpenerService module. Tests verify: (1) BrowserOpenerService.open()
+      is called after server start, (2) --no-open suppresses the call, (3) --no-open option
+      exists on the command.
+    state: Todo
+    dependencies:
+      - task-2
+    acceptanceCriteria:
+      - 'Test: --no-open option exists on the command'
+      - 'Test: BrowserOpenerService.open() called with correct URL after server start (default behavior)'
+      - 'Test: BrowserOpenerService.open() NOT called when --no-open is passed'
+      - 'All new tests fail (RED phase — integration not yet wired)'
+    tdd:
+      red:
+        - 'Add vi.mock for browser-opener.service.ts module in ui.command.test.ts'
+        - 'Write test: command has --no-open option'
+        - 'Write test: auto-opens browser with http://localhost:<port> after server start'
+        - 'Write test: --no-open suppresses browser open'
+      green: []
+      refactor: []
+    estimatedEffort: '20min'
+
+  - id: task-4
+    phaseId: phase-2
+    title: 'Wire --no-open flag and BrowserOpenerService into ui.command.ts (GREEN + REFACTOR)'
+    description: >
+      Add .option("--no-open", "Do not auto-open browser") to createUiCommand(). After the
+      "Server ready" message (line 81), add conditional BrowserOpenerService instantiation
+      and open() call when options.open !== false. Import the service from core package.
+    state: Todo
+    dependencies:
+      - task-3
+    acceptanceCriteria:
+      - 'ui.command.ts imports BrowserOpenerService'
+      - 'Command has .option("--no-open", "Do not auto-open browser")'
+      - 'options type includes open?: boolean'
+      - 'After messages.success(), if options.open !== false, instantiates BrowserOpenerService and calls open(url)'
+      - 'BrowserOpenerService constructed with { warn: messages.warn } to use CLI message system'
+      - 'All tests from task-3 pass (GREEN)'
+      - 'All existing tests still pass'
+      - 'pnpm typecheck passes'
+    tdd:
+      red: []
+      green:
+        - 'Add --no-open option to Commander command definition'
+        - 'Update options type to include open?: boolean'
+        - 'Import BrowserOpenerService'
+        - 'After messages.success() line, conditionally instantiate and call opener.open(url)'
+        - 'Run tests — all pass'
+      refactor:
+        - 'Extract url variable to avoid duplication with messages.success() line'
+        - 'Verify help text includes --no-open in examples section'
+    estimatedEffort: '15min'
+
+totalEstimate: '1.5h'
+openQuestions: []
+
+content: |
+  ## Summary
+
+  The implementation follows strict TDD across two phases. Phase 1 builds the
+  BrowserOpenerService as an isolated, fully-tested unit — tests first (task-1),
+  then implementation (task-2). Phase 2 integrates the service into the existing
+  ui.command — integration tests first (task-3), then wiring (task-4). Each RED
+  task produces failing tests; each GREEN task makes them pass with minimal code.
+  The total change is ~25 lines of service code, ~5 lines of command integration,
+  and ~80 lines of tests.

--- a/tests/unit/infrastructure/services/browser-opener.service.test.ts
+++ b/tests/unit/infrastructure/services/browser-opener.service.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  BrowserOpenerService,
+  type BrowserOpenerDeps,
+} from '@/infrastructure/services/browser-opener.service.js';
+
+function createMockChild() {
+  return { unref: vi.fn() };
+}
+
+function createService(platform: NodeJS.Platform, execFileError?: Error) {
+  const child = createMockChild();
+  const execFile = vi
+    .fn<BrowserOpenerDeps['execFile']>()
+    .mockImplementation(
+      (_cmd: string, _args: readonly string[], callback: (error: Error | null) => void) => {
+        if (execFileError) {
+          callback(execFileError);
+        } else {
+          callback(null);
+        }
+        return child as unknown as ReturnType<BrowserOpenerDeps['execFile']>;
+      }
+    );
+  const warn = vi.fn();
+  const service = new BrowserOpenerService({ platform, execFile, warn });
+  return { service, execFile, warn, child };
+}
+
+describe('BrowserOpenerService', () => {
+  const testUrl = 'http://localhost:3000';
+
+  describe('darwin (macOS)', () => {
+    it('calls execFile with "open" command and url as argument', () => {
+      const { service, execFile } = createService('darwin');
+      service.open(testUrl);
+      expect(execFile).toHaveBeenCalledWith('open', [testUrl], expect.any(Function));
+    });
+
+    it('calls unref on the child process', () => {
+      const { service, child } = createService('darwin');
+      service.open(testUrl);
+      expect(child.unref).toHaveBeenCalled();
+    });
+  });
+
+  describe('linux', () => {
+    it('calls execFile with "xdg-open" command and url as argument', () => {
+      const { service, execFile } = createService('linux');
+      service.open(testUrl);
+      expect(execFile).toHaveBeenCalledWith('xdg-open', [testUrl], expect.any(Function));
+    });
+
+    it('calls unref on the child process', () => {
+      const { service, child } = createService('linux');
+      service.open(testUrl);
+      expect(child.unref).toHaveBeenCalled();
+    });
+  });
+
+  describe('win32 (Windows)', () => {
+    it('calls execFile with "cmd" and /c start args', () => {
+      const { service, execFile } = createService('win32');
+      service.open(testUrl);
+      expect(execFile).toHaveBeenCalledWith(
+        'cmd',
+        ['/c', 'start', '', testUrl],
+        expect.any(Function)
+      );
+    });
+
+    it('calls unref on the child process', () => {
+      const { service, child } = createService('win32');
+      service.open(testUrl);
+      expect(child.unref).toHaveBeenCalled();
+    });
+  });
+
+  describe('unsupported platform', () => {
+    it('does not call execFile on unsupported platform', () => {
+      const { service, execFile } = createService('freebsd' as NodeJS.Platform);
+      service.open(testUrl);
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
+    it('does not call warn on unsupported platform', () => {
+      const { service, warn } = createService('freebsd' as NodeJS.Platform);
+      service.open(testUrl);
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('calls warn when execFile fails', () => {
+      const error = new Error('xdg-open not found');
+      const { service, warn } = createService('linux', error);
+      service.open(testUrl);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('xdg-open not found'));
+    });
+
+    it('does not throw when execFile fails', () => {
+      const error = new Error('command not found');
+      const { service } = createService('darwin', error);
+      expect(() => service.open(testUrl)).not.toThrow();
+    });
+  });
+
+  describe('constructor defaults', () => {
+    it('creates service with default deps when none provided', () => {
+      const service = new BrowserOpenerService();
+      expect(service).toBeInstanceOf(BrowserOpenerService);
+    });
+  });
+});

--- a/tests/unit/presentation/cli/commands/ui.command.test.ts
+++ b/tests/unit/presentation/cli/commands/ui.command.test.ts
@@ -37,6 +37,14 @@ vi.mock('@/infrastructure/di/container.js', () => ({
       if (token === 'IWebServerService') {
         return mockWebServerService;
       }
+      // Return empty stubs for notification-related services
+      if (
+        token === 'IAgentRunRepository' ||
+        token === 'IPhaseTimingRepository' ||
+        token === 'INotificationService'
+      ) {
+        return {};
+      }
       throw new Error(`Unknown token: ${token}`);
     }),
   },
@@ -55,8 +63,26 @@ vi.mock('@/infrastructure/services/web-server.service.js', () => ({
   }),
 }));
 
+// Mock notification watcher service (requires start/stop methods)
+vi.mock('@/infrastructure/services/notifications/notification-watcher.service.js', () => ({
+  initializeNotificationWatcher: vi.fn(),
+  getNotificationWatcher: vi.fn().mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+// Mock BrowserOpenerService — use a class so `new` works
+const mockBrowserOpen = vi.fn();
+vi.mock('@/infrastructure/services/browser-opener.service.js', () => ({
+  BrowserOpenerService: vi.fn().mockImplementation(function () {
+    return { open: mockBrowserOpen };
+  }),
+}));
+
 import { findAvailablePort } from '@/infrastructure/services/port.service.js';
 import { resolveWebDir } from '@/infrastructure/services/web-server.service.js';
+import { BrowserOpenerService } from '@/infrastructure/services/browser-opener.service.js';
 import { createUiCommand } from '../../../../../src/presentation/cli/commands/ui.command.js';
 
 describe('UI Command', () => {
@@ -65,6 +91,7 @@ describe('UI Command', () => {
     (findAvailablePort as ReturnType<typeof vi.fn>).mockResolvedValue(4050);
     mockWebServerService.start.mockClear();
     mockWebServerService.stop.mockClear();
+    mockBrowserOpen.mockClear();
     process.exitCode = undefined;
   });
 
@@ -157,6 +184,48 @@ describe('UI Command', () => {
       const portOption = cmd.options.find((o) => o.long === '--port');
       expect(portOption).toBeDefined();
       expect(portOption!.flags).toContain('<number>');
+    });
+  });
+
+  describe('--no-open flag', () => {
+    it('should have a --no-open option', () => {
+      const cmd = createUiCommand();
+      const noOpenOption = cmd.options.find((o) => o.long === '--no-open');
+      expect(noOpenOption).toBeDefined();
+    });
+  });
+
+  describe('auto-open browser', () => {
+    it('should open browser with correct URL after server start by default', async () => {
+      const cmd = createUiCommand();
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(vi.fn());
+
+      await cmd.parseAsync([], { from: 'user' });
+
+      expect(BrowserOpenerService).toHaveBeenCalled();
+      expect(mockBrowserOpen).toHaveBeenCalledWith('http://localhost:4050');
+      consoleSpy.mockRestore();
+    });
+
+    it('should open browser with custom port URL', async () => {
+      (findAvailablePort as ReturnType<typeof vi.fn>).mockResolvedValue(9090);
+      const cmd = createUiCommand();
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(vi.fn());
+
+      await cmd.parseAsync(['--port', '9090'], { from: 'user' });
+
+      expect(mockBrowserOpen).toHaveBeenCalledWith('http://localhost:9090');
+      consoleSpy.mockRestore();
+    });
+
+    it('should NOT open browser when --no-open is passed', async () => {
+      const cmd = createUiCommand();
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(vi.fn());
+
+      await cmd.parseAsync(['--no-open'], { from: 'user' });
+
+      expect(mockBrowserOpen).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `BrowserOpenerService` infrastructure service that opens the user's default browser using platform-specific commands (`open` on macOS, `xdg-open` on Linux, `cmd /c start` on Windows) via `execFile` for shell-injection safety
- Integrate auto-open into `shep ui` command — browser opens automatically after the server is ready
- Add `--no-open` flag to suppress auto-open for headless/CI environments
- Fire-and-forget spawning ensures the CLI is never blocked; failures are logged as warnings

## Details

The service follows the project's injectable-deps pattern (like `FileDialogService`) for full testability without global mocking. Platform detection, `execFile`, and warning logger are all injectable with sensible defaults.

### Files changed

| File | Change |
|------|--------|
| `packages/core/src/infrastructure/services/browser-opener.service.ts` | New service with cross-platform browser opening |
| `src/presentation/cli/commands/ui.command.ts` | Add `--no-open` flag and auto-open call after server ready |
| `tests/unit/infrastructure/services/browser-opener.service.test.ts` | Unit tests for all 3 platforms, unsupported platform, error handling |
| `tests/unit/presentation/cli/commands/ui.command.test.ts` | Tests for auto-open default, custom port, and `--no-open` suppression |
| `specs/037-auto-open-browser/` | Feature specification (spec, research, plan, tasks, feature YAML) |

## Test plan

- [x] Unit tests for `BrowserOpenerService` cover macOS, Linux, Windows, unsupported platform, and error handling
- [x] Unit tests for `ui.command.ts` cover auto-open by default, custom port URL, and `--no-open` suppression
- [ ] CI passes lint, typecheck, and unit tests
- [ ] Manual smoke test: `shep ui` opens browser, `shep ui --no-open` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)