### PR TITLE
chore(config): add claude code commit convention rules

### DIFF
--- a/.claude/rules/commit-conventions.md
+++ b/.claude/rules/commit-conventions.md
@@ -1,0 +1,14 @@
+Commit message should follow Conventional Commits
+<type>(<scope>): <lowercase subject>
+
+## Rules
+
+1. Must be one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+1. scope-enum Should be: specs, shep-kit, cli, tui, web, api, domain, agents, deployment, tsp, deps, config, dx, release, ci
+1. Must be lower-case (no capitals: pr not PR)
+1. Cannot be empty
+1. No trailing period
+1. Max 72 chars
+1. header-max-length 100 chars
+1. body/footer-leading-blank Must have blank line before body/footer
+1. body/footer-max-line-length 100 chars


### PR DESCRIPTION
## Summary
- Adds `.claude/rules/commit-conventions.md` with commit message rules for Claude Code
- Enforces Conventional Commits format, valid scopes, lowercase subjects, and line length limits

## Test plan
- [x] Verify the rules file is correctly formatted
- [x] Confirm no other files are included in the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)