### PR TITLE
feat(web): display pr metadata in feature drawer with shared ci-status-badge

### DIFF
--- a/specs/044-pr-info-feature-drawer/feature.yaml
+++ b/specs/044-pr-info-feature-drawer/feature.yaml
@@ -1,0 +1,39 @@
+feature:
+  id: 044-pr-info-feature-drawer
+  name: pr-info-feature-drawer
+  number: 44
+  branch: feat/044-pr-info-feature-drawer
+  lifecycle: research
+  createdAt: '2026-02-25T15:25:30Z'
+status:
+  phase: implementation-complete
+  progress:
+    completed: 8
+    total: 8
+    percentage: 100
+  currentTask: null
+  lastUpdated: '2026-02-25T15:53:30.375Z'
+  lastUpdatedBy: feature-agent:implement
+  completedPhases:
+    - analyze
+    - requirements
+    - research
+    - plan
+    - phase-1
+    - phase-2
+    - phase-3
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+tasks:
+  current: null
+  blocked: []
+  failed: []
+checkpoints:
+  - phase: feature-created
+    completedAt: '2026-02-25T15:25:30Z'
+    completedBy: feature-agent
+errors:
+  current: null
+  history: []

--- a/specs/044-pr-info-feature-drawer/plan.yaml
+++ b/specs/044-pr-info-feature-drawer/plan.yaml
@@ -1,0 +1,149 @@
+# Implementation Plan (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: pr-info-feature-drawer
+summary: >
+  Extract CiStatusBadge into a shared component, extend FeatureNodeData with an optional PR
+  field, pipe PR data through the server component, and render a PR metadata card in the
+  feature drawer. Implementation follows three phases: shared component extraction, data
+  plumbing, and UI rendering with tests and stories at each step.
+
+relatedFeatures: []
+technologies:
+  - React (Next.js App Router, server components)
+  - TypeScript
+  - Tailwind CSS
+  - shadcn/ui (Badge component)
+  - lucide-react (ExternalLink, GitCommitHorizontal, CheckCircle2, Loader2, XCircle icons)
+  - Vitest + React Testing Library (unit tests)
+  - Storybook (component stories)
+relatedLinks: []
+
+phases:
+  - id: phase-1
+    name: 'Extract CiStatusBadge to shared component'
+    description: >
+      Move CiStatusBadge from merge-review.tsx into a new shared directory at
+      components/common/ci-status-badge/ with barrel export, unit tests, and Storybook stories.
+      Update merge-review.tsx to import from the shared location and clean up unused imports.
+      This phase comes first because the feature-drawer PR section depends on this shared
+      component, and extracting it first ensures merge-review is not regressed before adding
+      the new consumer.
+    parallel: false
+
+  - id: phase-2
+    name: 'Data plumbing — extend FeatureNodeData and map PR data'
+    description: >
+      Add the optional pr field to the FeatureNodeData interface in feature-node-state-config.ts
+      and map feature.pr into FeatureNodeData in page.tsx using a conditional spread. This phase
+      establishes the data pipeline from domain to presentation before building the UI, following
+      the data-down pattern.
+    parallel: false
+
+  - id: phase-3
+    name: 'Render PrInfoSection in feature drawer'
+    description: >
+      Add the PrInfoSection sub-component to feature-drawer.tsx that renders a bordered PR
+      metadata card (number link, status badge, CI status, commit hash) between the Status and
+      Details sections. Add comprehensive unit tests and Storybook stories covering all PR state
+      combinations and edge cases.
+    parallel: false
+
+filesToCreate:
+  - src/presentation/web/components/common/ci-status-badge/ci-status-badge.tsx
+  - src/presentation/web/components/common/ci-status-badge/index.ts
+  - src/presentation/web/components/common/ci-status-badge/ci-status-badge.stories.tsx
+  - tests/unit/presentation/web/components/common/ci-status-badge/ci-status-badge.test.tsx
+
+filesToModify:
+  - src/presentation/web/components/common/merge-review/merge-review.tsx
+  - src/presentation/web/components/common/feature-node/feature-node-state-config.ts
+  - src/presentation/web/app/page.tsx
+  - src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
+  - src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx
+  - tests/unit/presentation/web/components/common/feature-drawer/feature-drawer.test.tsx
+
+openQuestions: []
+
+content: |
+  ## Architecture Overview
+
+  This feature is entirely within the presentation layer. The data flow is:
+
+  ```
+  Domain Feature.pr (PullRequest)
+    → page.tsx server component (maps to FeatureNodeData.pr subset)
+    → ControlCenter → FeatureDrawer (receives via selectedNode prop)
+    → PrInfoSection sub-component (renders PR card)
+    → CiStatusBadge shared component (renders CI status)
+  ```
+
+  No domain, application, or infrastructure changes are needed. The PullRequest type, PrStatus
+  enum, and CiStatus enum already exist in the domain generated output. The implementation
+  adds one new shared component (CiStatusBadge extraction), one new type field (FeatureNodeData.pr),
+  one mapping line (page.tsx), and one new sub-component (PrInfoSection in feature-drawer.tsx).
+
+  The feature-drawer.tsx file currently contains 4 private sub-components (StateBadge,
+  DetailsSection, DetailRow, DrawerActions) across 233 lines. Adding PrInfoSection (~50-60 lines)
+  keeps the file under 300 lines and follows the established colocated sub-component pattern.
+
+  ## Key Design Decisions
+
+  **1. CiStatusBadge extraction to `components/common/ci-status-badge/`**
+  All 28 existing shared components under `components/common/` use the directory-per-component
+  pattern with a barrel `index.ts`. CiStatusBadge is a ~25-line pure function mapping CiStatus
+  to a styled Badge — ideal for extraction. Both merge-review and feature-drawer import from
+  the same shared location, eliminating duplication. After extraction, merge-review.tsx drops
+  its CheckCircle2 and XCircle icon imports (only used by CiStatusBadge) and its CiStatus enum
+  import, but retains Loader2 (used by DrawerActionBar approve icon).
+
+  **2. Inline PR type on FeatureNodeData (not reusing MergeReviewPr)**
+  FeatureNodeData already uses inline optional types for its fields (agentType, blockedBy, etc.).
+  Defining `pr?: { url: string; number: number; status: PrStatus; ciStatus?: CiStatus;
+  commitHash?: string }` inline keeps the type colocated and avoids coupling feature-drawer
+  to merge-review. The shape is identical to MergeReviewPr but independently defined.
+
+  **3. PrInfoSection as private sub-component in feature-drawer.tsx**
+  Matches the existing pattern where StateBadge, DetailsSection, DetailRow, and DrawerActions
+  are all private functions in the same file. The section is guarded by
+  `if (!selectedNode.pr) return null`, matching the conditional rendering used by DetailsSection
+  (hasAnyDetail guard) and the progress bar (progress > 0 guard). Positioned between Status
+  and Details, separated by Separator components.
+
+  **4. PR status badge as inline switch in PrInfoSection**
+  With 3 PrStatus values and one consumer, extracting a shared PrStatusBadge would be premature.
+  A switch/map inline in PrInfoSection maps: Open → blue (bg-blue-50 text-blue-700),
+  Merged → purple (bg-purple-50 text-purple-700), Closed → red (bg-red-50 text-red-700).
+  This uses the same `bg-{color}-50 text-{color}-700` pattern established by CiStatusBadge.
+
+  **5. Conditional spread for PR data mapping in page.tsx**
+  Follows the existing pattern at lines 104-106 of page.tsx:
+  `...(feature.pr && { pr: { url, number, status, ciStatus, commitHash } })`. Only
+  display-relevant fields are extracted, excluding ciFixAttempts and ciFixHistory.
+
+  **6. data-testid="feature-drawer-pr" for the PR section**
+  Follows the existing `feature-drawer-{section}` naming convention (header, status, progress,
+  details, delete). Content within the section is queried by text/role as done elsewhere.
+
+  ## Implementation Strategy
+
+  Phase 1 (CiStatusBadge extraction) comes first because it is the foundation that both
+  merge-review and the new feature-drawer PR section depend on. Extracting and testing it
+  in isolation catches regressions early before adding a second consumer.
+
+  Phase 2 (data plumbing) adds the type and mapping. It has no visual impact and is a small,
+  safe change. The type must exist before the UI can consume it.
+
+  Phase 3 (UI rendering) builds the PrInfoSection last, when the shared component and data
+  pipeline are both in place. Tests and stories are written alongside the component, following
+  TDD red-green-refactor cycles.
+
+  ## Risk Mitigation
+
+  | Risk | Mitigation |
+  | ---- | ---------- |
+  | Merge-review regression after CiStatusBadge extraction | Run existing merge-review tests/stories after extraction; TypeScript compiler catches broken imports |
+  | Unused imports left in merge-review after extraction | Research identified exact cleanup: remove CheckCircle2, XCircle, CiStatus; keep Loader2 |
+  | PR data undefined for features without PRs | Conditional render `if (!pr) return null` ensures zero DOM when no PR; all existing tests pass unchanged |
+  | Badge color inconsistency across light/dark themes | Using the same `bg-{color}-50 text-{color}-700` pattern as CiStatusBadge ensures consistency |
+  | Feature-drawer.tsx growing too large | Adding ~50-60 lines keeps file under 300 total, well within acceptable range |

--- a/specs/044-pr-info-feature-drawer/research.yaml
+++ b/specs/044-pr-info-feature-drawer/research.yaml
@@ -1,0 +1,379 @@
+# Research Artifact (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: pr-info-feature-drawer
+summary: >
+  Technical research for displaying PR metadata in the feature drawer. The implementation
+  leverages existing domain types (PullRequest, PrStatus, CiStatus), extracts the CiStatusBadge
+  from merge-review into a shared component, extends FeatureNodeData with an optional pr field,
+  and adds a PrInfoSection sub-component to feature-drawer.tsx following established codebase
+  patterns for conditional rendering, styling, and testing.
+
+relatedFeatures: []
+
+technologies:
+  - React 19 (Next.js App Router, server components)
+  - TypeScript 5
+  - Tailwind CSS 4
+  - shadcn/ui (Badge component)
+  - lucide-react (ExternalLink, GitCommitHorizontal, CheckCircle2, Loader2, XCircle icons)
+  - Vitest + React Testing Library (unit tests)
+  - Storybook 8 (component stories)
+
+relatedLinks: []
+
+decisions:
+  - title: 'CiStatusBadge extraction location'
+    chosen: 'New file at components/common/ci-status-badge/ci-status-badge.tsx with index.ts barrel export'
+    rejected:
+      - >
+        Flat file at components/common/ci-status-badge.tsx (no directory) — rejected because every
+        existing shared component in components/common/ follows the directory-with-index pattern
+        (e.g., drawer-action-bar/, elapsed-time/, empty-state/). A flat file would break the
+        established convention and make it harder to add tests or stories colocated later.
+      - >
+        Keep CiStatusBadge in merge-review and re-export from merge-review/index.ts — rejected
+        because it couples a generic presentational component to the merge-review feature. The
+        feature-drawer would import from merge-review, creating an unnatural dependency between
+        two peer components. Shared components should live in their own directory under common/.
+    rationale: >
+      The codebase consistently uses directory-per-component under components/common/ with an
+      index.ts barrel export. Confirmed by examining 28 existing directories (action-button/,
+      drawer-action-bar/, elapsed-time/, empty-state/, feature-drawer/, merge-review/, etc.).
+      Creating ci-status-badge/ follows this exact pattern. The CiStatusBadge is a ~25-line pure
+      presentational component with no hooks or state — it takes a CiStatus enum and returns a
+      styled Badge. Both merge-review.tsx and feature-drawer.tsx will import from
+      @/components/common/ci-status-badge.
+
+  - title: 'PR data type for FeatureNodeData'
+    chosen: 'Inline optional type on FeatureNodeData with a presentation-layer subset: { url: string; number: number; status: PrStatus; ciStatus?: CiStatus; commitHash?: string }'
+    rejected:
+      - >
+        Reuse domain PullRequest type directly — rejected because domain PullRequest includes
+        ciFixAttempts and ciFixHistory fields that are irrelevant to the drawer display. Importing
+        the full domain type into a presentation-layer interface creates an unnecessary coupling
+        and exposes implementation details (fix attempt history) to the UI layer.
+      - >
+        Create a new FeatureNodePr interface in feature-node-state-config.ts — rejected because
+        while it would be slightly more reusable, there is currently only one consumer (feature
+        drawer) and the type is small (5 fields). Creating a separate named interface adds
+        indirection with no current benefit. If a second consumer needs the same shape, extraction
+        is trivial later.
+    rationale: >
+      The existing pattern in the codebase is to define field types inline on FeatureNodeData
+      (see agentType?: AgentTypeValue, blockedBy?: string). The PR data is a small subset of
+      the domain PullRequest type, specifically excluding ciFixAttempts and ciFixHistory which
+      are operational data not displayed in the drawer. This keeps the presentation layer
+      decoupled from domain internals. The MergeReviewPr type in merge-review-config.ts uses
+      the same subset pattern (url, number, status, commitHash?, ciStatus?) confirming this
+      approach is consistent with codebase conventions.
+
+  - title: 'PR status badge styling approach'
+    chosen: 'Map PrStatus enum values to Badge variant/className combinations inline in the PrInfoSection component'
+    rejected:
+      - >
+        Create a dedicated PrStatusBadge shared component (similar to CiStatusBadge) — rejected
+        because the PR status badge has only 3 cases, each is a single Badge with different
+        className props, and there is currently only one consumer (feature drawer). The merge-review
+        component renders PR status as a simple Badge variant="outline" without color coding.
+        Extracting a shared component for 3 inline badges would be premature abstraction.
+      - >
+        Use Badge variants (default, secondary, destructive) to represent PR statuses — rejected
+        because shadcn/ui's built-in Badge variants don't include a purple variant for "Merged"
+        status. Custom className overrides are needed regardless, so using variants provides no
+        benefit over direct className styling. The CiStatusBadge already uses the className
+        pattern (bg-green-50 text-green-700, etc.) establishing the precedent.
+    rationale: >
+      The CiStatusBadge pattern uses a switch statement with inline Badge + className for each
+      status. PR status is simpler (3 values, no icons needed) and has only one consumer in the
+      drawer. A switch or object map inline in PrInfoSection keeps the code colocated with its
+      only consumer. PrStatus color mapping: Open → blue (bg-blue-50 text-blue-700), Merged →
+      purple (bg-purple-50 text-purple-700), Closed → red (bg-red-50 text-red-700). This matches
+      the semantic color scale pattern used throughout the codebase.
+
+  - title: 'PrInfoSection placement and rendering strategy'
+    chosen: 'Render PrInfoSection as a sub-component inside feature-drawer.tsx, positioned between Status section and DetailsSection, guarded by if (selectedNode.pr)'
+    rejected:
+      - >
+        Create PrInfoSection as a separate file in the feature-drawer/ directory — rejected
+        because the existing pattern is to define sub-components (StateBadge, DetailsSection,
+        DetailRow, DrawerActions) as private functions within feature-drawer.tsx. The file is
+        currently 233 lines; adding ~50-60 lines for PrInfoSection keeps it under 300 lines
+        which is reasonable for a component file with related sub-components.
+      - >
+        Render PR info as DetailRow entries inside the existing DetailsSection — rejected because
+        the spec explicitly requires a bordered card visual treatment matching merge-review, and
+        DetailRow renders simple label-value text pairs without card styling. Mixing card-styled
+        PR info with plain text details would be visually inconsistent and conflate conceptually
+        different information (PR metadata vs feature implementation details).
+    rationale: >
+      Following the established pattern in feature-drawer.tsx where StateBadge, DetailsSection,
+      DetailRow, and DrawerActions are all private sub-components in the same file. The
+      PrInfoSection renders only when pr data exists (conditional render, not CSS hidden),
+      matching the pattern used by DetailsSection (hasAnyDetail guard) and the progress bar
+      (progress > 0 guard). Position between Status and Details follows the information hierarchy
+      specified in the requirements: state → PR → details.
+
+  - title: 'PR data mapping in page.tsx server component'
+    chosen: 'Conditional spread pattern: ...(feature.pr && { pr: { url, number, status, ciStatus, commitHash } })'
+    rejected:
+      - >
+        Map all PullRequest fields wholesale with spread: ...(feature.pr && { pr: feature.pr }) —
+        rejected because this would pass ciFixAttempts and ciFixHistory to the presentation layer.
+        While harmless at runtime (React ignores unknown props, FeatureNodeData has [key: string]:
+        unknown), it leaks domain implementation details and increases the serialized data size
+        sent from server component to client component unnecessarily.
+      - >
+        Use a separate mapPrData() helper function — rejected because the mapping is a simple
+        5-field destructure. The existing pattern in page.tsx uses inline conditional spreads
+        for optional fields (agentType, errorMessage, blockedBy). A helper function for such a
+        small mapping adds indirection without benefit.
+    rationale: >
+      The existing page.tsx already uses this exact pattern for 3 other optional fields:
+      ...(run?.agentType && { agentType: ... }), ...(run?.error && { errorMessage: ... }),
+      ...(blockedBy && { blockedBy }). Adding ...(feature.pr && { pr: { ... } }) is perfectly
+      consistent. The destructured subset ensures only display-relevant fields reach the client.
+
+  - title: 'Test data-testid strategy for PR section'
+    chosen: 'Use data-testid="feature-drawer-pr" on the PR section container, matching the existing naming convention'
+    rejected:
+      - >
+        Use role-based queries only (getByRole, getByText) — rejected because the existing test
+        file consistently uses data-testid for section-level containers (feature-drawer-header,
+        feature-drawer-status, feature-drawer-progress, feature-drawer-details, feature-drawer-delete).
+        Role-based queries are used for interactive elements (buttons, links) but sections use testids.
+      - >
+        Use more granular testids for each PR field (feature-drawer-pr-number, feature-drawer-pr-status,
+        etc.) — rejected because the existing pattern uses a single testid per section and then queries
+        content within. The PR section has enough distinct text content (PR number, status text, commit
+        hash) to be testable without additional testids.
+    rationale: >
+      The existing test file uses a consistent naming convention: feature-drawer-{section}. Adding
+      feature-drawer-pr follows this pattern. Tests can then use getByTestId('feature-drawer-pr')
+      for visibility checks and getByText/getByRole for content assertions within the section.
+      This matches the approach used for feature-drawer-details and feature-drawer-delete.
+
+openQuestions:
+  - question: 'Should the MergeReviewPr type be reused or should a new type be defined?'
+    resolved: true
+    options:
+      - option: Define inline type on FeatureNodeData
+        description: >
+          Add the pr field as an inline optional type directly on the FeatureNodeData interface.
+          Keeps the type colocated with its consumer, avoids cross-component imports, and follows
+          the existing pattern where FeatureNodeData fields use inline types or simple type aliases.
+          The 5-field type is small enough not to warrant a separate interface.
+        selected: true
+      - option: Reuse MergeReviewPr from merge-review-config.ts
+        description: >
+          Import MergeReviewPr type which has the exact same shape (url, number, status,
+          commitHash?, ciStatus?). Avoids type duplication but creates a dependency from
+          feature-node-state-config.ts to merge-review-config.ts. Since these are sibling
+          components, this coupling is undesirable and would make merge-review a prerequisite
+          for feature-drawer compilation.
+        selected: false
+      - option: Create a shared FeatureNodePr interface in a separate types file
+        description: >
+          Extract the PR type into a shared types file (e.g., components/common/types.ts) that
+          both feature-drawer and merge-review could reference. More formal but adds a new file
+          and abstraction layer for a 5-field type with only two consumers. Premature for the
+          current scope.
+        selected: false
+    selectionRationale: >
+      Inline type definition is the simplest approach and follows the existing FeatureNodeData
+      pattern. The type is 5 fields — small enough to define inline. MergeReviewPr reuse would
+      create an undesirable dependency between sibling components. A shared types file is
+      premature when there are only two consumers and the type is trivial. If a third consumer
+      emerges, extraction is trivial.
+
+  - question: 'How should the feature-drawer Storybook stories be structured for PR variations?'
+    resolved: true
+    options:
+      - option: Add new story fixtures and per-variant stories to the existing stories file
+        description: >
+          Add PR data fixtures (doneWithPrData, doneWithPartialPrData) alongside existing fixtures
+          and add new stories (DoneWithPr, DoneWithPartialPr, PrStatusMerged, PrStatusOpen, etc.)
+          following the same DrawerTrigger pattern. Keeps all feature-drawer stories in one file
+          and follows the existing organization.
+        selected: true
+      - option: Create a separate feature-drawer-pr.stories.tsx file
+        description: >
+          Isolate PR-specific stories in their own file. Keeps the existing stories file untouched
+          but creates a second stories file in the same directory. This is unusual in the codebase —
+          no existing component has multiple .stories.tsx files.
+        selected: false
+      - option: Add an interactive matrix story that cycles through PrStatus values
+        description: >
+          Create an AllPrStatuses interactive story similar to AllStates/AllLifecycles. While
+          comprehensive, PR status is a simpler dimension (3 values) and the interactive approach
+          is heavier than needed. Individual per-status stories with DrawerTrigger are clearer
+          for documentation purposes.
+        selected: false
+    selectionRationale: >
+      Adding to the existing stories file follows the established pattern — every component has
+      exactly one .stories.tsx file in the codebase. New fixtures and stories slot into the
+      existing file structure naturally. The DrawerTrigger wrapper component is already available
+      for reuse. An interactive matrix is overkill for 3 PR status values.
+
+  - question: 'Should the CiStatusBadge shared component have its own Storybook story?'
+    resolved: true
+    options:
+      - option: Yes, create a ci-status-badge.stories.tsx in the new shared component directory
+        description: >
+          Follow the MANDATORY Storybook stories rule. Every web UI component MUST have a
+          colocated .stories.tsx file. CiStatusBadge is a new shared component, so it needs
+          stories. Stories document all 3 CiStatus variants (Success, Pending, Failure) and
+          serve as living documentation. This is also useful for the component library.
+        selected: true
+      - option: No, rely on consumer stories (merge-review and feature-drawer stories)
+        description: >
+          The component is already visually tested through merge-review stories and will be
+          tested through new feature-drawer stories. However, this violates the MANDATORY rule
+          that every web UI component must have colocated stories. It also makes it harder to
+          review the component in isolation.
+        selected: false
+      - option: Add stories later as a follow-up task
+        description: >
+          Defer story creation to avoid scope creep. However, the CLAUDE.md rules state
+          "Commits without stories will be rejected" — deferral risks blocking the PR.
+        selected: false
+    selectionRationale: >
+      CLAUDE.md states "MANDATORY — Storybook stories: Every web UI component MUST have a
+      colocated .stories.tsx file. Commits without stories will be rejected." Since CiStatusBadge
+      is being extracted into a new shared component directory, it becomes a first-class component
+      that requires its own stories. The stories are trivial (~30 lines for 3 variants) and
+      provide valuable isolated documentation.
+
+content: |
+  ## Technology Decisions
+
+  ### 1. CiStatusBadge Extraction Location
+
+  **Chosen:** New directory at `components/common/ci-status-badge/` with `ci-status-badge.tsx` and `index.ts` barrel export.
+
+  **Rejected:**
+  - Flat file at `components/common/ci-status-badge.tsx` — breaks the directory-per-component convention used by all 28 existing shared components under `common/`.
+  - Re-export from `merge-review/index.ts` — creates unnatural dependency; shared components should live independently.
+
+  **Rationale:** Codebase convention is directory-per-component with barrel export. The component is a ~25-line pure function mapping CiStatus enum to styled Badge. Both merge-review and feature-drawer import from `@/components/common/ci-status-badge`.
+
+  ### 2. PR Data Type for FeatureNodeData
+
+  **Chosen:** Inline optional type on `FeatureNodeData` — `pr?: { url: string; number: number; status: PrStatus; ciStatus?: CiStatus; commitHash?: string }`.
+
+  **Rejected:**
+  - Reuse domain `PullRequest` directly — leaks `ciFixAttempts` and `ciFixHistory` to presentation layer.
+  - Reuse `MergeReviewPr` — creates cross-component dependency between sibling components.
+
+  **Rationale:** Follows existing pattern where FeatureNodeData fields use inline types. The 5-field subset is the same shape as MergeReviewPr but defined independently for decoupling.
+
+  ### 3. PR Status Badge Styling
+
+  **Chosen:** Inline switch/map in PrInfoSection with Badge + className overrides per PrStatus value.
+
+  **Rejected:**
+  - Dedicated PrStatusBadge shared component — premature abstraction for 3 simple Badge renders with one consumer.
+  - Badge variant props — shadcn/ui lacks a purple variant for Merged; className overrides needed regardless.
+
+  **Rationale:** Follows CiStatusBadge pattern (switch + inline className). Color mapping: Open → blue, Merged → purple, Closed → red.
+
+  ### 4. PrInfoSection Placement
+
+  **Chosen:** Private sub-component inside `feature-drawer.tsx`, positioned between Status and DetailsSection, guarded by `if (selectedNode.pr)`.
+
+  **Rejected:**
+  - Separate file — breaks the existing pattern of colocated sub-components in feature-drawer.tsx.
+  - DetailRow entries — cannot achieve bordered card visual treatment matching merge-review.
+
+  **Rationale:** Matches StateBadge, DetailsSection, DetailRow, DrawerActions pattern. File stays under 300 lines.
+
+  ### 5. Server Component Data Mapping
+
+  **Chosen:** Conditional spread: `...(feature.pr && { pr: { url, number, status, ciStatus, commitHash } })`.
+
+  **Rejected:**
+  - Wholesale spread `{ pr: feature.pr }` — leaks operational domain fields.
+  - Helper function — unnecessary for 5-field inline destructure.
+
+  **Rationale:** Matches existing page.tsx pattern for agentType, errorMessage, blockedBy optional fields.
+
+  ### 6. Test Data-TestID Strategy
+
+  **Chosen:** `data-testid="feature-drawer-pr"` on PR section container.
+
+  **Rejected:**
+  - Role-based queries only — inconsistent with existing section-level testid pattern.
+  - Granular per-field testids — unnecessary given distinct text content within section.
+
+  **Rationale:** Follows `feature-drawer-{section}` convention (header, status, progress, details, delete → pr).
+
+  ## Library Analysis
+
+  | Library | Purpose | Decision | Reasoning |
+  | ------- | ------- | -------- | --------- |
+  | `@shepai/core/domain/generated/output` (PrStatus, CiStatus) | Enum types for PR and CI status | Use | Already generated by TypeSpec, already imported in merge-review. Provides type-safe exhaustive switch. |
+  | `shadcn/ui Badge` | Status badge rendering | Use | Already used in merge-review for CiStatusBadge. Provides consistent styling foundation. |
+  | `lucide-react` (ExternalLink, GitCommitHorizontal, CheckCircle2, Loader2, XCircle) | Icons for PR link, commit hash, CI status | Use | Already installed and used in merge-review.tsx. Same icon set, same size patterns (h-3.5 w-3.5). |
+  | `shadcn/ui Separator` | Visual divider between sections | Use | Already used between Status/Details sections in feature-drawer.tsx. |
+  | No new libraries needed | — | — | All required dependencies already exist in the project. |
+
+  ## Security Considerations
+
+  - **External link safety:** PR URL renders as an `<a>` tag with `target="_blank"` and `rel="noopener noreferrer"`. This matches the exact pattern in merge-review.tsx (line 127) and prevents the opened page from accessing `window.opener`. No changes needed.
+  - **XSS via PR data:** PR number is rendered as a number, PR status as an enum value (not arbitrary string), commit hash is sliced to 7 chars and rendered in a `<code>` tag. All values come from the domain model which is populated by the GitHub API adapter. React's JSX escaping prevents injection. No additional sanitization needed.
+  - **URL validation:** The PR URL comes from GitHub's API via the domain layer and is not user-editable in the UI. It's rendered as an href in an anchor tag. React does not execute `javascript:` URIs in href attributes by default, but the domain adapter already validates URLs. No additional validation needed in the presentation layer.
+
+  ## Performance Implications
+
+  - **Zero cost when no PR data:** The PrInfoSection uses conditional rendering (`if (!pr) return null`), meaning zero DOM nodes are created for features without PR data. This is the same pattern used by DetailsSection and the progress bar.
+  - **Minimal data transfer:** The pr field adds ~100-150 bytes to FeatureNodeData serialization for features with PRs (url + number + status + optional ciStatus + optional commitHash). This is negligible compared to existing feature data.
+  - **No new network requests:** PR data is already fetched as part of the Feature domain model in the server component. The mapping is a simple object spread, not an additional query.
+  - **CiStatusBadge extraction:** Moving the component to a shared file has zero runtime cost — it's the same code, just imported from a different path. Tree-shaking remains effective.
+
+  ## Architecture Notes
+
+  ### Data Flow
+  ```
+  Domain Feature (with pr?: PullRequest)
+    → page.tsx server component (maps to FeatureNodeData.pr subset)
+    → ControlCenter client component (passes as node data)
+    → FeatureDrawer (receives via selectedNode prop)
+    → PrInfoSection sub-component (renders PR card)
+  ```
+
+  ### Files Modified (9 total)
+
+  1. **`feature-node-state-config.ts`** — Add optional `pr` field to FeatureNodeData interface (~5 lines). Import PrStatus, CiStatus from domain.
+  2. **`page.tsx`** — Add conditional spread for feature.pr mapping (~3 lines).
+  3. **`ci-status-badge/ci-status-badge.tsx`** (new) — Extract CiStatusBadge from merge-review (~25 lines moved).
+  4. **`ci-status-badge/index.ts`** (new) — Barrel export (~1 line).
+  5. **`ci-status-badge/ci-status-badge.stories.tsx`** (new) — Stories for all 3 CiStatus variants (~30-40 lines).
+  6. **`merge-review.tsx`** — Replace local CiStatusBadge with import from shared component. Remove unused icon imports.
+  7. **`feature-drawer.tsx`** — Add PrInfoSection sub-component with bordered card layout (~50-60 lines).
+  8. **`feature-drawer.stories.tsx`** — Add PR data fixtures and 4+ new stories (~50-60 lines).
+  9. **`feature-drawer.test.tsx`** — Add PR section test suite with 8+ test cases (~80-100 lines).
+
+  ### Key Patterns to Follow
+
+  - **Conditional rendering:** `{condition ? <Component /> : null}` (not `{condition && <Component />}`)
+  - **Badge styling:** `border-transparent bg-{color}-50 text-{color}-700 hover:bg-{color}-50`
+  - **Icon sizing:** `h-3.5 w-3.5` for inline badge icons, `h-4 w-4` for section header icons
+  - **Section spacing:** `space-y-3 px-4 py-3` inside bordered cards
+  - **Card borders:** `border-border rounded-lg border`
+  - **Label text:** `text-muted-foreground text-xs font-medium`
+  - **Test organization:** `describe('PR info section', () => { ... })` nested under main describe
+  - **Story organization:** PR fixtures near existing fixtures, stories grouped with a comment header
+
+  ### Merge-Review Import Cleanup
+
+  After extracting CiStatusBadge, merge-review.tsx needs import cleanup:
+  - `CheckCircle2` — ONLY used in CiStatusBadge → remove from merge-review imports
+  - `Loader2` — used in CiStatusBadge AND DrawerActionBar approve icon → keep in merge-review imports
+  - `XCircle` — ONLY used in CiStatusBadge → remove from merge-review imports
+  - `CiStatus` enum import — ONLY used for CiStatusBadge prop type → remove from merge-review imports
+
+  The merge-review.tsx file will add an import for CiStatusBadge from `@/components/common/ci-status-badge`.
+
+  ---
+
+  _Research completed — proceed with planning phase_

--- a/specs/044-pr-info-feature-drawer/spec.yaml
+++ b/specs/044-pr-info-feature-drawer/spec.yaml
@@ -1,0 +1,251 @@
+# Feature Specification (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: pr-info-feature-drawer
+number: 044
+branch: feat/044-pr-info-feature-drawer
+oneLiner: Display PR metadata (number, link, status, CI, commit) in the feature drawer for completed features
+userQuery: >
+  Feature: Add PR information to feature in status completed in feature drawer
+summary: >
+  When a feature has an associated pull request, display PR metadata (number, URL link, status
+  badge, CI status, commit hash) in a dedicated section within the feature drawer. The domain
+  model already contains PR data on the Feature entity; it needs to be piped through
+  FeatureNodeData and rendered in the drawer, reusing the existing CiStatusBadge from the
+  MergeReview component.
+phase: Requirements
+sizeEstimate: S
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - React (Next.js App Router, server components)
+  - TypeScript
+  - Tailwind CSS
+  - shadcn/ui (Badge component)
+  - lucide-react (ExternalLink, GitCommitHorizontal, CheckCircle2, XCircle, Loader2 icons)
+  - Vitest + React Testing Library (unit tests)
+  - Storybook (component stories)
+  - TypeSpec (domain model generation)
+
+relatedLinks: []
+
+# Open questions (resolved with AI recommendations)
+openQuestions:
+  - question: Should PR info display for all features with a PR, or only when state is "done"?
+    resolved: true
+    options:
+      - option: All features with PR data
+        description: >
+          Show the PR section whenever feature.pr is defined, regardless of feature state.
+          This gives users visibility into PR status during merge review, CI fixing, and
+          after completion. Since the domain only populates PR data once a PR is created
+          (typically at merge review or later), there is no risk of showing stale or premature
+          data. This avoids coupling display logic to specific states, keeping the component simpler.
+        selected: true
+      - option: Only in "done" state
+        description: >
+          Restrict PR section visibility to features in the done/completed state only.
+          This is more conservative but artificially hides useful information during
+          merge-review and ci-fixing states when a PR already exists. Requires additional
+          state-checking logic in the component.
+        selected: false
+    selectionRationale: >
+      Showing PR info for all features with PR data is recommended because: (1) the domain
+      only attaches PR data once a PR is actually created, so there's no premature display risk;
+      (2) users benefit from seeing PR status during merge-review and ci-fixing phases from the
+      drawer; (3) it keeps the component simpler — a single `if (pr)` guard rather than
+      `if (pr && state === 'done')`. The user's original request mentioned "completed" features,
+      but the natural UX is to show PR data whenever it exists.
+    answer: All features with PR data
+
+  - question: Should the CiStatusBadge be extracted into a shared component, or kept in merge-review and duplicated?
+    resolved: true
+    options:
+      - option: Extract to shared component
+        description: >
+          Move CiStatusBadge from merge-review.tsx into a shared location (e.g.,
+          components/common/ci-status-badge.tsx) and import it from both merge-review
+          and feature-drawer. Eliminates duplication, ensures consistent rendering,
+          and makes future changes to CI badge styling a single-point edit. Adds one
+          new file but reduces overall code and maintenance burden.
+        selected: true
+      - option: Duplicate in feature drawer
+        description: >
+          Copy the ~20-line CiStatusBadge function into feature-drawer.tsx. Pragmatic
+          and fast, avoids touching merge-review.tsx, but creates two copies that could
+          drift. Acceptable for a small component but introduces a maintenance smell.
+        selected: false
+    selectionRationale: >
+      Extracting CiStatusBadge to a shared component is recommended because: (1) the component
+      is already proven and stable in merge-review; (2) having two consumers makes extraction
+      the right time per DRY principles; (3) it's a ~20-line pure presentational component with
+      no dependencies beyond Badge and lucide icons, making extraction trivial; (4) it establishes
+      a reusable pattern for any future CI status display needs.
+    answer: Extract to shared component
+
+  - question: Where should the PR info section be positioned within the feature drawer?
+    resolved: true
+    options:
+      - option: Between Status and Details sections
+        description: >
+          Place PR info after the state/progress section and before the details section
+          (description, agent, runtime). This groups status-related information together —
+          feature state flows naturally into PR state. Follows information hierarchy from
+          high-level status down to implementation details.
+        selected: true
+      - option: Between Details and Delete sections
+        description: >
+          Place PR info after details (description, agent, runtime) and before the delete
+          button. Treats PR info as supplementary metadata appended at the bottom. This
+          position is less prominent and may be missed by users scrolling.
+        selected: false
+      - option: Inside Details section as additional rows
+        description: >
+          Add PR fields as DetailRow entries within the existing Details section. Avoids
+          adding a new section but mixes PR metadata with feature implementation details,
+          which are conceptually different. Also loses the card-style visual treatment from
+          merge-review.
+        selected: false
+    selectionRationale: >
+      Placing PR info between Status and Details is recommended because it follows the
+      information hierarchy: feature lifecycle state → PR state → implementation details.
+      Users checking a completed feature will naturally scan state badge, then PR outcome,
+      then details. This mirrors the merge-review flow where PR info is the primary focus
+      after status. The section gets a dedicated visual treatment (bordered card) consistent
+      with merge-review, making it scannable.
+    answer: Between Status and Details sections
+
+  - question: Should the PR section use the same bordered card style as merge-review, or a simpler inline style?
+    resolved: true
+    options:
+      - option: Bordered card style (match merge-review)
+        description: >
+          Use the same bordered rounded card with padding that merge-review uses for its PR
+          metadata display. Provides visual consistency across the app, clearly delineates PR
+          info as a cohesive block, and makes the section instantly recognizable to users who
+          have seen the merge-review UI.
+        selected: true
+      - option: Inline DetailRow style
+        description: >
+          Render PR fields as simple label-value rows matching the Details section style.
+          Lighter visual weight, integrates more seamlessly with the drawer, but loses the
+          visual distinction that signals "this is PR information" and diverges from the
+          established merge-review pattern.
+        selected: false
+    selectionRationale: >
+      The bordered card style is recommended for visual consistency with merge-review. Since
+      CiStatusBadge is being extracted as a shared component, the visual treatment should also
+      be consistent. Users will recognize the PR card pattern from the merge-review flow,
+      reducing cognitive load.
+    answer: Bordered card style (match merge-review)
+
+content: |
+  ## Problem Statement
+
+  When a feature has an associated pull request, the user has no visibility into PR metadata
+  from the feature drawer. The domain model already stores PR data (`Feature.pr?: PullRequest`
+  with url, number, status, ciStatus, commitHash) but this data is not passed through to
+  `FeatureNodeData` and not rendered in the feature drawer component.
+
+  The MergeReview component already has a polished PR metadata card UI with CiStatusBadge, but
+  this is only visible during the merge review flow — not accessible from the general feature
+  drawer. Users must navigate to the merge-review panel to see PR status for completed features,
+  which is unintuitive.
+
+  ## Success Criteria
+
+  - [ ] PR info section appears in feature drawer when the feature has PR data (`pr` field defined)
+  - [ ] PR info section is hidden when the feature has no PR data (`pr` field undefined)
+  - [ ] PR number is displayed as "#N" and links to the PR URL, opening in a new tab with `rel="noopener noreferrer"`
+  - [ ] PR status is displayed as a colored Badge matching PrStatus values: Open (blue), Merged (purple), Closed (red)
+  - [ ] CI status badge renders correctly for all 3 CiStatus values: Success/Passing (green), Pending (yellow/animated), Failure/Failing (red)
+  - [ ] CI status badge is omitted when `ciStatus` is undefined (not all PRs have CI)
+  - [ ] Commit hash displays first 7 characters with monospace font styling, omitted when `commitHash` is undefined
+  - [ ] CiStatusBadge is extracted from merge-review.tsx into a shared component and imported by both consumers
+  - [ ] `FeatureNodeData` interface includes an optional `pr` field with the required subset of PullRequest fields
+  - [ ] `page.tsx` server component maps `feature.pr` into `FeatureNodeData` when present
+  - [ ] Unit tests cover: PR section visible with full PR data, PR section hidden without PR data, all PrStatus variants, all CiStatus variants, missing optional fields (ciStatus, commitHash)
+  - [ ] Storybook stories demonstrate: Done + full PR, Done + PR without CI/commit, feature without PR, multiple PrStatus values
+  - [ ] All existing feature drawer tests continue to pass without modification
+  - [ ] No regressions in merge-review component after CiStatusBadge extraction
+
+  ## Functional Requirements
+
+  - **FR-1: Extend FeatureNodeData with PR data** — Add an optional `pr` field to the `FeatureNodeData` interface containing: `url: string`, `number: number`, `status: PrStatus`, `ciStatus?: CiStatus`, `commitHash?: string`. This is the presentation-layer subset of the domain PullRequest type (excludes `ciFixAttempts` and `ciFixHistory` which are not displayed).
+
+  - **FR-2: Map PR data in server component** — In `page.tsx`, when constructing `FeatureNodeData` from domain `Feature`, map `feature.pr` to the `pr` field when present. Use conditional spread: `...(feature.pr && { pr: { url, number, status, ciStatus, commitHash } })`.
+
+  - **FR-3: Render PR info section in feature drawer** — Add a `PrInfoSection` sub-component within feature-drawer.tsx that renders a bordered card containing PR metadata. The section renders only when `selectedNode.pr` is defined (no state-gating). Position it between the Status section and the Details section, separated by a `<Separator />`.
+
+  - **FR-4: Display PR number as external link** — Render the PR number as `#N` (e.g., "#42") wrapped in an anchor tag linking to `pr.url`. The link opens in a new tab (`target="_blank"`) with `rel="noopener noreferrer"`. Include an `ExternalLink` icon adjacent to the text.
+
+  - **FR-5: Display PR status badge** — Render `pr.status` as a shadcn/ui `Badge` with color coding: `Open` → blue/default variant, `Merged` → purple variant, `Closed` → red/destructive variant. Use the PrStatus enum value as display text.
+
+  - **FR-6: Display CI status badge** — When `pr.ciStatus` is defined, render the shared `CiStatusBadge` component showing: `Success` → green with CheckCircle2 icon and "Passing" text, `Pending` → yellow with animated Loader2 spinner and "Pending" text, `Failure` → red with XCircle icon and "Failing" text. When `pr.ciStatus` is undefined, omit the CI badge entirely.
+
+  - **FR-7: Display abbreviated commit hash** — When `pr.commitHash` is defined, render the first 7 characters with a `GitCommitHorizontal` icon and monospace font styling (`font-mono`). When `pr.commitHash` is undefined, omit the commit display entirely.
+
+  - **FR-8: Extract CiStatusBadge to shared component** — Move the existing `CiStatusBadge` component from `merge-review.tsx` into a new shared file (e.g., `components/common/ci-status-badge.tsx`). Update merge-review.tsx to import from the shared location. The feature-drawer also imports from the shared location. No behavioral changes to CiStatusBadge itself.
+
+  ## Non-Functional Requirements
+
+  - **NFR-1: Visual consistency** — The PR info card in the feature drawer must visually match the PR metadata card in merge-review.tsx (same border style, spacing, icon sizes, badge variants, font treatments). Users should recognize it as the same information.
+
+  - **NFR-2: Accessibility** — The PR link must have accessible text (the PR number serves as link text). Badge colors must not be the sole indicator of status — text labels are required alongside colors. The external link should indicate it opens a new window (via the ExternalLink icon as visual cue).
+
+  - **NFR-3: No performance regression** — Adding the optional `pr` field to FeatureNodeData and the conditional section render must not introduce measurable performance regression. The PR section should not render any DOM when `pr` is undefined (conditional render, not hidden via CSS).
+
+  - **NFR-4: Backward compatibility** — The `pr` field on FeatureNodeData is optional. All existing features without PR data continue to render identically. No changes to existing test fixtures or stories unless they explicitly test the new PR section.
+
+  - **NFR-5: Test coverage** — Unit tests must cover all PrStatus × CiStatus combinations, the absence of optional fields (ciStatus, commitHash), and the complete absence of PR data. Minimum: 8 test cases for PR section behavior.
+
+  - **NFR-6: Storybook documentation** — Stories must demonstrate all meaningful visual states: full PR data, partial PR data (missing CI, missing commit), no PR data, and each PrStatus value. Stories serve as living documentation for designers and developers.
+
+  ## Product Questions & AI Recommendations
+
+  | # | Question | AI Recommendation | Rationale |
+  | - | -------- | ----------------- | --------- |
+  | 1 | Show PR info for all features with PR data, or only "done" state? | All features with PR data | Domain only attaches PR once created; showing it always is simpler and more useful during merge-review/ci-fixing phases |
+  | 2 | Extract CiStatusBadge to shared component or duplicate? | Extract to shared component | Two consumers justifies extraction; ~20 lines, pure presentational, trivial to extract; prevents drift |
+  | 3 | Where to position PR section in drawer? | Between Status and Details | Follows information hierarchy: state → PR → details; most prominent position for PR info |
+  | 4 | Bordered card or inline row style? | Bordered card (match merge-review) | Visual consistency with merge-review; users recognize the pattern; clear visual delineation |
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `src/presentation/web/components/common/feature-node/feature-node-state-config.ts` | Medium | Add optional `pr` field to `FeatureNodeData` interface |
+  | `src/presentation/web/app/page.tsx` | Low | Map `feature.pr` into `FeatureNodeData` during node construction |
+  | `src/presentation/web/components/common/feature-drawer/feature-drawer.tsx` | High | Add new `PrInfoSection` sub-component to render PR metadata card |
+  | `src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx` | Medium | Add stories with PR data variations |
+  | `tests/unit/presentation/web/components/common/feature-drawer/feature-drawer.test.tsx` | Medium | Add test cases for PR section visibility and content |
+  | `src/presentation/web/components/common/merge-review/merge-review.tsx` | Medium | Extract `CiStatusBadge` to shared location, update import |
+  | `src/presentation/web/components/common/ci-status-badge.tsx` (new) | Medium | New shared CiStatusBadge component extracted from merge-review |
+
+  ## Dependencies
+
+  - Domain `PullRequest` type from `@shepai/core/domain/generated/output` (already exists)
+  - `PrStatus` and `CiStatus` enums from same module (already exist)
+  - `Badge` component from shadcn/ui (already in use)
+  - `ExternalLink`, `GitCommitHorizontal`, `CheckCircle2`, `Loader2`, `XCircle` icons from lucide-react (already installed)
+  - `Separator` component from shadcn/ui (already in use in feature-drawer)
+
+  ## Size Estimate
+
+  **S** — This is a small, well-scoped feature confined to the presentation layer. The domain
+  model and PR types already exist. The UI pattern is established in MergeReview. Implementation:
+  1. Add one optional field to FeatureNodeData interface (~5 lines)
+  2. One conditional spread in page.tsx mapping (~2 lines)
+  3. Extract CiStatusBadge to shared file (~25 lines, moved not written)
+  4. New PrInfoSection sub-component in feature-drawer.tsx (~50-60 lines)
+  5. Unit tests (~80-100 lines for 8+ test cases)
+  6. Storybook stories (~40-50 lines for 4+ stories)
+
+  Total new/modified code: ~200-250 lines across 7 files. No domain, infrastructure, or
+  TypeSpec changes required.
+
+  ---
+
+  _Requirements completed — proceed with research/planning_

--- a/specs/044-pr-info-feature-drawer/tasks.yaml
+++ b/specs/044-pr-info-feature-drawer/tasks.yaml
@@ -1,0 +1,267 @@
+# Task Breakdown (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: pr-info-feature-drawer
+summary: >
+  8 tasks across 3 phases. Phase 1 extracts CiStatusBadge to a shared component with tests
+  and stories (3 tasks). Phase 2 extends FeatureNodeData and maps PR data in the server
+  component (2 tasks). Phase 3 builds the PrInfoSection UI with tests and stories (3 tasks).
+
+relatedFeatures: []
+technologies:
+  - React (Next.js App Router)
+  - TypeScript
+  - Tailwind CSS
+  - shadcn/ui (Badge)
+  - lucide-react
+  - Vitest + React Testing Library
+  - Storybook
+relatedLinks: []
+
+tasks:
+  - id: task-1
+    phaseId: phase-1
+    title: 'Create shared CiStatusBadge component with tests'
+    description: >
+      Extract the CiStatusBadge function from merge-review.tsx into a new shared component at
+      components/common/ci-status-badge/ci-status-badge.tsx with a barrel index.ts. Write unit
+      tests that cover all 3 CiStatus variants (Success → green "Passing", Pending → yellow
+      animated "Pending", Failure → red "Failing"). The component is a pure function taking a
+      CiStatus prop and returning a styled Badge — no hooks, no state.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'ci-status-badge.tsx exports a CiStatusBadge component accepting { status: CiStatus }'
+      - 'index.ts barrel exports CiStatusBadge'
+      - 'Unit test renders CiStatusBadge with CiStatus.Success and asserts "Passing" text and green styling'
+      - 'Unit test renders CiStatusBadge with CiStatus.Pending and asserts "Pending" text and animate-spin class'
+      - 'Unit test renders CiStatusBadge with CiStatus.Failure and asserts "Failing" text and red styling'
+      - 'All 3 tests pass'
+    tdd:
+      red:
+        - 'Write test file at tests/unit/presentation/web/components/common/ci-status-badge/ci-status-badge.test.tsx'
+        - 'Import CiStatusBadge from @/components/common/ci-status-badge (does not exist yet — test fails)'
+        - 'Write 3 test cases: renders "Passing" for Success, renders "Pending" with spinner for Pending, renders "Failing" for Failure'
+      green:
+        - 'Create ci-status-badge/ci-status-badge.tsx with the CiStatusBadge component (copy from merge-review.tsx lines 21-45)'
+        - 'Create ci-status-badge/index.ts with barrel export'
+        - 'Run tests — all 3 pass'
+      refactor:
+        - 'Ensure the component file has no unused imports'
+        - 'Verify Badge and icon imports use the same paths as merge-review'
+    estimatedEffort: '20min'
+
+  - id: task-2
+    phaseId: phase-1
+    title: 'Add Storybook stories for CiStatusBadge'
+    description: >
+      Create ci-status-badge.stories.tsx in the shared component directory with stories for
+      all 3 CiStatus variants. Follow the codebase convention of one .stories.tsx per component.
+      This satisfies the MANDATORY Storybook stories rule from CLAUDE.md.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'ci-status-badge.stories.tsx exists in the ci-status-badge/ directory'
+      - 'Stories include Success, Pending, and Failure variants'
+      - 'Meta title follows naming convention (e.g., "Common/CiStatusBadge")'
+      - 'Stories render without errors in Storybook'
+    tdd: null
+    estimatedEffort: '10min'
+
+  - id: task-3
+    phaseId: phase-1
+    title: 'Update merge-review.tsx to import shared CiStatusBadge'
+    description: >
+      Remove the local CiStatusBadge function from merge-review.tsx. Add an import of
+      CiStatusBadge from @/components/common/ci-status-badge. Clean up icon imports that were
+      only used by CiStatusBadge: remove CheckCircle2 and XCircle from lucide-react imports,
+      remove CiStatus enum import from domain. Keep Loader2 (still used by DrawerActionBar
+      approve icon on line 211).
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'merge-review.tsx no longer contains a local CiStatusBadge function definition'
+      - 'merge-review.tsx imports CiStatusBadge from @/components/common/ci-status-badge'
+      - 'CheckCircle2 and XCircle are removed from lucide-react import'
+      - 'CiStatus enum import is removed from merge-review.tsx'
+      - 'Loader2 remains in lucide-react import (used by approve icon)'
+      - 'TypeScript compilation passes with no errors'
+      - 'Existing merge-review behavior is unchanged (visual + functional)'
+    tdd:
+      red:
+        - 'Existing merge-review tests should pass before and after the change — verify they pass now'
+      green:
+        - 'Delete the local CiStatusBadge function (lines 21-45 of merge-review.tsx)'
+        - 'Add import: import { CiStatusBadge } from @/components/common/ci-status-badge'
+        - 'Remove CheckCircle2, XCircle from lucide-react import line'
+        - 'Remove CiStatus from the domain import line'
+        - 'Run TypeScript compilation and existing tests — all pass'
+      refactor:
+        - 'Verify no other unused imports remain in merge-review.tsx'
+    estimatedEffort: '10min'
+
+  - id: task-4
+    phaseId: phase-2
+    title: 'Extend FeatureNodeData interface with optional pr field'
+    description: >
+      Add an optional pr field to the FeatureNodeData interface in feature-node-state-config.ts.
+      The field is a presentation-layer subset of the domain PullRequest type: url (string),
+      number (number), status (PrStatus), ciStatus (optional CiStatus), commitHash (optional
+      string). Import PrStatus and CiStatus from domain generated output.
+    state: Todo
+    dependencies:
+      - task-3
+    acceptanceCriteria:
+      - 'FeatureNodeData has an optional pr field with the correct 5-field type'
+      - 'PrStatus and CiStatus are imported from @shepai/core/domain/generated/output'
+      - 'TypeScript compilation passes'
+      - 'All existing feature-drawer tests still pass (pr is optional, no existing data affected)'
+    tdd:
+      red:
+        - 'Write a type-level test or assertion that FeatureNodeData["pr"] accepts { url, number, status, ciStatus?, commitHash? }'
+        - 'Alternatively, add a test in the feature-drawer test file that creates a FeatureNodeData with pr field and asserts it compiles'
+      green:
+        - 'Add the pr field type to FeatureNodeData interface in feature-node-state-config.ts'
+        - 'Add PrStatus and CiStatus imports from domain generated output'
+      refactor:
+        - 'Verify the pr type aligns with MergeReviewPr shape for consistency'
+    estimatedEffort: '10min'
+
+  - id: task-5
+    phaseId: phase-2
+    title: 'Map feature.pr to FeatureNodeData in page.tsx'
+    description: >
+      In the server component page.tsx, add a conditional spread when constructing the nodeData
+      object to map feature.pr into the new FeatureNodeData.pr field. Extract only the 5
+      display-relevant fields (url, number, status, ciStatus, commitHash), excluding
+      ciFixAttempts and ciFixHistory from the domain PullRequest type.
+    state: Todo
+    dependencies:
+      - task-4
+    acceptanceCriteria:
+      - 'page.tsx maps feature.pr to FeatureNodeData.pr using conditional spread pattern'
+      - 'Only url, number, status, ciStatus, commitHash are included (not ciFixAttempts/ciFixHistory)'
+      - 'When feature.pr is undefined, the pr field is omitted from nodeData'
+      - 'TypeScript compilation passes'
+    tdd:
+      red:
+        - 'This is a server component data mapping — verify TypeScript compilation catches any type mismatches'
+      green:
+        - 'Add ...(feature.pr && { pr: { url: feature.pr.url, number: feature.pr.number, status: feature.pr.status, ciStatus: feature.pr.ciStatus, commitHash: feature.pr.commitHash } }) to the nodeData construction'
+      refactor:
+        - 'Ensure the spread pattern is consistent with the existing agentType/errorMessage/blockedBy spreads'
+    estimatedEffort: '5min'
+
+  - id: task-6
+    phaseId: phase-3
+    title: 'Add PrInfoSection sub-component to feature-drawer.tsx'
+    description: >
+      Add a PrInfoSection private sub-component inside feature-drawer.tsx that renders a bordered
+      card containing: PR number as external link, PR status badge (colored by PrStatus), CI
+      status badge (shared CiStatusBadge, conditional on ciStatus), and abbreviated commit hash
+      (conditional on commitHash). Position the section between the Status section (after the
+      second Separator) and the DetailsSection. Add necessary icon and type imports.
+    state: Todo
+    dependencies:
+      - task-4
+      - task-1
+    acceptanceCriteria:
+      - 'PrInfoSection renders a bordered card when selectedNode.pr is defined'
+      - 'PrInfoSection returns null when selectedNode.pr is undefined'
+      - 'PR number displays as "#N" linking to pr.url with target="_blank" and rel="noopener noreferrer"'
+      - 'PR status renders as a colored Badge: Open → blue, Merged → purple, Closed → red'
+      - 'CI status renders CiStatusBadge when pr.ciStatus is defined, omitted otherwise'
+      - 'Commit hash displays first 7 chars with font-mono and GitCommitHorizontal icon when defined, omitted otherwise'
+      - 'Section has data-testid="feature-drawer-pr"'
+      - 'Section is positioned between Status and Details, with Separators'
+    tdd:
+      red:
+        - 'Write tests first in feature-drawer.test.tsx under a new describe("PR info section") block'
+        - 'Test 1: PR section visible when pr data is provided — assert testid="feature-drawer-pr" is in document'
+        - 'Test 2: PR section hidden when pr is undefined — assert testid not in document'
+        - 'Test 3: PR number displays as link with correct href and "#N" text'
+        - 'Tests fail because PrInfoSection does not exist yet'
+      green:
+        - 'Add PrInfoSection function to feature-drawer.tsx with bordered card layout'
+        - 'Add PR number link, status badge, conditional CI status, conditional commit hash'
+        - 'Insert PrInfoSection between Status and Details in the main FeatureDrawer component'
+        - 'Add necessary imports (ExternalLink, GitCommitHorizontal, PrStatus, CiStatus, Badge, CiStatusBadge)'
+        - 'All 3 initial tests pass'
+      refactor:
+        - 'Extract PrStatus-to-className mapping into a const object for readability'
+        - 'Ensure consistent spacing and styling with merge-review PR card'
+    estimatedEffort: '30min'
+
+  - id: task-7
+    phaseId: phase-3
+    title: 'Add comprehensive PR section unit tests'
+    description: >
+      Expand the PR info section test suite to cover all PrStatus variants, all CiStatus
+      variants, missing optional fields (ciStatus, commitHash), and the complete absence of PR
+      data. Minimum 8 test cases as required by NFR-5.
+    state: Todo
+    dependencies:
+      - task-6
+    acceptanceCriteria:
+      - 'Test for each PrStatus value: Open displays blue badge, Merged displays purple badge, Closed displays red badge'
+      - 'Test for each CiStatus value: Success shows "Passing", Pending shows "Pending", Failure shows "Failing"'
+      - 'Test that CI badge is omitted when ciStatus is undefined'
+      - 'Test that commit hash is omitted when commitHash is undefined'
+      - 'Test that commit hash displays first 7 characters with font-mono styling'
+      - 'Test that PR link has target="_blank" and rel="noopener noreferrer"'
+      - 'At least 8 test cases total in the PR info section describe block'
+      - 'All existing feature-drawer tests continue to pass without modification'
+    tdd:
+      red:
+        - 'Write remaining test cases for PrStatus variants, CiStatus variants, optional field handling'
+        - 'Some may already pass from task-6 implementation; write them to ensure coverage'
+      green:
+        - 'Fix any test failures by adjusting PrInfoSection rendering logic'
+      refactor:
+        - 'Create a prData fixture helper to reduce test boilerplate'
+        - 'Ensure test data follows the same pattern as defaultData in the existing test file'
+    estimatedEffort: '25min'
+
+  - id: task-8
+    phaseId: phase-3
+    title: 'Add feature-drawer Storybook stories for PR variations'
+    description: >
+      Add PR data fixtures and new stories to feature-drawer.stories.tsx demonstrating: Done
+      feature with full PR data (all fields), Done feature with partial PR data (missing ciStatus
+      and commitHash), feature without PR data (existing stories already cover this), and
+      individual PrStatus variants (Open, Merged, Closed). Follow the existing DrawerTrigger
+      pattern.
+    state: Todo
+    dependencies:
+      - task-6
+    acceptanceCriteria:
+      - 'New PR data fixtures added to the stories file (doneWithPrData, doneWithPartialPrData)'
+      - 'Story: DoneWithPr — shows feature drawer with full PR card (number, status, CI, commit)'
+      - 'Story: DoneWithPartialPr — shows PR card without CI status and commit hash'
+      - 'Story: PrStatusOpen — shows PR with Open status (blue badge)'
+      - 'Story: PrStatusMerged — shows PR with Merged status (purple badge)'
+      - 'Stories render without errors in Storybook'
+      - 'Existing stories are not modified'
+    tdd: null
+    estimatedEffort: '15min'
+
+totalEstimate: '2h 5min'
+
+openQuestions: []
+
+content: |
+  ## Summary
+
+  The implementation is split into 8 focused tasks across 3 phases. Phase 1 establishes the
+  shared CiStatusBadge foundation by extracting it from merge-review, adding tests and stories,
+  then updating merge-review to import from the shared location. Phase 2 extends the data
+  model by adding the optional PR type to FeatureNodeData and mapping it in the server component.
+  Phase 3 builds the UI: the PrInfoSection sub-component in feature-drawer.tsx, followed by
+  comprehensive test coverage (8+ test cases) and Storybook stories for all PR state variations.
+
+  Tasks are ordered by dependency — each task builds on the output of previous tasks. The
+  critical path runs through task-1 (shared component) → task-4 (type extension) → task-6
+  (UI rendering). Tasks 2 and 3 can proceed in parallel after task-1. Tasks 7 and 8 can
+  proceed in parallel after task-6.

--- a/src/presentation/web/app/page.tsx
+++ b/src/presentation/web/app/page.tsx
@@ -104,6 +104,15 @@ export default async function HomePage() {
         ...(run?.agentType && { agentType: run.agentType as FeatureNodeData['agentType'] }),
         ...(run?.error && { errorMessage: run.error }),
         ...(blockedBy && { blockedBy }),
+        ...(feature.pr && {
+          pr: {
+            url: feature.pr.url,
+            number: feature.pr.number,
+            status: feature.pr.status,
+            ciStatus: feature.pr.ciStatus,
+            commitHash: feature.pr.commitHash,
+          },
+        }),
       };
 
       const featureNodeId = `feat-${feature.id}`;

--- a/src/presentation/web/components/common/ci-status-badge/ci-status-badge.stories.tsx
+++ b/src/presentation/web/components/common/ci-status-badge/ci-status-badge.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CiStatus } from '@shepai/core/domain/generated/output';
+import { CiStatusBadge } from './ci-status-badge';
+
+const meta: Meta<typeof CiStatusBadge> = {
+  title: 'Common/CiStatusBadge',
+  component: CiStatusBadge,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CiStatusBadge>;
+
+/** CI passed — green badge with check icon. */
+export const Success: Story = {
+  args: { status: CiStatus.Success },
+};
+
+/** CI pending — yellow badge with animated spinner. */
+export const Pending: Story = {
+  args: { status: CiStatus.Pending },
+};
+
+/** CI failed — red badge with X icon. */
+export const Failure: Story = {
+  args: { status: CiStatus.Failure },
+};

--- a/src/presentation/web/components/common/ci-status-badge/ci-status-badge.tsx
+++ b/src/presentation/web/components/common/ci-status-badge/ci-status-badge.tsx
@@ -1,0 +1,29 @@
+import { CheckCircle2, Loader2, XCircle } from 'lucide-react';
+import { CiStatus } from '@shepai/core/domain/generated/output';
+import { Badge } from '@/components/ui/badge';
+
+export function CiStatusBadge({ status }: { status: CiStatus }) {
+  switch (status) {
+    case CiStatus.Success:
+      return (
+        <Badge className="border-transparent bg-green-50 text-green-700 hover:bg-green-50">
+          <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+          Passing
+        </Badge>
+      );
+    case CiStatus.Pending:
+      return (
+        <Badge className="border-transparent bg-yellow-50 text-yellow-700 hover:bg-yellow-50">
+          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+          Pending
+        </Badge>
+      );
+    case CiStatus.Failure:
+      return (
+        <Badge className="border-transparent bg-red-50 text-red-700 hover:bg-red-50">
+          <XCircle className="mr-1 h-3.5 w-3.5" />
+          Failing
+        </Badge>
+      );
+  }
+}

--- a/src/presentation/web/components/common/ci-status-badge/index.ts
+++ b/src/presentation/web/components/common/ci-status-badge/index.ts
@@ -1,0 +1,1 @@
+export { CiStatusBadge } from './ci-status-badge';

--- a/src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx
+++ b/src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { PrStatus, CiStatus } from '@shepai/core/domain/generated/output';
 import { FeatureDrawer } from './feature-drawer';
 import type { FeatureNodeData } from '@/components/common/feature-node';
 import type { FeatureLifecyclePhase, FeatureNodeState } from '@/components/common/feature-node';
@@ -352,4 +353,56 @@ export const DeletingState: Story = {
 /** FeatureDrawer with a running agent showing the running-agent warning in the AlertDialog. */
 export const DeleteRunningAgent: Story = {
   render: () => <DrawerTriggerWithDelete data={runningData} label="Open Running Agent Delete" />,
+};
+
+/* ---------------------------------------------------------------------------
+ * PR info stories
+ * ------------------------------------------------------------------------- */
+
+const doneWithPrData: FeatureNodeData = {
+  ...doneData,
+  pr: {
+    url: 'https://github.com/org/repo/pull/42',
+    number: 42,
+    status: PrStatus.Merged,
+    ciStatus: CiStatus.Success,
+    commitHash: 'abc1234567890def',
+  },
+};
+
+const doneWithPartialPrData: FeatureNodeData = {
+  ...doneData,
+  pr: {
+    url: 'https://github.com/org/repo/pull/99',
+    number: 99,
+    status: PrStatus.Merged,
+  },
+};
+
+/** Done feature with full PR card — number, status, CI, commit hash. */
+export const DoneWithPr: Story = {
+  render: () => <DrawerTrigger data={doneWithPrData} label="Open Done + PR" />,
+};
+
+/** Done feature with partial PR data — no CI status, no commit hash. */
+export const DoneWithPartialPr: Story = {
+  render: () => <DrawerTrigger data={doneWithPartialPrData} label="Open Done + Partial PR" />,
+};
+
+/** PR with Open status — blue badge. */
+export const PrStatusOpen: Story = {
+  render: () => (
+    <DrawerTrigger
+      data={{
+        ...doneWithPrData,
+        pr: { ...doneWithPrData.pr!, status: PrStatus.Open, ciStatus: CiStatus.Pending },
+      }}
+      label="Open PR Status: Open"
+    />
+  ),
+};
+
+/** PR with Merged status — purple badge. */
+export const PrStatusMerged: Story = {
+  render: () => <DrawerTrigger data={doneWithPrData} label="Open PR Status: Merged" />,
 };

--- a/src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
+++ b/src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { XIcon, Loader2, Trash2 } from 'lucide-react';
+import { XIcon, Loader2, Trash2, ExternalLink, GitCommitHorizontal } from 'lucide-react';
+import { PrStatus } from '@shepai/core/domain/generated/output';
 import { cn } from '@/lib/utils';
 import { OpenActionMenu } from '@/components/common/open-action-menu';
 import {
@@ -11,6 +12,7 @@ import {
   DrawerDescription,
 } from '@/components/ui/drawer';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { CometSpinner } from '@/components/ui/comet-spinner';
 import {
@@ -24,6 +26,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { CiStatusBadge } from '@/components/common/ci-status-badge';
 import { featureNodeStateConfig, lifecycleDisplayLabels } from '@/components/common/feature-node';
 import type { FeatureNodeData } from '@/components/common/feature-node';
 import { useFeatureActions } from './use-feature-actions';
@@ -107,6 +110,14 @@ export function FeatureDrawer({
                 </div>
               ) : null}
             </div>
+
+            {/* PR info */}
+            {selectedNode.pr ? (
+              <>
+                <Separator />
+                <PrInfoSection pr={selectedNode.pr} />
+              </>
+            ) : null}
 
             <Separator />
 
@@ -209,6 +220,55 @@ function DetailRow({ label, value }: { label: string; value: string }) {
     <div className="flex flex-col gap-0.5">
       <span className="text-muted-foreground text-xs font-medium">{label}</span>
       <span className="text-sm">{value}</span>
+    </div>
+  );
+}
+
+const prStatusStyles: Record<PrStatus, string> = {
+  [PrStatus.Open]: 'border-transparent bg-blue-50 text-blue-700 hover:bg-blue-50',
+  [PrStatus.Merged]: 'border-transparent bg-purple-50 text-purple-700 hover:bg-purple-50',
+  [PrStatus.Closed]: 'border-transparent bg-red-50 text-red-700 hover:bg-red-50',
+};
+
+function PrInfoSection({ pr }: { pr: NonNullable<FeatureNodeData['pr']> }) {
+  return (
+    <div data-testid="feature-drawer-pr" className="border-border mx-4 rounded-lg border">
+      <div className="space-y-3 px-4 py-3">
+        {/* PR number + link */}
+        <div className="flex items-center justify-between">
+          <a
+            href={pr.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary flex items-center gap-1.5 text-sm font-semibold underline underline-offset-2"
+          >
+            PR #{pr.number}
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+          <Badge className={prStatusStyles[pr.status]}>{pr.status}</Badge>
+        </div>
+
+        {/* CI status */}
+        {pr.ciStatus ? (
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-xs font-medium">CI Status</span>
+            <CiStatusBadge status={pr.ciStatus} />
+          </div>
+        ) : null}
+
+        {/* Commit hash */}
+        {pr.commitHash ? (
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-xs font-medium">Commit</span>
+            <div className="flex items-center gap-1.5">
+              <GitCommitHorizontal className="text-muted-foreground h-3.5 w-3.5" />
+              <code className="bg-muted text-foreground rounded-md px-1.5 py-0.5 font-mono text-[11px]">
+                {pr.commitHash.slice(0, 7)}
+              </code>
+            </div>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/presentation/web/components/common/feature-node/feature-node-state-config.ts
+++ b/src/presentation/web/components/common/feature-node/feature-node-state-config.ts
@@ -1,5 +1,6 @@
 import { Loader2, CircleAlert, CircleCheck, Ban, CircleX, type LucideIcon } from 'lucide-react';
 import type { Node } from '@xyflow/react';
+import type { PrStatus, CiStatus } from '@shepai/core/domain/generated/output';
 import type { AgentTypeValue } from './agent-type-icons';
 
 export type FeatureNodeState =
@@ -60,6 +61,14 @@ export interface FeatureNodeData {
   errorMessage?: string;
   /** Agent executor type (e.g. "claude-code", "cursor"). */
   agentType?: AgentTypeValue;
+  /** PR metadata for features with an associated pull request */
+  pr?: {
+    url: string;
+    number: number;
+    status: PrStatus;
+    ciStatus?: CiStatus;
+    commitHash?: string;
+  };
   onAction?: () => void;
   onSettings?: () => void;
   showHandles?: boolean;

--- a/src/presentation/web/components/common/merge-review/merge-review.tsx
+++ b/src/presentation/web/components/common/merge-review/merge-review.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import {
-  CheckCircle2,
   ExternalLink,
   GitMerge,
   Loader2,
-  XCircle,
   AlertTriangle,
   FileDiff,
   GitCommitHorizontal,
@@ -13,36 +11,10 @@ import {
   ArrowRight,
   Layers,
 } from 'lucide-react';
-import { CiStatus } from '@shepai/core/domain/generated/output';
 import { Badge } from '@/components/ui/badge';
+import { CiStatusBadge } from '@/components/common/ci-status-badge';
 import { DrawerActionBar } from '@/components/common/drawer-action-bar';
 import type { MergeReviewProps, MergeReviewPhase } from './merge-review-config';
-
-function CiStatusBadge({ status }: { status: CiStatus }) {
-  switch (status) {
-    case CiStatus.Success:
-      return (
-        <Badge className="border-transparent bg-green-50 text-green-700 hover:bg-green-50">
-          <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
-          Passing
-        </Badge>
-      );
-    case CiStatus.Pending:
-      return (
-        <Badge className="border-transparent bg-yellow-50 text-yellow-700 hover:bg-yellow-50">
-          <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
-          Pending
-        </Badge>
-      );
-    case CiStatus.Failure:
-      return (
-        <Badge className="border-transparent bg-red-50 text-red-700 hover:bg-red-50">
-          <XCircle className="mr-1 h-3.5 w-3.5" />
-          Failing
-        </Badge>
-      );
-  }
-}
 
 function PhaseList({ phases }: { phases: MergeReviewPhase[] }) {
   return (

--- a/tests/unit/presentation/web/components/common/ci-status-badge/ci-status-badge.test.tsx
+++ b/tests/unit/presentation/web/components/common/ci-status-badge/ci-status-badge.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CiStatus } from '@shepai/core/domain/generated/output';
+import { CiStatusBadge } from '@/components/common/ci-status-badge';
+
+describe('CiStatusBadge', () => {
+  it('renders green badge with "Passing" text for CiStatus.Success', () => {
+    const { container } = render(<CiStatusBadge status={CiStatus.Success} />);
+
+    expect(screen.getByText('Passing')).toBeInTheDocument();
+    const badge = container.querySelector('[class*="bg-green"]');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('renders yellow badge with animated spinner for CiStatus.Pending', () => {
+    const { container } = render(<CiStatusBadge status={CiStatus.Pending} />);
+
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('renders red badge with "Failing" text for CiStatus.Failure', () => {
+    const { container } = render(<CiStatusBadge status={CiStatus.Failure} />);
+
+    expect(screen.getByText('Failing')).toBeInTheDocument();
+    const badge = container.querySelector('[class*="bg-red"]');
+    expect(badge).toBeInTheDocument();
+  });
+});

--- a/tests/unit/presentation/web/components/common/feature-drawer/feature-drawer.test.tsx
+++ b/tests/unit/presentation/web/components/common/feature-drawer/feature-drawer.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { PrStatus, CiStatus } from '@shepai/core/domain/generated/output';
 import { FeatureDrawer } from '@/components/common/feature-drawer';
 import type { FeatureDrawerProps } from '@/components/common/feature-drawer';
 import { featureNodeStateConfig, lifecycleDisplayLabels } from '@/components/common/feature-node';
@@ -336,6 +337,125 @@ describe('FeatureDrawer', () => {
 
       const triggerButton = screen.getByRole('button', { name: /delete feature/i });
       expect(triggerButton).toBeDisabled();
+    });
+  });
+
+  describe('PR info section', () => {
+    const prData: FeatureNodeData['pr'] = {
+      url: 'https://github.com/org/repo/pull/42',
+      number: 42,
+      status: PrStatus.Merged,
+      ciStatus: CiStatus.Success,
+      commitHash: 'abc1234567890',
+    };
+
+    it('renders PR section when pr data is provided', () => {
+      renderDrawer({ ...defaultData, state: 'done', progress: 100, pr: prData });
+      expect(screen.getByTestId('feature-drawer-pr')).toBeInTheDocument();
+    });
+
+    it('hides PR section when pr is undefined', () => {
+      renderDrawer({ ...defaultData, pr: undefined });
+      expect(screen.queryByTestId('feature-drawer-pr')).not.toBeInTheDocument();
+    });
+
+    it('displays PR number as link with correct href and text', () => {
+      renderDrawer({ ...defaultData, pr: prData });
+      const link = screen.getByRole('link', { name: /PR #42/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
+    });
+
+    it('PR link opens in new tab with noopener noreferrer', () => {
+      renderDrawer({ ...defaultData, pr: prData });
+      const link = screen.getByRole('link', { name: /PR #42/i });
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('displays blue badge for PrStatus.Open', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, status: PrStatus.Open },
+      });
+      const prSection = screen.getByTestId('feature-drawer-pr');
+      const badge = prSection.querySelector('[class*="bg-blue-50"]');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('Open');
+    });
+
+    it('displays purple badge for PrStatus.Merged', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, status: PrStatus.Merged },
+      });
+      const badge = screen.getByText('Merged');
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain('bg-purple-50');
+    });
+
+    it('displays red badge for PrStatus.Closed', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, status: PrStatus.Closed },
+      });
+      const badge = screen.getByText('Closed');
+      expect(badge).toBeInTheDocument();
+      expect(badge.className).toContain('bg-red-50');
+    });
+
+    it('renders CiStatusBadge with "Passing" for CiStatus.Success', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, ciStatus: CiStatus.Success },
+      });
+      expect(screen.getByText('Passing')).toBeInTheDocument();
+    });
+
+    it('renders CiStatusBadge with "Pending" for CiStatus.Pending', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, ciStatus: CiStatus.Pending },
+      });
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    it('renders CiStatusBadge with "Failing" for CiStatus.Failure', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, ciStatus: CiStatus.Failure },
+      });
+      expect(screen.getByText('Failing')).toBeInTheDocument();
+    });
+
+    it('omits CI badge when ciStatus is undefined', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, ciStatus: undefined },
+      });
+      expect(screen.queryByText('Passing')).not.toBeInTheDocument();
+      expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+      expect(screen.queryByText('Failing')).not.toBeInTheDocument();
+      expect(screen.queryByText('CI Status')).not.toBeInTheDocument();
+    });
+
+    it('displays first 7 chars of commit hash with font-mono', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, commitHash: 'abc1234567890' },
+      });
+      const code = screen.getByText('abc1234');
+      expect(code).toBeInTheDocument();
+      expect(code.tagName.toLowerCase()).toBe('code');
+      expect(code.className).toContain('font-mono');
+    });
+
+    it('omits commit hash when commitHash is undefined', () => {
+      renderDrawer({
+        ...defaultData,
+        pr: { ...prData, commitHash: undefined },
+      });
+      expect(screen.queryByText('Commit')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Extract CiStatusBadge** from `merge-review.tsx` into a shared component at `components/common/ci-status-badge/` with its own tests and stories
- **Extend FeatureNodeData** with an optional `pr` field carrying PR url, number, status, ciStatus, and commitHash
- **Add PrInfoSection** to the feature drawer that renders a bordered card with PR link (external, new tab), PR status badge (Open/Merged/Closed color-coded), CI status badge (Passing/Pending/Failing via shared component), and abbreviated commit hash — shown whenever a feature has PR data attached
- **Map PR data** from domain Feature entity through `page.tsx` server component into FeatureNodeData

## Changes

| File | Change |
|------|--------|
| `feature-node-state-config.ts` | Add optional `pr` field to `FeatureNodeData` interface |
| `page.tsx` | Map `feature.pr` into node data during server-side construction |
| `feature-drawer.tsx` | Add `PrInfoSection` sub-component between Status and Details sections |
| `merge-review.tsx` | Remove inline `CiStatusBadge`, import from shared location |
| `ci-status-badge/` (new) | Shared `CiStatusBadge` component with index barrel, stories, and tests |
| `feature-drawer.test.tsx` | 13 new test cases for PR section (all status variants, optional fields) |
| `feature-drawer.stories.tsx` | 4 new stories (full PR, partial PR, Open status, Merged status) |
| `specs/044-pr-info-feature-drawer/` | Feature specification artifacts |

## Test plan

- [ ] `pnpm test:unit` — all existing + 13 new feature-drawer PR tests pass
- [ ] `pnpm test:unit` — CiStatusBadge extraction tests pass
- [ ] `pnpm validate` — lint, format, typecheck all green
- [ ] Storybook — verify PR info card renders correctly in new stories
- [ ] Verify merge-review component still renders CI badges correctly after extraction

Spec: `specs/044-pr-info-feature-drawer/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)