### PR TITLE
feat(agents): skip push and pr when repo has no git remote

### DIFF
--- a/packages/core/src/application/ports/output/services/git-pr-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/git-pr-service.interface.ts
@@ -85,6 +85,14 @@ export type MergeStrategy = 'squash' | 'merge' | 'rebase';
  */
 export interface IGitPrService {
   /**
+   * Check if the repository has any configured git remotes.
+   *
+   * @param cwd - Working directory path
+   * @returns True if at least one remote is configured
+   */
+  hasRemote(cwd: string): Promise<boolean>;
+
+  /**
    * Check if the working directory has uncommitted changes.
    *
    * @param cwd - Working directory path

--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -171,6 +171,7 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
     mergeNodeDeps: {
       getDiffSummary: (cwd: string, baseBranch: string) =>
         gitPrService.getPrDiffSummary(cwd, baseBranch),
+      hasRemote: (cwd: string) => gitPrService.hasRemote(cwd),
       featureRepository,
     },
   };

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -112,6 +112,21 @@ export function buildMergeSquashPrompt(
 
   // Non-PR path: local merge in the ORIGINAL repo (not the worktree)
   const originalRepo = state.repositoryPath;
+  const hasRemote = state.push || state.openPr;
+
+  const fetchSteps = hasRemote
+    ? `2. Fetch latest: \`git fetch origin\`
+3. Checkout the base branch: \`git checkout ${baseBranch}\`
+4. Pull latest base: \`git pull origin ${baseBranch}\`
+5. Merge the feature branch: \`git merge --squash ${branch}\`
+6. If merge conflicts are encountered, resolve them manually and complete the merge
+7. Commit the squash merge with a descriptive conventional commit message
+8. Delete the feature branch after successful merge: \`git branch -d ${branch}\``
+    : `2. Checkout the base branch: \`git checkout ${baseBranch}\`
+3. Merge the feature branch: \`git merge --squash ${branch}\`
+4. If merge conflicts are encountered, resolve them manually and complete the merge
+5. Commit the squash merge with a descriptive conventional commit message
+6. Delete the feature branch after successful merge: \`git branch -d ${branch}\``;
 
   return `You are performing a local merge in the original repository directory.
 
@@ -129,13 +144,7 @@ ${originalRepo}
 ## Instructions
 
 1. Change to the original repository: \`cd ${originalRepo}\`
-2. Fetch latest: \`git fetch origin\`
-3. Checkout the base branch: \`git checkout ${baseBranch}\`
-4. Pull latest base: \`git pull origin ${baseBranch}\`
-5. Merge the feature branch: \`git merge --squash ${branch}\`
-6. If merge conflicts are encountered, resolve them manually and complete the merge
-7. Commit the squash merge with a descriptive conventional commit message
-8. Delete the feature branch after successful merge: \`git branch -d ${branch}\`
+${fetchSteps}
 
 ## Constraints
 

--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -25,6 +25,11 @@ import type { ExecFunction } from './worktree.service.js';
 export class GitPrService implements IGitPrService {
   constructor(@inject('ExecFunction') private readonly execFile: ExecFunction) {}
 
+  async hasRemote(cwd: string): Promise<boolean> {
+    const { stdout } = await this.execFile('git', ['remote'], { cwd });
+    return stdout.trim().length > 0;
+  }
+
   async hasUncommittedChanges(cwd: string): Promise<boolean> {
     const { stdout } = await this.execFile('git', ['status', '--porcelain'], { cwd });
     return stdout.trim().length > 0;

--- a/tests/integration/infrastructure/services/agents/graph-state-transitions/setup.ts
+++ b/tests/integration/infrastructure/services/agents/graph-state-transitions/setup.ts
@@ -89,6 +89,7 @@ export function createStubMergeNodeDeps(featureId?: string): Omit<MergeNodeDeps,
       deletions: 10,
       commitCount: 2,
     }),
+    hasRemote: vi.fn().mockResolvedValue(true),
     featureRepository: {
       findById: vi.fn().mockResolvedValue({
         id: featureId ?? 'feat-test',

--- a/tests/integration/infrastructure/services/agents/merge-flow.test.ts
+++ b/tests/integration/infrastructure/services/agents/merge-flow.test.ts
@@ -102,7 +102,11 @@ describe('Merge Flow (Graph-level)', () => {
     const featureRepo = overrides?.featureRepo ?? createMockFeatureRepo();
     const deps: FeatureAgentGraphDeps = {
       executor: createMockExecutor(),
-      mergeNodeDeps: { getDiffSummary, featureRepository: featureRepo },
+      mergeNodeDeps: {
+        getDiffSummary,
+        hasRemote: vi.fn().mockResolvedValue(true),
+        featureRepository: featureRepo,
+      },
     };
     return { deps, getDiffSummary, featureRepo };
   }

--- a/tests/unit/application/ports/output/services/git-pr-service.interface.test.ts
+++ b/tests/unit/application/ports/output/services/git-pr-service.interface.test.ts
@@ -128,9 +128,10 @@ describe('PrCreateResult', () => {
 });
 
 describe('IGitPrService', () => {
-  it('should be implementable with all 10 methods', () => {
+  it('should be implementable with all 11 methods', () => {
     // Compile-time check: a mock class implementing IGitPrService must provide all methods
     const mock: IGitPrService = {
+      hasRemote: async () => true,
       hasUncommittedChanges: async () => false,
       commitAll: async () => 'abc123',
       push: async () => {

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
@@ -138,6 +138,7 @@ function baseDeps(overrides?: Partial<MergeNodeDeps>): MergeNodeDeps {
   return {
     executor: createMockExecutor(),
     getDiffSummary: createMockGetDiffSummary(),
+    hasRemote: vi.fn().mockResolvedValue(true),
     featureRepository: createMockFeatureRepo(),
     ...overrides,
   };
@@ -270,6 +271,20 @@ describe('createMergeNode (agent-driven)', () => {
         expect.any(String),
         'main'
       );
+    });
+
+    it('should override push and openPr to false when no remote is configured', async () => {
+      const noRemoteDeps = baseDeps({ hasRemote: vi.fn().mockResolvedValue(false) });
+      const node = createMergeNode(noRemoteDeps);
+      const state = baseState({ push: true, openPr: true });
+      await node(state);
+
+      expect(mockBuildCommitPushPrPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({ push: false, openPr: false }),
+        expect.any(String),
+        'main'
+      );
+      expect(mockParsePrUrl).not.toHaveBeenCalled();
     });
 
     it('should NOT parse prUrl when openPr=false', async () => {

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.test.ts
@@ -191,6 +191,26 @@ describe('buildMergeSquashPrompt', () => {
       expect(prompt).toContain('cd /tmp/repo');
     });
 
+    it('should include fetch/pull from origin when push or openPr is set', () => {
+      const prompt = buildMergeSquashPrompt(
+        baseState({ prUrl: null, prNumber: null, push: true }),
+        'feat/test',
+        'main'
+      );
+      expect(prompt).toContain('git fetch origin');
+      expect(prompt).toContain('git pull origin');
+    });
+
+    it('should NOT include fetch/pull from origin when no remote (push=false, openPr=false)', () => {
+      const prompt = buildMergeSquashPrompt(
+        baseState({ prUrl: null, prNumber: null, push: false, openPr: false }),
+        'feat/test',
+        'main'
+      );
+      expect(prompt).not.toContain('git fetch origin');
+      expect(prompt).not.toContain('git pull origin');
+    });
+
     it('should include branch names', () => {
       const prompt = buildMergeSquashPrompt(baseState(), 'feat/my-branch', 'main');
       expect(prompt).toContain('feat/my-branch');


### PR DESCRIPTION
## Summary

- Adds `hasRemote()` to `IGitPrService` interface and implementation to detect repos without a configured git remote
- Merge node now checks for remote availability before agent call 1 — overrides `push` and `openPr` to `false` when no remote exists
- Local merge prompt skips `git fetch origin` / `git pull origin` when no remote, avoiding failures on local-only repos
- Local squash merge still proceeds normally (checkout base → merge --squash → commit → delete branch)

## Test plan

- [x] Unit tests: merge node correctly overrides push/openPr when `hasRemote` returns false
- [x] Unit tests: merge prompt omits fetch/pull steps when push=false and openPr=false
- [x] All 44 existing merge tests pass
- [x] TypeScript typecheck passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)