### PR TITLE
fix(web): include server external packages in production next config

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prelint": "pnpm generate",
     "build:cli": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths && mkdir -p dist/packages/core/src/infrastructure/services/tool-installer && cp -r packages/core/src/infrastructure/services/tool-installer/tools dist/packages/core/src/infrastructure/services/tool-installer/tools",
     "build": "pnpm build:cli && pnpm build:web:prod",
-    "build:web:prod": "pnpm build:web && rm -rf web && mkdir -p web && cp -r src/presentation/web/.next web/.next && cp -r src/presentation/web/public web/public && cp src/presentation/web/package.json web/ && node -e \"require('fs').writeFileSync('web/next.config.mjs','const c={typedRoutes:true,distDir:\\\".next\\\"};export default c;\\n')\"",
+    "build:web:prod": "pnpm build:web && rm -rf web && mkdir -p web && cp -r src/presentation/web/.next web/.next && test -d src/presentation/web/public && cp -r src/presentation/web/public web/public || true && cp src/presentation/web/package.json web/ && node -e \"require('fs').writeFileSync('web/next.config.mjs','const c={serverExternalPackages:[\\\"tsyringe\\\",\\\"reflect-metadata\\\",\\\"better-sqlite3\\\"],typedRoutes:true,distDir:\\\".next\\\"};export default c;\\n')\"",
     "build:web": "pnpm --filter @shepai/web build",
     "build:storybook": "storybook build",
     "test": "vitest run tests/unit tests/integration --passWithNoTests && pnpm run test:e2e",


### PR DESCRIPTION
## Summary
- Fixes empty control center when running `shep ui` in production mode
- Adds `serverExternalPackages` (`tsyringe`, `reflect-metadata`, `better-sqlite3`) to the generated production `next.config.mjs` — these native/DI modules were externalized at build time but missing from the runtime config, causing resolution failures
- Guards `public/` directory copy with existence check to prevent silent build failures

## Test plan
- [ ] Run `pnpm build` to rebuild CLI + web production output
- [ ] Run `shep ui` and verify the control center renders with content (not empty)
- [ ] Verify `web/next.config.mjs` includes `serverExternalPackages`
- [ ] Verify `web/public/` directory is present after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)