### PR TITLE
feat(cli): improve feat ls view

### DIFF
--- a/src/presentation/cli/commands/feat/show.command.ts
+++ b/src/presentation/cli/commands/feat/show.command.ts
@@ -34,14 +34,14 @@ const NODE_TO_PHASE: Record<string, string> = {
   merge: 'Merging',
 };
 
-/** Map graph node names to approval action labels. */
-const NODE_TO_APPROVE: Record<string, string> = {
-  analyze: 'Approve Analysis',
-  requirements: 'Approve PRD',
-  research: 'Approve Research',
-  plan: 'Approve Plan',
-  implement: 'Approve Implementation',
-  merge: 'Approve Merge',
+/** Map graph node names to review action labels. */
+const NODE_TO_REVIEW: Record<string, string> = {
+  analyze: 'Review Analysis',
+  requirements: 'Review Requirements',
+  research: 'Review Research',
+  plan: 'Review Plan',
+  implement: 'Review Merge',
+  merge: 'Review Merge',
 };
 
 /** Map lifecycle event phases to display labels and symbols. */
@@ -78,8 +78,8 @@ function formatStatus(feature: Feature, run: AgentRun | null): string {
     return `${colors.success(symbols.success)} ${colors.success('Completed')}`;
   if (run.status === 'failed') return `${colors.error(symbols.error)} ${colors.error('Failed')}`;
   if (run.status === 'waiting_approval') {
-    const action = nodeName ? (NODE_TO_APPROVE[nodeName] ?? phase) : phase;
-    return `${colors.warning(symbols.warning)} ${colors.warning(action)}`;
+    const action = nodeName ? (NODE_TO_REVIEW[nodeName] ?? phase) : phase;
+    return `${colors.brand(symbols.pointer)} ${colors.brand(action)}`;
   }
   if (run.status === 'interrupted')
     return `${colors.error(symbols.error)} ${colors.error('Interrupted')}`;


### PR DESCRIPTION
## Summary
- Replace "Approve X" status labels with "Review X" and use brand pointer icon instead of warning
- Sort features by status priority: running > waiting approval > failed > completed
- Replace Agent column with compact approval gates + push flag column (R P M with checkboxes)
- Use phase timings for accurate elapsed time (sums all phases across retries)
- Add proper name truncation with ellipsis instead of hard cut
- Split Time column into Elapsed (duration) and Done (completion time)
- Consistent status label changes in both ls and show commands

## Test plan
- [x] Run shep feat ls and verify column layout, sorting, and gate checkboxes
- [x] Verify elapsed time reflects total across all phases (not just last run)
- [x] Verify completed features show both elapsed and Done X ago
- [x] Run shep feat show and verify status labels match
- [x] Check terminal rendering at 100+ column width

Generated with Claude Code