### PR TITLE
fix(web): include serverExternalPackages in production next config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prelint": "pnpm generate",
     "build:cli": "tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths && mkdir -p dist/packages/core/src/infrastructure/services/tool-installer && cp -r packages/core/src/infrastructure/services/tool-installer/tools dist/packages/core/src/infrastructure/services/tool-installer/tools",
     "build": "pnpm build:cli && pnpm build:web:prod",
-    "build:web:prod": "pnpm build:web && rm -rf web && mkdir -p web && cp -r src/presentation/web/.next web/.next && cp -r src/presentation/web/public web/public && cp src/presentation/web/package.json web/ && node -e \"require('fs').writeFileSync('web/next.config.mjs','const c={typedRoutes:true,distDir:\\\".next\\\"};export default c;\\n')\"",
+    "build:web:prod": "pnpm build:web && rm -rf web && mkdir -p web && cp -r src/presentation/web/.next web/.next && cp -r src/presentation/web/public web/public && cp src/presentation/web/package.json web/ && node -e \"require('fs').writeFileSync('web/next.config.mjs','const c={typedRoutes:true,distDir:\\\".next\\\",serverExternalPackages:[\\\"tsyringe\\\",\\\"reflect-metadata\\\",\\\"better-sqlite3\\\"],output:\\\"standalone\\\"};export default c;\\n')\"",
     "build:web": "pnpm --filter @shepai/web build",
     "build:storybook": "storybook build",
     "test": "vitest run tests/unit tests/integration --passWithNoTests && pnpm run test:e2e",


### PR DESCRIPTION
## Summary
- The `build:web:prod` script generates a minimal `next.config.mjs` for the npm-published bundle, but it was missing `serverExternalPackages` and `output: 'standalone'`
- Without `serverExternalPackages`, Next.js bundles native Node.js modules (`node:os`, `node:child_process`) into server chunks, causing `os.platform()` to be statically evaluated at build time
- On macOS installs built in Linux CI, this resulted in `spawn x-terminal-emulator ENOENT` instead of using the correct macOS terminal command

## Test plan
- [ ] Install the built npm package on macOS and run `shep ui`
- [ ] Click "Open Shell" and verify it spawns Terminal (not `x-terminal-emulator`)
- [ ] Verify `open-folder` action works correctly on macOS
- [ ] On Linux, verify `x-terminal-emulator` is still used correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)