### PR TITLE
fix(domain): backfill ci_fix columns missing after migration rebase

### DIFF
--- a/tests/integration/infrastructure/persistence/sqlite/migration-015.test.ts
+++ b/tests/integration/infrastructure/persistence/sqlite/migration-015.test.ts
@@ -25,8 +25,8 @@ describe('Migration 015 — onboarding and approval gate defaults', () => {
     db.close();
   });
 
-  it('should set LATEST_SCHEMA_VERSION to 20', () => {
-    expect(LATEST_SCHEMA_VERSION).toBe(20);
+  it('should set LATEST_SCHEMA_VERSION to 21', () => {
+    expect(LATEST_SCHEMA_VERSION).toBe(21);
   });
 
   it('should add all 5 new columns to settings table', () => {


### PR DESCRIPTION
## Summary
- Migration 19 was reordered during a rebase — old version added `parent_id`, new version adds `ci_fix_attempts`/`ci_fix_history`
- Databases that ran the old migration 19 had `user_version=19`, so the new migration 19 was skipped, leaving `ci_fix_attempts` and `ci_fix_history` columns missing
- Adds conditional backfill in migration 20 (for databases at v19) and a new migration 21 (for databases already at v20)

## Test plan
- [x] All 2534 unit tests pass
- [x] All 354 integration tests pass (including `list-features` and `sqlite-feature` tests that were previously failing)
- [ ] Verify UI no longer shows "table features has no column named ci_fix_attempts" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)