### PR TITLE
fix(agents): prevent data loss in merge node for no-remote repos

### DIFF
--- a/packages/core/src/application/ports/output/services/git-pr-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/git-pr-service.interface.ts
@@ -202,4 +202,16 @@ export interface IGitPrService {
    * @throws GitPrError with GIT_ERROR code
    */
   getPrDiffSummary(cwd: string, baseBranch: string): Promise<DiffSummary>;
+
+  /**
+   * Verify that a feature branch has been merged into a base branch.
+   * Uses `git merge-base --is-ancestor` to check if featureBranch
+   * is an ancestor of baseBranch (meaning all its commits are reachable).
+   *
+   * @param cwd - Working directory path
+   * @param featureBranch - The branch that should have been merged
+   * @param baseBranch - The branch that should contain the merge
+   * @returns True if featureBranch is an ancestor of baseBranch
+   */
+  verifyMerge(cwd: string, featureBranch: string, baseBranch: string): Promise<boolean>;
 }

--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -173,6 +173,8 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
         gitPrService.getPrDiffSummary(cwd, baseBranch),
       hasRemote: (cwd: string) => gitPrService.hasRemote(cwd),
       getDefaultBranch: (cwd: string) => gitPrService.getDefaultBranch(cwd),
+      verifyMerge: (cwd: string, featureBranch: string, baseBranch: string) =>
+        gitPrService.verifyMerge(cwd, featureBranch, baseBranch),
       featureRepository,
     },
   };

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -124,7 +124,8 @@ ${steps.join('\n')}
 export function buildMergeSquashPrompt(
   state: FeatureAgentState,
   branch: string,
-  baseBranch: string
+  baseBranch: string,
+  hasRemote = false
 ): string {
   if (state.prUrl && state.prNumber) {
     // PR path: remote merge via GitHub CLI — no local merge needed
@@ -149,7 +150,6 @@ export function buildMergeSquashPrompt(
 
   // Non-PR path: local merge in the ORIGINAL repo (not the worktree)
   const originalRepo = state.repositoryPath;
-  const hasRemote = state.push || state.openPr;
 
   const fetchSteps = hasRemote
     ? `2. Fetch latest: \`git fetch origin\`
@@ -187,6 +187,8 @@ ${fetchSteps}
 
 - Use squash merge strategy to keep history clean
 - All commands MUST run in \`${originalRepo}\` (the original repo), NOT in the worktree
+- NEVER remove, modify, or prune git worktrees — they are managed by the system
+- Do NOT try to \`git checkout\` the feature branch — \`git merge --squash\` reads from it without checking it out
 - If conflicts arise during merge, attempt to resolve them intelligently
 - Do NOT modify any source code beyond what is needed for conflict resolution
 - Report the merge result clearly`;

--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -223,6 +223,17 @@ export class GitPrService implements IGitPrService {
     return this.parseDiffStat(diffStat, logOutput);
   }
 
+  async verifyMerge(cwd: string, featureBranch: string, baseBranch: string): Promise<boolean> {
+    try {
+      await this.execFile('git', ['merge-base', '--is-ancestor', featureBranch, baseBranch], {
+        cwd,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private parseGitError(error: unknown): GitPrError {
     const message = error instanceof Error ? error.message : String(error);
     const cause = error instanceof Error ? error : undefined;

--- a/tests/integration/infrastructure/services/agents/graph-state-transitions/setup.ts
+++ b/tests/integration/infrastructure/services/agents/graph-state-transitions/setup.ts
@@ -91,6 +91,7 @@ export function createStubMergeNodeDeps(featureId?: string): Omit<MergeNodeDeps,
     }),
     hasRemote: vi.fn().mockResolvedValue(true),
     getDefaultBranch: vi.fn().mockResolvedValue('main'),
+    verifyMerge: vi.fn().mockResolvedValue(true),
     featureRepository: {
       findById: vi.fn().mockResolvedValue({
         id: featureId ?? 'feat-test',

--- a/tests/unit/application/ports/output/services/git-pr-service.interface.test.ts
+++ b/tests/unit/application/ports/output/services/git-pr-service.interface.test.ts
@@ -156,9 +156,10 @@ describe('IGitPrService', () => {
         deletions: 0,
         commitCount: 0,
       }),
+      verifyMerge: async () => true,
     };
 
-    // Verify all 10 methods exist
+    // Verify all methods exist
     const methodNames: (keyof IGitPrService)[] = [
       'hasUncommittedChanges',
       'commitAll',
@@ -170,9 +171,10 @@ describe('IGitPrService', () => {
       'watchCi',
       'deleteBranch',
       'getPrDiffSummary',
+      'verifyMerge',
     ];
 
-    expect(methodNames).toHaveLength(10);
+    expect(methodNames).toHaveLength(11);
     for (const name of methodNames) {
       expect(typeof mock[name]).toBe('function');
     }

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.test.ts
@@ -191,24 +191,47 @@ describe('buildMergeSquashPrompt', () => {
       expect(prompt).toContain('cd /tmp/repo');
     });
 
-    it('should include fetch/pull from origin when push or openPr is set', () => {
+    it('should include fetch/pull from origin when hasRemote=true', () => {
       const prompt = buildMergeSquashPrompt(
-        baseState({ prUrl: null, prNumber: null, push: true }),
+        baseState({ prUrl: null, prNumber: null }),
         'feat/test',
-        'main'
+        'main',
+        true
       );
       expect(prompt).toContain('git fetch origin');
       expect(prompt).toContain('git pull origin');
     });
 
-    it('should NOT include fetch/pull from origin when no remote (push=false, openPr=false)', () => {
+    it('should NOT include fetch/pull from origin when hasRemote=false', () => {
       const prompt = buildMergeSquashPrompt(
-        baseState({ prUrl: null, prNumber: null, push: false, openPr: false }),
+        baseState({ prUrl: null, prNumber: null }),
+        'feat/test',
+        'main',
+        false
+      );
+      expect(prompt).not.toContain('git fetch origin');
+      expect(prompt).not.toContain('git pull origin');
+    });
+
+    it('should NOT include fetch/pull when hasRemote defaults to false', () => {
+      const prompt = buildMergeSquashPrompt(
+        baseState({ prUrl: null, prNumber: null }),
         'feat/test',
         'main'
       );
       expect(prompt).not.toContain('git fetch origin');
       expect(prompt).not.toContain('git pull origin');
+    });
+
+    it('should include worktree protection constraints', () => {
+      const prompt = buildMergeSquashPrompt(
+        baseState({ prUrl: null, prNumber: null }),
+        'feat/test',
+        'main'
+      );
+      expect(prompt).toContain('NEVER remove');
+      expect(prompt).toContain('worktree');
+      expect(prompt).not.toContain('git checkout feat/test');
     });
 
     it('should include branch names', () => {

--- a/tests/unit/infrastructure/services/git/git-pr.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.test.ts
@@ -366,4 +366,27 @@ describe('GitPrService', () => {
       expect(result.commitCount).toBe(3);
     });
   });
+
+  describe('verifyMerge', () => {
+    it('should return true when feature branch is ancestor of base branch', async () => {
+      vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
+
+      const result = await service.verifyMerge('/repo', 'feat/test', 'main');
+
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith(
+        'git',
+        ['merge-base', '--is-ancestor', 'feat/test', 'main'],
+        { cwd: '/repo' }
+      );
+    });
+
+    it('should return false when feature branch is NOT ancestor of base branch', async () => {
+      vi.mocked(mockExec).mockRejectedValue(new Error('exit code 1'));
+
+      const result = await service.verifyMerge('/repo', 'feat/test', 'main');
+
+      expect(result).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Critical bug fix: the merge agent could delete worktrees and silently fail when merging locally in repos without a git remote, causing **complete data loss** of all implementation work.

**Root cause**: When merging locally (no remote), the agent executor's cwd was set to the worktree. The agent tried to `git checkout` the feature branch, got blocked by the worktree lock, then deleted the worktree to unblock itself — destroying all implementation work. The merge then failed (broken cwd), but the node reported success.

**Four fixes applied:**
- **cwd override**: Merge agent call uses `repositoryPath` as cwd instead of worktree
- **hasRemote param**: Uses actual remote check instead of `state.push || state.openPr` flags
- **merge verification**: `git merge-base --is-ancestor` check after local merge; throws if merge didn't happen
- **worktree protection**: Explicit constraints in prompt: "NEVER remove worktrees", "Do NOT checkout feature branch"

## Test plan

- [x] Unit tests for merge node (26 tests passing)
- [x] Unit tests for merge prompts (25 tests passing)
- [x] Unit tests for git-pr service verifyMerge (26 tests passing)
- [x] Integration tests for merge flow including new no-remote scenario (10 tests passing)
- [x] Integration tests for graph state transitions (9 tests passing)
- [x] TypeScript typecheck passes
- [x] All pre-commit hooks pass (lint, format, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)