### PR TITLE
fix(agents): handle merge node rejection loop

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-graph.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-graph.ts
@@ -226,7 +226,7 @@ export function createFeatureAgentGraph(
     graph
       .addNode('merge', createMergeNode(mergeNodeDeps))
       .addEdge('implement', 'merge')
-      .addEdge('merge', END);
+      .addConditionalEdges('merge', routeReexecution('merge', END));
   } else {
     graph.addEdge('implement', END);
   }

--- a/tests/integration/infrastructure/services/agents/merge-flow.test.ts
+++ b/tests/integration/infrastructure/services/agents/merge-flow.test.ts
@@ -247,7 +247,13 @@ describe('Merge Flow (Graph-level)', () => {
       expect(interrupts2[0].value.diffSummary).toBeDefined();
 
       // Resume past merge → completes
-      const result3 = await graph.invoke(new Command({ resume: { approved: true } }), config);
+      const result3 = await graph.invoke(
+        new Command({
+          resume: { approved: true },
+          update: { _approvalAction: 'approved', _rejectionFeedback: null },
+        }),
+        config
+      );
       expect(getInterrupts(result3)).toHaveLength(0);
 
       // After resume, lifecycle should be updated to Review (allowMerge=false, no auto-merge)

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.test.ts
@@ -23,6 +23,9 @@ vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 const {
   mockInterrupt,
   mockShouldInterrupt,
+  mockGetCompletedPhases,
+  mockClearCompletedPhase,
+  mockMarkPhaseComplete,
   mockRecordPhaseStart,
   mockRecordPhaseEnd,
   mockRecordApprovalWaitStart,
@@ -33,6 +36,9 @@ const {
 } = vi.hoisted(() => ({
   mockInterrupt: vi.fn(),
   mockShouldInterrupt: vi.fn().mockReturnValue(false),
+  mockGetCompletedPhases: vi.fn().mockReturnValue([]),
+  mockClearCompletedPhase: vi.fn(),
+  mockMarkPhaseComplete: vi.fn(),
   mockRecordPhaseStart: vi.fn().mockResolvedValue('timing-123'),
   mockRecordPhaseEnd: vi.fn().mockResolvedValue(undefined),
   mockRecordApprovalWaitStart: vi.fn().mockResolvedValue(undefined),
@@ -58,6 +64,9 @@ vi.mock('@/infrastructure/services/agents/feature-agent/nodes/node-helpers.js', 
   }),
   readSpecFile: vi.fn().mockReturnValue('name: Test Feature\ndescription: A test\n'),
   shouldInterrupt: mockShouldInterrupt,
+  getCompletedPhases: mockGetCompletedPhases,
+  clearCompletedPhase: mockClearCompletedPhase,
+  markPhaseComplete: mockMarkPhaseComplete,
   retryExecute: vi
     .fn()
     .mockImplementation(


### PR DESCRIPTION
## Summary

- Fixed merge node skipping to completion after a single rejection instead of re-interrupting for another approval cycle
- Added rejection detection logic with `getCompletedPhases`/`clearCompletedPhase`/`markPhaseComplete` pattern (matching requirements and plan nodes)
- Changed merge edge from hardcoded `.addEdge('merge', END)` to `.addConditionalEdges('merge', routeReexecution('merge', END))`
- On approval resume, skips commit/push/PR (already done) but still runs lifecycle update and optional merge/squash

## Test plan

- [x] 8 consecutive PRD rejections then approve
- [x] 8 consecutive plan rejections then approve
- [x] Single merge rejection + re-interrupt
- [x] Merge reject then approve cycle
- [x] 8 consecutive merge rejections then approve
- [x] Full walkthrough with merge rejection mid-flow (req → plan → merge reject × 3 → approve)
- [x] All existing tests still pass (54 graph-state-transition tests, 21 merge unit tests, 8 merge integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)