### PR TITLE
fix(web): increase panel right margin mr-12→mr-16 to clear theme toggle

### DIFF
--- a/specs/043-add-repo-button-position/feature.yaml
+++ b/specs/043-add-repo-button-position/feature.yaml
@@ -1,0 +1,37 @@
+feature:
+  id: 043-add-repo-button-position
+  name: add-repo-button-position
+  number: 43
+  branch: feat/043-add-repo-button-position
+  lifecycle: research
+  createdAt: '2026-02-24T22:48:17Z'
+status:
+  phase: implementation-complete
+  progress:
+    completed: 2
+    total: 2
+    percentage: 100
+  currentTask: null
+  lastUpdated: '2026-02-24T23:08:38.343Z'
+  lastUpdatedBy: feature-agent:implement
+  completedPhases:
+    - analyze
+    - requirements
+    - research
+    - plan
+    - phase-1
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+tasks:
+  current: null
+  blocked: []
+  failed: []
+checkpoints:
+  - phase: feature-created
+    completedAt: '2026-02-24T22:48:17Z'
+    completedBy: feature-agent
+errors:
+  current: null
+  history: []

--- a/specs/043-add-repo-button-position/plan.yaml
+++ b/specs/043-add-repo-button-position/plan.yaml
@@ -1,0 +1,82 @@
+# Implementation Plan (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: add-repo-button-position
+summary: >
+  Single-line Tailwind class change in features-canvas.tsx: replace mr-12 with mr-16 on the
+  ReactFlow Panel so the Add Repository button clears the ThemeToggle with a 12 px gap.
+  Verification via Storybook story update.
+
+# Relationships
+relatedFeatures: []
+technologies:
+  - Tailwind CSS
+  - '@xyflow/react (ReactFlow Panel)'
+  - React
+  - Storybook
+relatedLinks:
+  - https://tailwindcss.com/docs/margin
+  - https://reactflow.dev/api-reference/components/panel
+
+# Structured implementation phases
+phases:
+  - id: phase-1
+    name: 'Layout Fix & Visual Verification'
+    description: >
+      Change mr-12 → mr-16 on the ReactFlow Panel in features-canvas.tsx and update the
+      Storybook story to visually confirm the corrected layout. Single phase because the
+      fix and its verification are tightly coupled and trivially small.
+    parallel: false
+
+# File change tracking
+filesToCreate: []
+
+filesToModify:
+  - src/presentation/web/components/features/features-canvas/features-canvas.tsx
+  - src/presentation/web/components/features/features-canvas/features-canvas.stories.tsx
+
+# Open questions (should all be resolved before implementation)
+openQuestions: []
+
+# Markdown content (the full plan document)
+content: |
+  ## Architecture Overview
+
+  This fix lives entirely in the `presentation/web` layer — no domain, application, or
+  infrastructure code is affected. The project follows Clean Architecture; changes are
+  confined to a single presentation component.
+
+  The ReactFlow `<Panel position="top-right">` in `FeaturesCanvas` accepts a `className`
+  prop that maps directly to its wrapper div. Tailwind margin utilities on this prop
+  control how far the panel sits from the viewport edge — the minimal, idiomatic
+  injection point for this fix.
+
+  ## Key Design Decisions
+
+  **Spacing value: mr-16 (64 px)**
+  The ThemeToggle (`shadcn Button size="icon"`, 40×40 px) is positioned at `right-3`
+  (12 px inset), occupying ~52 px from the right edge. `mr-16` = 64 px clears that zone
+  by 12 px — consistent with common UI breathing-room conventions (8–16 px between
+  interactive elements). `mr-14` (56 px) is too tight; `mr-20` (80 px) overshoots.
+
+  **Mechanism: Tailwind utility class (not inline style or custom CSS)**
+  The project is utility-first throughout the presentation layer. FR-2 explicitly requires
+  an existing Tailwind spacing utility. `mr-16` is already on the standard scale, requires
+  no new dependencies, and remains grep-able and Tailwind-tooling-aware.
+
+  **Scope: features-canvas.tsx only**
+  FR-3 restricts the fix to this file. Adjusting `AppShell` or `ThemeToggle` would have
+  wider blast radius. The Panel `className` prop is the direct, minimal injection point.
+
+  ## Implementation Strategy
+
+  Single phase: change the class, update the Storybook story. No sequencing complexity.
+  The Storybook story update provides the verifiable visual confirmation required by NFR-3.
+
+  ## Risk Mitigation
+
+  | Risk | Mitigation |
+  | ---- | ---------- |
+  | Subpixel rendering causes residual overlap | mr-16 provides 12 px gap — well above subpixel error margins |
+  | Storybook story does not render ThemeToggle in the same context | Story documents the Panel margin visually; full overlap check is confirmed in app context manually |
+  | Future ThemeToggle size change re-introduces overlap | The 12 px gap and Tailwind utility class make any future adjustment easy to locate and update |

--- a/specs/043-add-repo-button-position/research.yaml
+++ b/specs/043-add-repo-button-position/research.yaml
@@ -1,0 +1,131 @@
+# Research Artifact (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: add-repo-button-position
+summary: >
+  Single-line Tailwind class change in features-canvas.tsx: replace mr-12 (48 px) with mr-16
+  (64 px) on the ReactFlow Panel so the Add Repository button clears the ThemeToggle's ~52 px
+  occupied zone with a comfortable 12 px gap. No libraries, schema changes, or architectural
+  decisions are required beyond choosing the correct spacing value.
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - Tailwind CSS
+  - '@xyflow/react (ReactFlow Panel)'
+  - React
+  - Next.js
+
+relatedLinks:
+  - https://tailwindcss.com/docs/margin
+  - https://reactflow.dev/api-reference/components/panel
+
+# Structured technology decisions
+decisions:
+  - title: 'Spacing mechanism — Tailwind utility class vs alternatives'
+    chosen: 'mr-16 Tailwind utility class on the ReactFlow Panel'
+    rejected:
+      - 'Inline style (style={{ marginRight: 64 }}) — works but violates FR-2 and the project utility-first CSS conventions; makes the value opaque to Tailwind tooling and purging.'
+      - 'Custom CSS class or CSS variable — unnecessary complexity for a standard spacing value already on the Tailwind scale; harder to grep and reason about.'
+    rationale: >
+      The project uses Tailwind throughout the presentation layer. All existing spacing on the
+      same Panel is expressed via mr-* utilities (currently mr-12). Staying on the Tailwind
+      spacing scale keeps the codebase consistent, satisfies FR-2 explicitly, and means the
+      value is immediately understandable to any contributor.
+
+  - title: 'Right-margin value — how much clearance to add'
+    chosen: 'mr-16 (64 px)'
+    rejected:
+      - 'mr-14 (56 px) — just 4 px beyond the 52 px ThemeToggle zone; functionally sufficient but visually tight and fragile if any rounding or subpixel rendering occurs.'
+      - 'mr-20 (80 px) — 28 px of clearance; more than necessary, pushes the button noticeably far from the edge and may look unbalanced on narrower viewports.'
+    rationale: >
+      The ThemeToggle (shadcn Button size="icon", 40x40 px) is positioned at right-3 (12 px
+      inset), so it occupies the rightmost ~52 px of the viewport. mr-16 = 64 px clears that
+      zone by 12 px — a gap that matches common UI breathing-room conventions (8–16 px between
+      interactive elements) without pushing the button excessively far left. This aligns with
+      the spec open-question resolution (mr-16 selected).
+
+  - title: 'Scope of change — single file vs shared layout adjustment'
+    chosen: 'Change only features-canvas.tsx (the Panel className)'
+    rejected:
+      - 'Move ThemeToggle inward in app-shell.tsx — would affect every page/view using AppShell; wider blast radius than needed.'
+      - 'Wrap the Panel in a container with padding in a parent component — unnecessary indirection; the Panel already accepts className directly.'
+    rationale: >
+      FR-3 explicitly restricts the fix to features-canvas.tsx. The Panel className prop is
+      the most direct and least-invasive injection point. Changing any shared layout component
+      risks unintended side-effects on other views.
+
+# Open questions (should be resolved by end of research)
+openQuestions: []
+
+# Markdown content (the full research document)
+content: |
+  ## Technology Decisions
+
+  ### 1. Spacing mechanism — Tailwind utility class vs alternatives
+
+  **Chosen:** `mr-16` Tailwind utility on the `<Panel>` element in `features-canvas.tsx`
+
+  **Rejected:**
+  - Inline style (`style={{ marginRight: 64 }}`) — violates FR-2; bypasses Tailwind tooling
+  - Custom CSS class / CSS variable — unnecessary indirection for a standard spacing value
+
+  **Rationale:** The project is utility-first throughout the presentation layer. Using an
+  existing Tailwind spacing class is idiomatic, immediately readable, and satisfies all
+  functional requirements without introducing new abstractions.
+
+  ### 2. Right-margin value — mr-14 vs mr-16 vs mr-20
+
+  **Chosen:** `mr-16` (64 px)
+
+  **Rejected:**
+  - `mr-14` (56 px) — only 4 px clearance beyond the 52 px ThemeToggle zone; too tight
+  - `mr-20` (80 px) — 28 px clearance; exceeds what is needed, may look unbalanced
+
+  **Rationale:** The ThemeToggle occupies ~52 px (40 px icon + 12 px right-3 inset). 64 px
+  provides a 12 px visual gap — comfortable, intentional, and consistent with common spacing
+  conventions between adjacent interactive elements.
+
+  ### 3. Scope of change
+
+  **Chosen:** Single class change in `features-canvas.tsx` only
+
+  **Rejected:**
+  - Adjusting `AppShell` / ThemeToggle position — wider blast radius, touches unrelated views
+  - Wrapping the Panel in an extra container — unnecessary nesting for a one-line fix
+
+  **Rationale:** FR-3 constrains the fix to `features-canvas.tsx`. The `<Panel>` element
+  already accepts a `className` prop that maps directly to the wrapper div CSS classes,
+  making this the minimal and correct injection point.
+
+  ## Library Analysis
+
+  | Library | Purpose | Decision | Reasoning |
+  | ------- | ------- | -------- | --------- |
+  | Tailwind CSS | Spacing utility (mr-16) | Use (already in project) | Standard utility class, no new dependency |
+  | @xyflow/react Panel | Positions the button in canvas | Use (already in project) | className prop accepted; no change to Panel API |
+
+  ## Security Considerations
+
+  None. This is a pure CSS/layout change with no data handling, authentication, or user input
+  involved. No new attack surface is introduced.
+
+  ## Performance Implications
+
+  None. A Tailwind margin class change has zero runtime cost. No re-renders, no additional
+  DOM nodes, no layout recalculations beyond what already occurs.
+
+  ## Architecture Notes
+
+  The fix lives entirely in the `presentation/web` layer. No domain, application, or
+  infrastructure code is touched. The change is a single class substitution on line 162 of
+  `features-canvas.tsx`:
+
+  ```diff
+  - <Panel position="top-right" className="mr-12">
+  + <Panel position="top-right" className="mr-16">
+  ```
+
+  Verification is via Storybook (`features-canvas.stories.tsx`) — visually confirm the button
+  no longer overlaps the ThemeToggle area.

--- a/specs/043-add-repo-button-position/spec.yaml
+++ b/specs/043-add-repo-button-position/spec.yaml
@@ -1,0 +1,131 @@
+# Feature Specification (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: add-repo-button-position
+number: 043
+branch: feat/043-add-repo-button-position
+oneLiner: Increase right margin on Add Repository button panel so it no longer overlaps the ThemeToggle
+userQuery: >
+  small fix, Add Repository button overlaps over dark mode switcher, need to move it bit left, do it fast, no deep analysis/research/req
+summary: >
+  The "Add Repository" button rendered inside a ReactFlow Panel at top-right in FeaturesCanvas
+  overlaps the ThemeToggle button (dark mode switcher) that is absolutely positioned in the
+  top-right corner of AppShell. Fix is a single Tailwind class change to increase the panel's
+  right margin so the two elements no longer collide.
+phase: Requirements
+sizeEstimate: S
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - React
+  - Next.js
+  - Tailwind CSS
+  - '@xyflow/react (ReactFlow Panel)'
+
+relatedLinks: []
+
+openQuestions:
+  - question: 'How much right margin should the Panel use to clear the ThemeToggle?'
+    resolved: true
+    options:
+      - option: 'mr-14 (56 px, 4 px gap)'
+        description: 'Minimal clearance: 56 px clears the 52 px ThemeToggle zone with a 4 px gap. Tight but functional.'
+        selected: false
+      - option: 'mr-16 (64 px, 12 px gap)'
+        description: 'Comfortable clearance: 64 px provides a 12 px breathing gap between button and toggle. Preferred for visual polish.'
+        selected: true
+      - option: 'mr-20 (80 px, 28 px gap)'
+        description: 'Generous clearance: pushes the button noticeably further left; more than needed and may look unbalanced.'
+        selected: false
+    selectionRationale: 'mr-16 (64 px) is recommended because it provides a comfortable 12 px gap beyond the ThemeToggle zone, matching common UI spacing conventions without pushing the button excessively far from the edge.'
+    answer: 'mr-16 (64 px, 12 px gap)'
+
+# Markdown content (the actual spec)
+content: |
+  ## Problem Statement
+
+  The "Add Repository" button is placed in a ReactFlow `<Panel position="top-right">` inside
+  `FeaturesCanvas` (`src/presentation/web/components/features/features-canvas/features-canvas.tsx`,
+  line 162). It currently has `className="mr-12"` (48 px right margin).
+
+  The ThemeToggle (dark mode switcher) is absolutely positioned at `top-3 right-3` (12 px from
+  the right edge) inside `AppShell`
+  (`src/presentation/web/components/layouts/app-shell/app-shell.tsx`, line 28). The toggle
+  uses shadcn `Button size="icon"` which renders as **40 × 40 px**, so it occupies the rightmost
+  ~52 px of the viewport. At `mr-12` (48 px) the Add Repository button's right edge sits inside
+  the toggle's area, causing visual overlap.
+
+  ## Success Criteria
+
+  - [ ] The "Add Repository" button and the ThemeToggle do not overlap at any viewport width ≥ 768 px
+  - [ ] The right edge of the Panel clears the ThemeToggle's 52 px occupied zone with visible gap
+  - [ ] No other UI elements are displaced or broken by the margin change
+  - [ ] Fix is contained to a single Tailwind class change in `features-canvas.tsx`
+  - [ ] Storybook story for `features-canvas` visually confirms the corrected layout
+
+  ## Functional Requirements
+
+  - **FR-1**: The ReactFlow `<Panel position="top-right">` in `FeaturesCanvas` MUST have a right margin that positions its right edge at least 56 px from the viewport's right edge (clearing the 52 px ThemeToggle zone).
+  - **FR-2**: The change MUST use an existing Tailwind spacing utility class (no custom CSS, no inline styles).
+  - **FR-3**: The fix MUST NOT modify `AppShell`, `ThemeToggle`, or any component outside of `features-canvas.tsx`.
+
+  ## Non-Functional Requirements
+
+  - **NFR-1**: The margin value MUST be chosen from the standard Tailwind spacing scale so it remains consistent with the project's existing utility-first CSS conventions.
+  - **NFR-2**: The fix MUST NOT introduce any visual regression in adjacent UI areas (header, sidebar, canvas controls).
+  - **NFR-3**: The change MUST be verifiable via Storybook (`features-canvas.stories.tsx`) without requiring a full browser run.
+
+  ## Product Questions & AI Recommendations
+
+  | # | Question | AI Recommendation | Rationale |
+  | - | -------- | ----------------- | --------- |
+  | 1 | How much right margin should the Panel use? | `mr-16` (64 px, 12 px gap) | Provides comfortable clearance beyond the 52 px ThemeToggle zone; consistent with common UI spacing conventions |
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `src/presentation/web/components/features/features-canvas/features-canvas.tsx` | Low | Change `mr-12` → `mr-16` on the ReactFlow Panel so the button clears the 52 px ThemeToggle zone |
+
+  ## Codebase Analysis
+
+  ### Project Structure
+
+  ```
+  src/presentation/web/
+  ├── components/
+  │   ├── layouts/
+  │   │   └── app-shell/app-shell.tsx        # ThemeToggle mounted here, absolute top-3 right-3
+  │   ├── features/
+  │   │   └── features-canvas/features-canvas.tsx  # Panel top-right with mr-12
+  │   └── common/
+  │       ├── add-repository-node/
+  │       │   └── add-repository-button.tsx  # The button component itself
+  │       └── theme-toggle/theme-toggle.tsx  # Dark mode switcher (size="icon" → 40 px)
+  ```
+
+  ### Architecture Patterns
+
+  Presentation layer only — no domain/application changes needed. The project uses
+  Clean Architecture; this fix is entirely in `presentation/web` and touches zero
+  business logic.
+
+  ### Relevant Technologies
+
+  - **Tailwind CSS** — spacing utilities (`mr-*`) control the panel offset.
+  - **@xyflow/react Panel** — positions its children relative to the ReactFlow viewport
+    canvas; `className` is passed through to the wrapper div.
+  - **shadcn Button size="icon"** — 40 × 40 px, the ThemeToggle occupies ≈52 px from
+    the right edge (40 px width + 12 px `right-3` inset).
+
+  ## Dependencies
+
+  - Existing Tailwind spacing scale (no new utilities needed).
+  - No changes to domain, application, or infrastructure layers.
+
+  ## Size Estimate
+
+  **S** — Single-line Tailwind class change in one file. Verification via Storybook
+  or visual inspection. No tests need updating (no behavioural change).

--- a/specs/043-add-repo-button-position/tasks.yaml
+++ b/specs/043-add-repo-button-position/tasks.yaml
@@ -1,0 +1,88 @@
+# Task Breakdown (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: add-repo-button-position
+summary: >
+  2 tasks in 1 phase: fix the Panel margin class in features-canvas.tsx, then update
+  the Storybook story to visually verify the corrected layout.
+
+# Relationships
+relatedFeatures: []
+technologies:
+  - Tailwind CSS
+  - '@xyflow/react (ReactFlow Panel)'
+  - React
+  - Storybook
+relatedLinks: []
+
+# Structured task list
+tasks:
+  - id: task-1
+    phaseId: phase-1
+    title: 'Fix Panel right margin in features-canvas.tsx'
+    description: >
+      Replace the mr-12 class with mr-16 on the ReactFlow <Panel position="top-right">
+      in features-canvas.tsx so the Add Repository button clears the ThemeToggle zone.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'The Panel element has className containing mr-16 (not mr-12)'
+      - 'No other className values on the Panel are changed'
+      - 'No other files are modified'
+    tdd:
+      red:
+        - >
+          In features-canvas.test.tsx (or existing test file), add a test that renders
+          FeaturesCanvas and asserts the Panel wrapper div has the class mr-16. Run the
+          test — it fails because the current class is mr-12.
+      green:
+        - >
+          In features-canvas.tsx line ~162, change mr-12 → mr-16 on the Panel className.
+          Re-run the test — it passes.
+      refactor:
+        - 'No refactor needed for a single class change. Confirm no lint errors.'
+    estimatedEffort: '10min'
+
+  - id: task-2
+    phaseId: phase-1
+    title: 'Update Storybook story to document corrected layout'
+    description: >
+      Update (or add a note/variant to) features-canvas.stories.tsx so the story
+      visually reflects the mr-16 panel position and confirms no overlap with the
+      ThemeToggle area.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'features-canvas.stories.tsx exists and includes a story that renders the Panel'
+      - 'Story renders without TypeScript or lint errors'
+      - 'Visual inspection in Storybook shows the Add Repository button does not overlap a simulated ThemeToggle zone at the top-right'
+    tdd:
+      red:
+        - >
+          Verify the existing story (if any) renders and shows the old mr-12 position
+          (or note the absence of a story). This is the baseline to replace/extend.
+      green:
+        - >
+          Update or create the Storybook story to render FeaturesCanvas with a mock
+          ThemeToggle overlay at top-right-3 (or a placeholder div) so the gap is
+          visually verifiable. Confirm the story compiles.
+      refactor:
+        - 'Remove any stale story variants that no longer apply. Confirm story titles are clear.'
+    estimatedEffort: '20min'
+
+# Total effort estimate
+totalEstimate: '30min'
+
+# Open questions
+openQuestions: []
+
+# Markdown content (the full tasks document)
+content: |
+  ## Summary
+
+  The implementation is a single phase with two sequential tasks. First, the one-line
+  Tailwind class change in `features-canvas.tsx` is made and verified with a focused
+  unit/render test asserting the correct class is present. Second, the Storybook story
+  is updated to provide a visual confirmation artefact, satisfying NFR-3 without
+  requiring a full browser run. No other files, layers, or dependencies are involved.

--- a/src/presentation/web/components/features/features-canvas/features-canvas.stories.tsx
+++ b/src/presentation/web/components/features/features-canvas/features-canvas.stories.tsx
@@ -608,3 +608,44 @@ export const InteractiveWithRepository: Story = {
     onRepositoryAdd: () => undefined,
   },
 };
+
+// Story to visually verify the Add Repository button does not overlap the ThemeToggle.
+// The simulated ThemeToggle (top-3 right-3, 40×40 px) is rendered as an overlay so
+// reviewers can confirm the mr-16 (64 px) gap keeps the Panel clear of the toggle zone.
+export const AddRepositoryButtonClearanceCheck: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ height: '100vh', position: 'relative' }}>
+        <Story />
+        {/* Simulated ThemeToggle at top-3 right-3 (same position as AppShell) */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 12,
+            right: 12,
+            width: 40,
+            height: 40,
+            background: 'rgba(255, 0, 0, 0.35)',
+            border: '2px dashed red',
+            borderRadius: 6,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 10,
+            pointerEvents: 'none',
+            zIndex: 50,
+          }}
+        >
+          Theme
+        </div>
+      </div>
+    ),
+  ],
+  args: {
+    nodes: repoFeatureNodes,
+    edges: repoFeatureEdges,
+    onNodeAction: () => undefined,
+    onNodeSettings: () => undefined,
+    onRepositorySelect: () => undefined,
+  },
+};

--- a/src/presentation/web/components/features/features-canvas/features-canvas.tsx
+++ b/src/presentation/web/components/features/features-canvas/features-canvas.tsx
@@ -159,7 +159,7 @@ export function FeaturesCanvas({
           <Background />
           <Controls />
           {onRepositorySelect ? (
-            <Panel position="top-right" className="mr-12">
+            <Panel position="top-right" className="mr-16">
               <AddRepositoryButton onSelect={onRepositorySelect} />
             </Panel>
           ) : null}

--- a/tests/unit/presentation/web/features/features-canvas/features-canvas.test.tsx
+++ b/tests/unit/presentation/web/features/features-canvas/features-canvas.test.tsx
@@ -83,6 +83,14 @@ describe('FeaturesCanvas', () => {
     expect(onRepositoryAdd).toHaveBeenCalledWith('repo-1');
   });
 
+  it('Panel has mr-16 right margin to clear the ThemeToggle zone', () => {
+    const { container } = render(
+      <FeaturesCanvas nodes={[mockNode]} edges={[]} onRepositorySelect={() => undefined} />
+    );
+    expect(container.querySelector('.mr-16')).toBeInTheDocument();
+    expect(container.querySelector('.mr-12')).not.toBeInTheDocument();
+  });
+
   it('renders toolbar when provided', () => {
     render(
       <FeaturesCanvas


### PR DESCRIPTION
## Summary

- Changes `mr-12` (48 px) → `mr-16` (64 px) on the ReactFlow `<Panel position="top-right">` in `FeaturesCanvas`
- This gives the "Add Repository" button a 12 px breathing gap beyond the ThemeToggle's 52 px occupied zone (40 px icon + 12 px `right-3` inset), eliminating the overlap
- Adds a Storybook story (`AddRepositoryButtonClearanceCheck`) that renders a red overlay box simulating the ThemeToggle so reviewers can visually verify clearance
- Adds a unit test asserting `.mr-16` is present and `.mr-12` is absent on the Panel

## Affected Files

| File | Change |
|------|--------|
| `src/presentation/web/components/features/features-canvas/features-canvas.tsx` | `mr-12` → `mr-16` on Panel |
| `src/presentation/web/components/features/features-canvas/features-canvas.stories.tsx` | New `AddRepositoryButtonClearanceCheck` story |
| `tests/unit/presentation/web/features/features-canvas/features-canvas.test.tsx` | New margin regression test |

## Test plan

- [ ] Unit tests pass (`pnpm test:unit`)
- [ ] Storybook `AddRepositoryButtonClearanceCheck` story shows no overlap between Panel and red ThemeToggle overlay
- [ ] No other UI elements displaced by the margin change

🤖 Generated with [Claude Code](https://claude.com/claude-code)