### PR TITLE
feat(web): add code-server integration for in-browser vs code editing per feature

### DIFF
--- a/apis/json-schema/CodeServerConfig.yaml
+++ b/apis/json-schema/CodeServerConfig.yaml
@@ -1,0 +1,13 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: CodeServerConfig.yaml
+type: object
+properties:
+  idleTimeoutSeconds:
+    type: integer
+    minimum: -2147483648
+    maximum: 2147483647
+    default: 1800
+    description: "Idle timeout in seconds for code-server instances (default: 1800)"
+required:
+  - idleTimeoutSeconds
+description: code-server instance configuration

--- a/apis/json-schema/CodeServerInstance.yaml
+++ b/apis/json-schema/CodeServerInstance.yaml
@@ -1,0 +1,43 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: CodeServerInstance.yaml
+type: object
+properties:
+  id:
+    type: string
+    description: Unique identifier for this instance record
+  featureId:
+    type: string
+    description: Feature ID this instance is scoped to
+  pid:
+    type: integer
+    minimum: -2147483648
+    maximum: 2147483647
+    description: OS process ID of the code-server process
+  port:
+    type: integer
+    minimum: -2147483648
+    maximum: 2147483647
+    description: Port code-server is bound to on localhost
+  worktreePath:
+    type: string
+    description: Absolute path to the feature worktree
+  status:
+    $ref: CodeServerInstanceStatus.yaml
+    description: Current lifecycle status
+  startedAt:
+    type: string
+    format: date-time
+    description: When the instance was started
+  stoppedAt:
+    type: string
+    format: date-time
+    description: When the instance was stopped (if stopped)
+required:
+  - id
+  - featureId
+  - pid
+  - port
+  - worktreePath
+  - status
+  - startedAt
+description: State of a managed code-server instance

--- a/apis/json-schema/CodeServerInstanceStatus.yaml
+++ b/apis/json-schema/CodeServerInstanceStatus.yaml
@@ -1,0 +1,7 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: CodeServerInstanceStatus.yaml
+type: string
+enum:
+  - running
+  - stopped
+description: Status of a code-server instance

--- a/apis/json-schema/Settings.yaml
+++ b/apis/json-schema/Settings.yaml
@@ -23,6 +23,9 @@ properties:
   workflow:
     $ref: WorkflowConfig.yaml
     description: Global workflow configuration defaults
+  codeServer:
+    $ref: CodeServerConfig.yaml
+    description: code-server instance configuration
   onboardingComplete:
     type: boolean
     default: false
@@ -35,6 +38,7 @@ required:
   - agent
   - notifications
   - workflow
+  - codeServer
   - onboardingComplete
 allOf:
   - $ref: BaseEntity.yaml

--- a/packages/core/src/application/ports/output/services/code-server-manager-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/code-server-manager-service.interface.ts
@@ -1,0 +1,88 @@
+/**
+ * Code Server Manager Service Interface
+ *
+ * Output port for managing code-server (VS Code in the browser) instance lifecycle.
+ * Infrastructure layer provides the concrete implementation that handles process
+ * spawning, port allocation, and SQLite state persistence.
+ *
+ * Each code-server instance is scoped to a single feature worktree.
+ * Instances bind exclusively to 127.0.0.1 with --auth none for local-only access.
+ */
+
+import type { CodeServerInstance } from '../../../../domain/generated/output.js';
+
+/**
+ * Result returned when a code-server instance is successfully started.
+ */
+export interface CodeServerStartResult {
+  /** Full URL to access code-server (e.g., http://127.0.0.1:13370) */
+  url: string;
+  /** Port code-server is bound to on localhost */
+  port: number;
+  /** OS process ID of the code-server process */
+  pid: number;
+  /** Feature ID this instance is scoped to */
+  featureId: string;
+}
+
+/**
+ * Port interface for code-server process lifecycle management.
+ *
+ * Implementations must:
+ * - Allocate ports starting at 13370 to avoid collisions with daemon/dev servers
+ * - Spawn code-server as a detached process bound to 127.0.0.1 only (never 0.0.0.0)
+ * - Persist instance state to SQLite for reconciliation across daemon restarts
+ * - Use SIGTERM with 5-second timeout + SIGKILL fallback for graceful shutdown
+ * - Check PID liveness via process.kill(pid, 0) for status queries and reconciliation
+ */
+export interface ICodeServerManagerService {
+  /**
+   * Start a code-server instance for a feature worktree.
+   * Idempotent — returns existing instance URL if already running (PID alive).
+   *
+   * @param featureId - Feature ID to scope the instance to
+   * @param worktreePath - Absolute path to the feature worktree directory
+   * @returns Start result with URL, port, PID, and feature ID
+   * @throws Error if port allocation fails or code-server binary is not found
+   */
+  start(featureId: string, worktreePath: string): Promise<CodeServerStartResult>;
+
+  /**
+   * Stop a running code-server instance for a feature.
+   * Sends SIGTERM, waits up to 5 seconds, then SIGKILL if still alive.
+   * No-op if instance not found or already stopped.
+   *
+   * @param featureId - Feature ID of the instance to stop
+   */
+  stop(featureId: string): Promise<void>;
+
+  /**
+   * Get the current status of a code-server instance for a feature.
+   * Checks PID liveness and auto-reconciles stale state (marks dead PIDs as stopped).
+   *
+   * @param featureId - Feature ID to check
+   * @returns Instance state or null if no instance exists for this feature
+   */
+  getStatus(featureId: string): Promise<CodeServerInstance | null>;
+
+  /**
+   * List all instances with status "running".
+   *
+   * @returns Array of running code-server instances
+   */
+  listRunning(): Promise<CodeServerInstance[]>;
+
+  /**
+   * Stop all running code-server instances.
+   * Handles partial failures — logs errors and continues stopping remaining instances.
+   * Should be called during daemon shutdown.
+   */
+  stopAll(): Promise<void>;
+
+  /**
+   * Reconcile persisted state with actual process liveness.
+   * Queries all "running" instances from SQLite, checks each PID, and marks
+   * instances with dead PIDs as "stopped". Should run on service initialization.
+   */
+  reconcile(): Promise<void>;
+}

--- a/packages/core/src/application/ports/output/services/index.ts
+++ b/packages/core/src/application/ports/output/services/index.ts
@@ -38,3 +38,7 @@ export type {
   LaunchIdeFailed,
 } from './ide-launcher-service.interface.js';
 export type { IDaemonService, DaemonState } from './daemon-service.interface.js';
+export type {
+  ICodeServerManagerService,
+  CodeServerStartResult,
+} from './code-server-manager-service.interface.js';

--- a/packages/core/src/application/use-cases/code-server/get-code-server-status.use-case.ts
+++ b/packages/core/src/application/use-cases/code-server/get-code-server-status.use-case.ts
@@ -1,0 +1,49 @@
+/**
+ * GetCodeServerStatusUseCase
+ *
+ * Queries the current status of a code-server instance for a given feature ID.
+ * Delegates to ICodeServerManagerService.getStatus() which handles PID liveness
+ * checks and auto-reconciliation of stale state.
+ */
+
+import { injectable, inject } from 'tsyringe';
+import type { ICodeServerManagerService } from '../../ports/output/services/code-server-manager-service.interface.js';
+import { CodeServerInstanceStatus } from '../../../domain/generated/output.js';
+
+export interface GetCodeServerStatusInput {
+  featureId: string;
+}
+
+export interface CodeServerStatusResult {
+  status: 'running' | 'stopped';
+  url?: string;
+  port?: number;
+}
+
+@injectable()
+export class GetCodeServerStatusUseCase {
+  constructor(
+    @inject('ICodeServerManagerService')
+    private readonly codeServerManager: ICodeServerManagerService
+  ) {}
+
+  async execute(input: GetCodeServerStatusInput): Promise<CodeServerStatusResult | null> {
+    const instance = await this.codeServerManager.getStatus(input.featureId);
+
+    if (!instance) {
+      return null;
+    }
+
+    if (instance.status === CodeServerInstanceStatus.Running) {
+      return {
+        status: 'running',
+        url: `http://127.0.0.1:${instance.port}`,
+        port: instance.port,
+      };
+    }
+
+    return {
+      status: 'stopped',
+    };
+  }
+}

--- a/packages/core/src/application/use-cases/code-server/start-code-server.use-case.ts
+++ b/packages/core/src/application/use-cases/code-server/start-code-server.use-case.ts
@@ -1,0 +1,67 @@
+/**
+ * StartCodeServerUseCase
+ *
+ * Orchestrates starting a code-server instance for a feature worktree:
+ * validates the feature exists, checks code-server is installed,
+ * computes the worktree path, and delegates to ICodeServerManagerService
+ * for process spawning. Idle timeout is managed by the service layer
+ * (reads from settings DB directly).
+ */
+
+import { injectable, inject } from 'tsyringe';
+import type { IFeatureRepository } from '../../ports/output/repositories/feature-repository.interface.js';
+import type { IToolInstallerService } from '../../ports/output/services/tool-installer.service.js';
+import type { ICodeServerManagerService } from '../../ports/output/services/code-server-manager-service.interface.js';
+import { computeWorktreePath } from '../../../infrastructure/services/ide-launchers/compute-worktree-path.js';
+
+export interface StartCodeServerInput {
+  featureId: string;
+  repositoryPath: string;
+  branch: string;
+}
+
+export interface StartCodeServerResult {
+  url: string;
+  port: number;
+}
+
+@injectable()
+export class StartCodeServerUseCase {
+  constructor(
+    @inject('IFeatureRepository')
+    private readonly featureRepository: IFeatureRepository,
+    @inject('IToolInstallerService')
+    private readonly toolInstallerService: IToolInstallerService,
+    @inject('ICodeServerManagerService')
+    private readonly codeServerManager: ICodeServerManagerService
+  ) {}
+
+  async execute(input: StartCodeServerInput): Promise<StartCodeServerResult> {
+    const { featureId, repositoryPath, branch } = input;
+
+    // Validate feature exists
+    const feature = await this.featureRepository.findById(featureId);
+    if (!feature) {
+      throw new Error(`Feature not found: ${featureId}`);
+    }
+
+    // Check code-server is installed
+    const availability = await this.toolInstallerService.checkAvailability('code-server');
+    if (availability.status !== 'available') {
+      throw new Error(
+        'code-server is not installed. Install it from the Tools page or run: brew install code-server'
+      );
+    }
+
+    // Compute worktree path
+    const worktreePath = computeWorktreePath(repositoryPath, branch);
+
+    // Delegate to manager service
+    const result = await this.codeServerManager.start(featureId, worktreePath);
+
+    return {
+      url: result.url,
+      port: result.port,
+    };
+  }
+}

--- a/packages/core/src/application/use-cases/code-server/stop-code-server.use-case.ts
+++ b/packages/core/src/application/use-cases/code-server/stop-code-server.use-case.ts
@@ -1,0 +1,26 @@
+/**
+ * StopCodeServerUseCase
+ *
+ * Stops a running code-server instance for a given feature ID by delegating
+ * to ICodeServerManagerService. The manager handles SIGTERM/SIGKILL shutdown
+ * and SQLite state updates.
+ */
+
+import { injectable, inject } from 'tsyringe';
+import type { ICodeServerManagerService } from '../../ports/output/services/code-server-manager-service.interface.js';
+
+export interface StopCodeServerInput {
+  featureId: string;
+}
+
+@injectable()
+export class StopCodeServerUseCase {
+  constructor(
+    @inject('ICodeServerManagerService')
+    private readonly codeServerManager: ICodeServerManagerService
+  ) {}
+
+  async execute(input: StopCodeServerInput): Promise<void> {
+    await this.codeServerManager.stop(input.featureId);
+  }
+}

--- a/packages/core/src/domain/factories/settings-defaults.factory.ts
+++ b/packages/core/src/domain/factories/settings-defaults.factory.ts
@@ -148,6 +148,9 @@ export function createDefaultSettings(): Settings {
     agent,
     notifications,
     workflow,
+    codeServer: {
+      idleTimeoutSeconds: 1800,
+    },
     onboardingComplete: false,
     createdAt: now,
     updatedAt: now,

--- a/packages/core/src/domain/generated/output.ts
+++ b/packages/core/src/domain/generated/output.ts
@@ -362,6 +362,16 @@ export type WorkflowConfig = {
    */
   ciLogMaxChars?: number;
 };
+
+/**
+ * code-server instance configuration
+ */
+export type CodeServerConfig = {
+  /**
+   * Idle timeout in seconds for code-server instances (default: 1800)
+   */
+  idleTimeoutSeconds: number;
+};
 export enum AgentType {
   ClaudeCode = 'claude-code',
   GeminiCli = 'gemini-cli',
@@ -499,6 +509,10 @@ export type Settings = BaseEntity & {
    * Global workflow configuration defaults
    */
   workflow: WorkflowConfig;
+  /**
+   * code-server instance configuration
+   */
+  codeServer: CodeServerConfig;
   /**
    * Whether first-run onboarding has been completed (default: false)
    */
@@ -1451,6 +1465,48 @@ export type ToolInstallCommand = {
    * Package manager identifier
    */
   packageManager: string;
+};
+export enum CodeServerInstanceStatus {
+  Running = 'running',
+  Stopped = 'stopped',
+}
+
+/**
+ * State of a managed code-server instance
+ */
+export type CodeServerInstance = {
+  /**
+   * Unique identifier for this instance record
+   */
+  id: string;
+  /**
+   * Feature ID this instance is scoped to
+   */
+  featureId: string;
+  /**
+   * OS process ID of the code-server process
+   */
+  pid: number;
+  /**
+   * Port code-server is bound to on localhost
+   */
+  port: number;
+  /**
+   * Absolute path to the feature worktree
+   */
+  worktreePath: string;
+  /**
+   * Current lifecycle status
+   */
+  status: CodeServerInstanceStatus;
+  /**
+   * When the instance was started
+   */
+  startedAt: any;
+  /**
+   * When the instance was stopped (if stopped)
+   */
+  stoppedAt?: any;
 };
 export enum AgentStatus {
   Idle = 'Idle',

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -44,6 +44,8 @@ import type { IIdeLauncherService } from '../../application/ports/output/service
 import { JsonDrivenIdeLauncherService } from '../services/ide-launchers/json-driven-ide-launcher.service.js';
 import type { IDaemonService } from '../../application/ports/output/services/daemon-service.interface.js';
 import { DaemonPidService } from '../services/daemon/daemon-pid.service.js';
+import type { ICodeServerManagerService } from '../../application/ports/output/services/code-server-manager-service.interface.js';
+import { CodeServerManagerService } from '../services/code-server/code-server-manager.service.js';
 
 // Agent infrastructure interfaces and implementations
 import type { IAgentExecutorFactory } from '../../application/ports/output/agents/agent-executor-factory.interface.js';
@@ -103,6 +105,9 @@ import { InstallToolUseCase } from '../../application/use-cases/tools/install-to
 import { ListToolsUseCase } from '../../application/use-cases/tools/list-tools.use-case.js';
 import { LaunchToolUseCase } from '../../application/use-cases/tools/launch-tool.use-case.js';
 import { LaunchIdeUseCase } from '../../application/use-cases/ide/launch-ide.use-case.js';
+import { StartCodeServerUseCase } from '../../application/use-cases/code-server/start-code-server.use-case.js';
+import { StopCodeServerUseCase } from '../../application/use-cases/code-server/stop-code-server.use-case.js';
+import { GetCodeServerStatusUseCase } from '../../application/use-cases/code-server/get-code-server-status.use-case.js';
 import { AddRepositoryUseCase } from '../../application/use-cases/repositories/add-repository.use-case.js';
 import { ListRepositoriesUseCase } from '../../application/use-cases/repositories/list-repositories.use-case.js';
 import { DeleteRepositoryUseCase } from '../../application/use-cases/repositories/delete-repository.use-case.js';
@@ -187,6 +192,12 @@ export async function initializeContainer(): Promise<typeof container> {
     JsonDrivenIdeLauncherService
   );
   container.registerSingleton<IDaemonService>('IDaemonService', DaemonPidService);
+  container.register<ICodeServerManagerService>('ICodeServerManagerService', {
+    useFactory: (c) => {
+      const database = c.resolve<Database.Database>('Database');
+      return new CodeServerManagerService(database);
+    },
+  });
 
   // Register agent infrastructure
   container.register<IAgentRunRepository>('IAgentRunRepository', {
@@ -309,6 +320,9 @@ export async function initializeContainer(): Promise<typeof container> {
   container.registerSingleton(ListToolsUseCase);
   container.registerSingleton(LaunchToolUseCase);
   container.registerSingleton(LaunchIdeUseCase);
+  container.registerSingleton(StartCodeServerUseCase);
+  container.registerSingleton(StopCodeServerUseCase);
+  container.registerSingleton(GetCodeServerStatusUseCase);
   container.registerSingleton(AddRepositoryUseCase);
   container.registerSingleton(ListRepositoriesUseCase);
   container.registerSingleton(DeleteRepositoryUseCase);
@@ -369,6 +383,15 @@ export async function initializeContainer(): Promise<typeof container> {
   });
   container.register('LaunchIdeUseCase', {
     useFactory: (c) => c.resolve(LaunchIdeUseCase),
+  });
+  container.register('StartCodeServerUseCase', {
+    useFactory: (c) => c.resolve(StartCodeServerUseCase),
+  });
+  container.register('StopCodeServerUseCase', {
+    useFactory: (c) => c.resolve(StopCodeServerUseCase),
+  });
+  container.register('GetCodeServerStatusUseCase', {
+    useFactory: (c) => c.resolve(GetCodeServerStatusUseCase),
   });
   container.register('AddRepositoryUseCase', {
     useFactory: (c) => c.resolve(AddRepositoryUseCase),

--- a/packages/core/src/infrastructure/persistence/sqlite/mappers/code-server-instance.mapper.ts
+++ b/packages/core/src/infrastructure/persistence/sqlite/mappers/code-server-instance.mapper.ts
@@ -1,0 +1,77 @@
+/**
+ * Code Server Instance Database Mapper
+ *
+ * Maps between CodeServerInstance domain objects and SQLite database rows.
+ *
+ * Mapping Rules:
+ * - TypeScript objects (camelCase) ↔ SQL columns (snake_case)
+ * - Dates stored as ISO 8601 strings
+ * - Optional stoppedAt stored as NULL when missing
+ * - Timestamps (created_at, updated_at) stored as INTEGER (epoch ms)
+ */
+
+import type {
+  CodeServerInstance,
+  CodeServerInstanceStatus,
+} from '../../../../domain/generated/output.js';
+
+/**
+ * Database row type matching the code_server_instances table schema.
+ */
+export interface CodeServerInstanceRow {
+  id: string;
+  feature_id: string;
+  pid: number;
+  port: number;
+  worktree_path: string;
+  status: string;
+  started_at: string;
+  stopped_at: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+/**
+ * Maps CodeServerInstance domain object to database row.
+ *
+ * @param instance - CodeServerInstance domain object
+ * @returns Database row object with snake_case columns
+ */
+export function toDatabase(instance: CodeServerInstance): CodeServerInstanceRow {
+  return {
+    id: instance.id,
+    feature_id: instance.featureId,
+    pid: instance.pid,
+    port: instance.port,
+    worktree_path: instance.worktreePath,
+    status: instance.status,
+    started_at:
+      instance.startedAt instanceof Date ? instance.startedAt.toISOString() : instance.startedAt,
+    stopped_at: instance.stoppedAt
+      ? instance.stoppedAt instanceof Date
+        ? instance.stoppedAt.toISOString()
+        : instance.stoppedAt
+      : null,
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+}
+
+/**
+ * Maps database row to CodeServerInstance domain object.
+ *
+ * @param row - Database row with snake_case columns
+ * @returns CodeServerInstance domain object with camelCase properties
+ */
+export function fromDatabase(row: CodeServerInstanceRow): CodeServerInstance {
+  return {
+    id: row.id,
+    featureId: row.feature_id,
+    pid: row.pid,
+    port: row.port,
+    worktreePath: row.worktree_path,
+    status: row.status as CodeServerInstanceStatus,
+    startedAt: new Date(row.started_at),
+    ...(row.stopped_at !== null && { stoppedAt: new Date(row.stopped_at) }),
+  };
+}

--- a/packages/core/src/infrastructure/persistence/sqlite/mappers/settings.mapper.ts
+++ b/packages/core/src/infrastructure/persistence/sqlite/mappers/settings.mapper.ts
@@ -77,6 +77,9 @@ export interface SettingsRow {
   approval_gate_allow_plan: number;
   approval_gate_allow_merge: number;
   approval_gate_push_on_impl_complete: number;
+
+  // CodeServerConfig (codeServer.*)
+  cs_idle_timeout_seconds: number;
 }
 
 /**
@@ -147,6 +150,9 @@ export function toDatabase(settings: Settings): SettingsRow {
       .pushOnImplementationComplete
       ? 1
       : 0,
+
+    // CodeServerConfig
+    cs_idle_timeout_seconds: settings.codeServer?.idleTimeoutSeconds ?? 1800,
   };
 }
 
@@ -225,6 +231,11 @@ export function fromDatabase(row: SettingsRow): Settings {
         allowMerge: row.approval_gate_allow_merge === 1,
         pushOnImplementationComplete: row.approval_gate_push_on_impl_complete === 1,
       },
+    },
+
+    // CodeServerConfig
+    codeServer: {
+      idleTimeoutSeconds: row.cs_idle_timeout_seconds ?? 1800,
     },
 
     // Onboarding (INTEGER → boolean)

--- a/packages/core/src/infrastructure/persistence/sqlite/migrations.ts
+++ b/packages/core/src/infrastructure/persistence/sqlite/migrations.ts
@@ -372,6 +372,33 @@ ALTER TABLE features ADD COLUMN ci_fix_history TEXT;
       add('notif_evt_pr_checks_failed');
     },
   },
+  {
+    version: 23,
+    sql: `
+-- Migration 023: Create code_server_instances table for managed code-server process state
+CREATE TABLE IF NOT EXISTS code_server_instances (
+  id TEXT PRIMARY KEY NOT NULL,
+  feature_id TEXT NOT NULL UNIQUE,
+  pid INTEGER NOT NULL,
+  port INTEGER NOT NULL,
+  worktree_path TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'running',
+  started_at TEXT NOT NULL,
+  stopped_at TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_cs_instances_feature ON code_server_instances(feature_id);
+CREATE INDEX IF NOT EXISTS idx_cs_instances_status ON code_server_instances(status);
+`,
+  },
+  {
+    version: 24,
+    sql: `
+-- Migration 024: Add code-server idle timeout setting to settings table
+ALTER TABLE settings ADD COLUMN cs_idle_timeout_seconds INTEGER NOT NULL DEFAULT 1800;
+`,
+  },
 ];
 
 /**

--- a/packages/core/src/infrastructure/services/code-server/code-server-manager.service.ts
+++ b/packages/core/src/infrastructure/services/code-server/code-server-manager.service.ts
@@ -1,0 +1,328 @@
+/**
+ * Code Server Manager Service
+ *
+ * Infrastructure service for managing code-server (VS Code in the browser) instance lifecycle.
+ * Implements ICodeServerManagerService output port.
+ *
+ * Handles: process spawning (detached), port allocation, SQLite state persistence,
+ * graceful shutdown (SIGTERM → SIGKILL), PID liveness checks, and startup reconciliation.
+ */
+
+import { spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type Database from 'better-sqlite3';
+
+import type {
+  ICodeServerManagerService,
+  CodeServerStartResult,
+} from '../../../application/ports/output/services/code-server-manager-service.interface.js';
+import type { CodeServerInstance } from '../../../domain/generated/output.js';
+import { CodeServerInstanceStatus } from '../../../domain/generated/output.js';
+import {
+  toDatabase,
+  fromDatabase,
+  type CodeServerInstanceRow,
+} from '../../persistence/sqlite/mappers/code-server-instance.mapper.js';
+import { findAvailablePort } from '../port.service.js';
+import { getShepHomeDir } from '../filesystem/shep-directory.service.js';
+
+/** Default port range start for code-server instances */
+const CODE_SERVER_PORT_START = 13370;
+
+/** Default idle timeout in seconds (30 minutes) */
+const DEFAULT_IDLE_TIMEOUT_SECONDS = 1800;
+
+/** Maximum time in ms to wait for graceful shutdown before SIGKILL */
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5000;
+
+/** Maximum concurrent instances before logging a warning */
+const MAX_INSTANCES_BEFORE_WARNING = 5;
+
+export class CodeServerManagerService implements ICodeServerManagerService {
+  constructor(private readonly db: Database.Database) {}
+
+  async start(featureId: string, worktreePath: string): Promise<CodeServerStartResult> {
+    // Idempotent: check for existing running instance
+    const existing = await this.getStatus(featureId);
+    if (existing?.status === CodeServerInstanceStatus.Running) {
+      return {
+        url: `http://127.0.0.1:${existing.port}`,
+        port: existing.port,
+        pid: existing.pid,
+        featureId: existing.featureId,
+      };
+    }
+
+    // Remove any stale/stopped instance record for this feature before inserting
+    this.db.prepare('DELETE FROM code_server_instances WHERE feature_id = ?').run(featureId);
+
+    // Allocate an available port
+    const port = await findAvailablePort(CODE_SERVER_PORT_START);
+
+    // Read idle timeout from settings
+    const idleTimeoutSeconds = this.readIdleTimeout();
+
+    // Build code-server arguments
+    const shepHome = getShepHomeDir();
+    const userDataDir = join(shepHome, 'code-server', 'user-data', featureId);
+    const extensionsDir = join(shepHome, 'code-server', 'extensions');
+    const logDir = join(shepHome, 'logs');
+
+    // Ensure directories exist
+    await mkdir(userDataDir, { recursive: true });
+    await mkdir(extensionsDir, { recursive: true });
+    await mkdir(logDir, { recursive: true });
+
+    const args = [
+      '--bind-addr',
+      `127.0.0.1:${port}`,
+      '--auth',
+      'none',
+      '--user-data-dir',
+      userDataDir,
+      '--extensions-dir',
+      extensionsDir,
+      '--idle-timeout',
+      String(idleTimeoutSeconds),
+      worktreePath,
+    ];
+
+    // Open log file for stdout/stderr
+    const logPath = join(logDir, `code-server-${featureId}.log`);
+    const logStream = createWriteStream(logPath, { flags: 'a' });
+
+    // Spawn code-server as a detached process
+    const child = spawn('code-server', args, {
+      detached: true,
+      stdio: ['ignore', logStream, logStream],
+    });
+    child.unref();
+
+    const pid = child.pid;
+    if (!pid) {
+      throw new Error('Failed to spawn code-server process: no PID returned');
+    }
+
+    // Persist instance state to SQLite
+    const id = randomUUID();
+    const now = new Date();
+    const instance: CodeServerInstance = {
+      id,
+      featureId,
+      pid,
+      port,
+      worktreePath,
+      status: CodeServerInstanceStatus.Running,
+      startedAt: now,
+    };
+
+    const row = toDatabase(instance);
+    this.db
+      .prepare(
+        `
+      INSERT INTO code_server_instances (
+        id, feature_id, pid, port, worktree_path, status,
+        started_at, stopped_at, created_at, updated_at
+      ) VALUES (
+        @id, @feature_id, @pid, @port, @worktree_path, @status,
+        @started_at, @stopped_at, @created_at, @updated_at
+      )
+    `
+      )
+      .run(row);
+
+    // Log warning if too many instances are running
+    const running = await this.listRunning();
+    if (running.length > MAX_INSTANCES_BEFORE_WARNING) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[code-server] ${running.length} instances are running simultaneously. ` +
+          `Each instance uses 300-500MB RAM. Consider stopping unused instances.`
+      );
+    }
+
+    return {
+      url: `http://127.0.0.1:${port}`,
+      port,
+      pid,
+      featureId,
+    };
+  }
+
+  async stop(featureId: string): Promise<void> {
+    const instance = this.findRunningInstance(featureId);
+    if (!instance) return;
+
+    const { pid } = instance;
+
+    // Try graceful shutdown with SIGTERM
+    if (this.isAlive(pid)) {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // Process may have already exited
+      }
+
+      // Wait up to 5 seconds for graceful shutdown
+      const dead = await this.waitForExit(pid, GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+
+      // Force kill if still alive
+      if (!dead) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // Process may have exited between check and kill
+        }
+      }
+    }
+
+    // Update SQLite record
+    this.markStopped(instance.id);
+  }
+
+  async getStatus(featureId: string): Promise<CodeServerInstance | null> {
+    const row = this.db
+      .prepare(
+        'SELECT * FROM code_server_instances WHERE feature_id = ? ORDER BY created_at DESC LIMIT 1'
+      )
+      .get(featureId) as CodeServerInstanceRow | undefined;
+
+    if (!row) return null;
+
+    const instance = fromDatabase(row);
+
+    // Auto-reconcile: if persisted as "running" but PID is dead, update to "stopped"
+    if (instance.status === CodeServerInstanceStatus.Running && !this.isAlive(instance.pid)) {
+      this.markStopped(instance.id);
+      return {
+        ...instance,
+        status: CodeServerInstanceStatus.Stopped,
+        stoppedAt: new Date(),
+      };
+    }
+
+    return instance;
+  }
+
+  async listRunning(): Promise<CodeServerInstance[]> {
+    const rows = this.db
+      .prepare('SELECT * FROM code_server_instances WHERE status = ?')
+      .all(CodeServerInstanceStatus.Running) as CodeServerInstanceRow[];
+
+    return rows.map(fromDatabase);
+  }
+
+  async stopAll(): Promise<void> {
+    const running = await this.listRunning();
+    for (const instance of running) {
+      try {
+        await this.stop(instance.featureId);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[code-server] Failed to stop instance for feature ${instance.featureId}:`,
+          error
+        );
+      }
+    }
+  }
+
+  async reconcile(): Promise<void> {
+    const running = await this.listRunning();
+    let stoppedCount = 0;
+
+    for (const instance of running) {
+      if (!this.isAlive(instance.pid)) {
+        this.markStopped(instance.id);
+        stoppedCount++;
+      }
+    }
+
+    if (running.length > 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[code-server] Reconciliation: checked ${running.length} instance(s), ` +
+          `marked ${stoppedCount} as stopped`
+      );
+    }
+  }
+
+  /**
+   * Check whether a process with the given PID is alive.
+   */
+  private isAlive(pid: number): boolean {
+    if (!Number.isFinite(pid) || !Number.isInteger(pid) || pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Find a running instance by feature ID from SQLite.
+   */
+  private findRunningInstance(featureId: string): CodeServerInstance | null {
+    const row = this.db
+      .prepare('SELECT * FROM code_server_instances WHERE feature_id = ? AND status = ? LIMIT 1')
+      .get(featureId, CodeServerInstanceStatus.Running) as CodeServerInstanceRow | undefined;
+
+    return row ? fromDatabase(row) : null;
+  }
+
+  /**
+   * Mark an instance as stopped in SQLite.
+   */
+  private markStopped(id: string): void {
+    this.db
+      .prepare(
+        'UPDATE code_server_instances SET status = ?, stopped_at = ?, updated_at = ? WHERE id = ?'
+      )
+      .run(CodeServerInstanceStatus.Stopped, new Date().toISOString(), Date.now(), id);
+  }
+
+  /**
+   * Read the idle timeout setting from the settings table.
+   * Falls back to the default if settings are not initialized.
+   */
+  private readIdleTimeout(): number {
+    try {
+      const row = this.db.prepare('SELECT cs_idle_timeout_seconds FROM settings LIMIT 1').get() as
+        | { cs_idle_timeout_seconds: number }
+        | undefined;
+      return row?.cs_idle_timeout_seconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS;
+    } catch {
+      return DEFAULT_IDLE_TIMEOUT_SECONDS;
+    }
+  }
+
+  /**
+   * Wait for a process to exit, checking periodically.
+   * Returns true if the process exited within the timeout, false otherwise.
+   */
+  private waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const interval = 100;
+      let elapsed = 0;
+
+      const check = () => {
+        if (!this.isAlive(pid)) {
+          resolve(true);
+          return;
+        }
+        elapsed += interval;
+        if (elapsed >= timeoutMs) {
+          resolve(false);
+          return;
+        }
+        setTimeout(check, interval);
+      };
+
+      check();
+    });
+  }
+}

--- a/packages/core/src/infrastructure/services/tool-installer/tools/code-server.json
+++ b/packages/core/src/infrastructure/services/tool-installer/tools/code-server.json
@@ -1,0 +1,18 @@
+{
+  "name": "code-server",
+  "summary": "VS Code in the browser — run a full editor from any machine",
+  "description": "code-server allows you to run VS Code on any machine and access it through the browser. Get a consistent development environment with full VS Code functionality including extensions, terminal, and debugging.",
+  "tags": ["ide"],
+  "iconUrl": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg",
+  "binary": "code-server",
+  "packageManager": "brew",
+  "commands": {
+    "linux": "curl -fsSL https://code-server.dev/install.sh | sh",
+    "darwin": "brew install code-server"
+  },
+  "timeout": 300000,
+  "documentationUrl": "https://coder.com/docs/code-server",
+  "verifyCommand": "code-server --version",
+  "autoInstall": true,
+  "openDirectory": "code-server --bind-addr 127.0.0.1:0 --auth none {dir}"
+}

--- a/specs/045-code-server-integration/feature.yaml
+++ b/specs/045-code-server-integration/feature.yaml
@@ -1,0 +1,41 @@
+feature:
+  id: 045-code-server-integration
+  name: code-server-integration
+  number: 45
+  branch: feat/045-code-server-integration
+  lifecycle: research
+  createdAt: '2026-02-25T20:27:33Z'
+status:
+  phase: implementation-complete
+  progress:
+    completed: 20
+    total: 20
+    percentage: 100
+  currentTask: null
+  lastUpdated: '2026-02-25T21:52:17.145Z'
+  lastUpdatedBy: feature-agent:implement
+  completedPhases:
+    - analyze
+    - requirements
+    - research
+    - plan
+    - phase-1
+    - phase-2
+    - phase-3
+    - phase-4
+    - phase-5
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+tasks:
+  current: null
+  blocked: []
+  failed: []
+checkpoints:
+  - phase: feature-created
+    completedAt: '2026-02-25T20:27:33Z'
+    completedBy: feature-agent
+errors:
+  current: null
+  history: []

--- a/specs/045-code-server-integration/plan.yaml
+++ b/specs/045-code-server-integration/plan.yaml
@@ -1,0 +1,255 @@
+# Implementation Plan (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: code-server-integration
+summary: >
+  Integrate code-server as a managed browser-based editor per feature worktree. The implementation
+  follows Clean Architecture in five phases: (1) domain model and persistence foundation,
+  (2) service interface and infrastructure implementation for process lifecycle management,
+  (3) use cases orchestrating business logic, (4) API routes exposing functionality to the web layer,
+  (5) web UI integration in the feature drawer's OpenActionMenu. Key decisions: spawn via
+  child_process.spawn detached (existing pattern), SQLite persistence via migration v23/v24,
+  port allocation starting at 13370 via existing findAvailablePort(), and SIGTERM/SIGKILL graceful
+  shutdown. All new code follows TDD (red-green-refactor) with Storybook stories for UI components.
+
+relatedFeatures: []
+
+technologies:
+  - code-server (coder/code-server v4.x) - VS Code in the browser
+  - Node.js child_process.spawn - detached process spawning
+  - better-sqlite3 - instance state persistence via migration v23/v24
+  - tsyringe - DI registration for new service and use cases
+  - Next.js App Router API routes - start/stop/status endpoints
+  - React/shadcn-ui - feature drawer UI additions
+  - TypeSpec - CodeServerInstance value object
+  - Lucide React icons - Globe icon for browser editor action
+
+relatedLinks:
+  - https://github.com/coder/code-server
+  - https://coder.com/docs/code-server
+
+phases:
+  - id: phase-1
+    name: 'Foundation — Domain Model, Tool Metadata & Persistence'
+    description: >
+      Establishes the data foundation that all subsequent phases depend on. Defines the
+      CodeServerInstance TypeSpec value object and CodeServerInstanceStatus enum, adds the
+      code-server.json tool metadata file, and creates SQLite migrations (v23 for
+      code_server_instances table, v24 for settings idle timeout column). Also includes the
+      SQLite mapper for database round-tripping. This phase has zero runtime dependencies and
+      produces the types, schema, and metadata consumed by all later phases.
+    parallel: false
+
+  - id: phase-2
+    name: 'Service Layer — Interface & Infrastructure Implementation'
+    description: >
+      Builds the core process lifecycle management service. Defines the ICodeServerManagerService
+      interface in the application ports layer, then implements CodeServerManagerService in the
+      infrastructure layer with: start (port allocation + spawn + persist), stop (SIGTERM/SIGKILL
+      + persist), getStatus (PID liveness + reconcile), listRunning, stopAll, and reconcile.
+      Registers the service in the DI container. This is the highest-complexity phase and the
+      heart of the feature.
+    parallel: false
+
+  - id: phase-3
+    name: 'Use Cases — Business Logic Orchestration'
+    description: >
+      Creates three thin use cases that orchestrate validation and delegation:
+      StartCodeServerUseCase (validate feature exists, check code-server installed, delegate to
+      manager), StopCodeServerUseCase (delegate stop), GetCodeServerStatusUseCase (delegate
+      status query). Each use case is registered in the DI container with string-token aliases
+      for web route resolution.
+    parallel: false
+
+  - id: phase-4
+    name: 'API Routes — Web Endpoints'
+    description: >
+      Exposes the use cases via three Next.js App Router API routes: POST /api/code-server/start,
+      POST /api/code-server/stop, GET /api/code-server/status. Each route resolves the
+      corresponding use case via the DI container, validates input, and returns JSON responses
+      following existing route patterns.
+    parallel: false
+
+  - id: phase-5
+    name: 'Web UI — Feature Drawer Integration & Storybook'
+    description: >
+      Integrates code-server controls into the feature drawer. Extends useFeatureActions hook
+      with browser editor actions (start, stop, status fetch). Adds a "Browser Editor" menu item
+      to OpenActionMenu with Globe icon, loading/error/running states, and disabled state when
+      code-server is not installed. Creates Storybook stories for all new/modified components
+      covering all states (loading, running, stopped, error, not installed).
+    parallel: false
+
+filesToCreate:
+  # Phase 1 — Foundation
+  - tsp/domain/value-objects/code-server-instance.tsp
+  - packages/core/src/infrastructure/services/tool-installer/tools/code-server.json
+  - packages/core/src/infrastructure/persistence/sqlite/mappers/code-server-instance.mapper.ts
+
+  # Phase 2 — Service Layer
+  - packages/core/src/application/ports/output/services/code-server-manager-service.interface.ts
+  - packages/core/src/infrastructure/services/code-server/code-server-manager.service.ts
+  - packages/core/src/infrastructure/services/code-server/code-server-manager.service.test.ts
+
+  # Phase 3 — Use Cases
+  - packages/core/src/application/use-cases/code-server/start-code-server.use-case.ts
+  - packages/core/src/application/use-cases/code-server/stop-code-server.use-case.ts
+  - packages/core/src/application/use-cases/code-server/get-code-server-status.use-case.ts
+  - packages/core/src/application/use-cases/code-server/start-code-server.use-case.test.ts
+  - packages/core/src/application/use-cases/code-server/stop-code-server.use-case.test.ts
+  - packages/core/src/application/use-cases/code-server/get-code-server-status.use-case.test.ts
+
+  # Phase 4 — API Routes
+  - src/presentation/web/app/api/code-server/start/route.ts
+  - src/presentation/web/app/api/code-server/stop/route.ts
+  - src/presentation/web/app/api/code-server/status/route.ts
+
+  # Phase 5 — Web UI
+  - src/presentation/web/components/common/open-action-menu/open-action-menu.stories.tsx
+
+filesToModify:
+  # Phase 1 — Foundation
+  - tsp/domain/value-objects/index.tsp
+  - packages/core/src/infrastructure/persistence/sqlite/migrations.ts
+
+  # Phase 1 — Settings
+  - tsp/domain/entities/settings.tsp
+  - packages/core/src/infrastructure/persistence/sqlite/mappers/settings.mapper.ts
+
+  # Phase 2 — DI
+  - packages/core/src/application/ports/output/services/index.ts
+  - packages/core/src/infrastructure/di/container.ts
+
+  # Phase 5 — Web UI
+  - src/presentation/web/components/common/feature-drawer/use-feature-actions.ts
+  - src/presentation/web/components/common/open-action-menu/open-action-menu.tsx
+  - src/presentation/web/components/common/open-action-menu/config.ts
+  - src/presentation/web/components/common/feature-drawer/feature-drawer.stories.tsx
+
+openQuestions: []
+
+content: |
+  ## Status
+
+  - **Phase:** Planning
+  - **Updated:** 2026-02-25
+
+  ## Architecture Overview
+
+  The code-server integration follows the established Clean Architecture pattern with dependencies
+  pointing inward. The feature introduces a new vertical slice through all four layers:
+
+  **Domain Layer** — A `CodeServerInstance` TypeSpec value object and `CodeServerInstanceStatus` enum
+  define the data shape for instance state (PID, port, feature ID, worktree path, status, timestamps).
+  This is a value object (not entity) because it has no independent business behavior — it is
+  process state managed entirely by the infrastructure service.
+
+  **Application Layer** — An `ICodeServerManagerService` output port interface defines the contract
+  for process lifecycle management (start, stop, getStatus, listRunning, stopAll, reconcile). Three
+  thin use cases (Start, Stop, GetStatus) orchestrate validation (feature exists, tool installed)
+  before delegating to the service interface.
+
+  **Infrastructure Layer** — `CodeServerManagerService` implements the interface using Node.js
+  `child_process.spawn` with `detached: true` for process spawning, the existing `findAvailablePort()`
+  for port allocation starting at 13370, SQLite for state persistence via a new migration (v23 for
+  the instances table, v24 for the settings idle timeout column), and PID liveness checks via
+  `process.kill(pid, 0)` for reconciliation.
+
+  **Presentation Layer** — Three Next.js API routes (start, stop, status) expose the use cases.
+  The feature drawer's existing `OpenActionMenu` gains a "Browser Editor" dropdown item that triggers
+  start/stop and opens code-server in a new browser tab.
+
+  ### Integration with Existing Systems
+
+  | System | Integration Point |
+  | ------ | ----------------- |
+  | Tool metadata | New `code-server.json` in tools/ — installation detection, tools page listing |
+  | Port service | Reuse `findAvailablePort()` starting at 13370 |
+  | PID liveness | Reuse `process.kill(pid, 0)` pattern from DaemonPidService |
+  | Process spawn | Follow `spawn(detached: true, unref())` pattern from FeatureAgentProcessService |
+  | SQLite migrations | Add v23 (instances table) and v24 (settings column) |
+  | DI container | Register service + use cases with string-token aliases |
+  | Settings entity | Add `codeServer` nested config section with `idleTimeoutSeconds` |
+  | Feature drawer | Extend OpenActionMenu with "Browser Editor" item |
+
+  ## Key Design Decisions
+
+  ### 1. spawn() with detached:true for Process Management
+  Code-server is an external binary, so `spawn()` (not `fork()`) is the correct Node.js API.
+  Detached mode allows the process to outlive the spawning request handler and survive daemon
+  restarts. This is the exact pattern used by FeatureAgentProcessService for background workers.
+  `child.unref()` ensures the parent process can exit cleanly.
+
+  ### 2. SQLite for Instance State Persistence
+  Multi-record state with querying needs (find by featureId, list all running) naturally fits
+  SQLite, which is already the primary persistence layer (22 migrations). A JSON state file
+  would be insufficient for concurrent instances. Migration v23 creates the instances table
+  with a UNIQUE constraint on feature_id for idempotent starts.
+
+  ### 3. Port 13370 Start Range
+  Well above the daemon port range (4050+) and common dev server ports (3000-8080). The existing
+  `findAvailablePort()` function handles sequential probing with up to 20 attempts, matching NFR-8.
+
+  ### 4. SIGTERM → 5s → SIGKILL Shutdown
+  Industry-standard graceful shutdown (Docker, Kubernetes, systemd). code-server handles SIGTERM
+  for state saving. The 5-second timeout balances cleanup time vs user wait time.
+
+  ### 5. Value Object (Not Entity) for CodeServerInstance
+  CodeServerInstance is ephemeral process state with no business logic or domain events. It follows
+  the pattern of existing value objects (ToolInstallationStatus, ToolInstallCommand). The manager
+  service owns all lifecycle behavior.
+
+  ### 6. OpenActionMenu Integration (Not Separate Button)
+  The feature drawer already has an "Open" dropdown containing IDE, Terminal, Specs Folder, and
+  Copy Path actions. Adding "Browser Editor" as another DropdownMenuItem is visually consistent,
+  discoverable, and avoids redundant UI patterns.
+
+  ### 7. On-Demand Status Fetching (Not Polling)
+  Status is fetched when the drawer opens and after start/stop actions. This avoids continuous
+  polling overhead for state that changes infrequently. External changes (crash, idle timeout)
+  are caught on the next drawer open.
+
+  ### 8. Shared Extensions, Per-Instance User Data
+  Extensions are heavyweight and should be installed once (`--extensions-dir ~/.shep/code-server/extensions/`).
+  Workspace state is per-feature (`--user-data-dir ~/.shep/code-server/user-data/<featureId>/`).
+
+  ## Implementation Strategy
+
+  The five phases are ordered by dependency — each phase builds on the previous:
+
+  **Phase 1 (Foundation)** comes first because it produces the types, schema, and metadata that
+  all subsequent phases consume. The TypeSpec value object generates types used by the mapper,
+  service, and use cases. The SQLite migration creates the table used by the service. The tool
+  metadata enables installation detection used by the UI.
+
+  **Phase 2 (Service Layer)** is the highest-complexity phase and the core of the feature. It
+  depends on Phase 1's types and schema. The service encapsulates all process lifecycle logic
+  (spawn, track, stop, reconcile) behind an interface that use cases and tests can mock.
+
+  **Phase 3 (Use Cases)** depends on Phase 2's interface. The use cases are thin orchestrators
+  that validate preconditions (feature exists, tool installed) before delegating to the service.
+  They are the boundary between presentation and infrastructure.
+
+  **Phase 4 (API Routes)** depends on Phase 3's use cases. Routes are thin handlers that resolve
+  use cases via DI, validate request input, and return JSON responses.
+
+  **Phase 5 (Web UI)** depends on Phase 4's API routes. The UI calls the routes and displays
+  results. This phase also adds Storybook stories for all new/modified components.
+
+  ## Risk Mitigation
+
+  | Risk | Mitigation |
+  | ---- | ---------- |
+  | code-server not installed on host | Tool metadata enables install detection. UI disables button with tooltip. Start use case validates installation before spawning. |
+  | Port collisions with other services | Start at 13370, well above common ranges. findAvailablePort() probes up to 20 ports sequentially. |
+  | Orphaned processes after daemon restart | Reconciliation on service init: query "running" instances, check PID liveness, mark dead ones as stopped. |
+  | code-server crashes unexpectedly | Status check uses PID liveness. Dead PID → status updated to stopped. User can re-launch. |
+  | Resource exhaustion (300-500MB per instance) | Manual launch only (no auto-start). Log warning at 5+ simultaneous instances (NFR-9). Idle timeout default 30 min. |
+  | Race condition: duplicate start for same feature | Idempotent start: check for existing running instance first (UNIQUE constraint on feature_id). Return existing URL if alive. |
+  | Process stop hangs (SIGTERM not handled) | 5-second timeout with SIGKILL fallback ensures process always terminates. |
+  | TypeSpec compilation breaks existing types | Run `pnpm tsp:compile` after changes. Value object is additive (new model, no modifications to existing). |
+  | Migration conflicts with other branches | Use next sequential version (v23/v24). If conflict detected during merge, renumber. |
+
+  ---
+
+  _Plan complete — proceed to task breakdown_

--- a/specs/045-code-server-integration/research.yaml
+++ b/specs/045-code-server-integration/research.yaml
@@ -1,0 +1,650 @@
+# Research Artifact (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: code-server-integration
+summary: >
+  Technical research for integrating code-server as a managed browser-based editor per feature
+  worktree. The implementation follows existing Clean Architecture patterns: a new
+  ICodeServerManagerService interface in the application layer, a CodeServerManagerService
+  infrastructure implementation using Node.js child_process.spawn for detached process lifecycle,
+  SQLite persistence via migration v23 for instance state, three thin use cases, Next.js API routes,
+  and feature drawer UI integration via an additional "Browser Editor" action in the existing
+  OpenActionMenu. No new external libraries required — all functionality leverages existing
+  codebase patterns (port service, PID liveness, tool metadata, DI container).
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - code-server (coder/code-server v4.x) - VS Code in the browser, installed via tool metadata system
+  - Node.js child_process.spawn - detached process spawning (existing pattern from FeatureAgentProcessService)
+  - better-sqlite3 - instance state persistence via new migration (existing dependency)
+  - tsyringe - DI registration for new service and use cases (existing dependency)
+  - Next.js App Router API routes - three new endpoints for start/stop/status
+  - React/shadcn-ui - feature drawer UI additions (Button, Tooltip, DropdownMenuItem)
+  - TypeSpec - domain model for CodeServerInstance value object
+  - Lucide React icons - Globe icon for browser editor action (existing dependency)
+
+relatedLinks:
+  - https://github.com/coder/code-server
+  - https://coder.com/docs/code-server/install
+  - https://coder.com/docs/code-server/guide
+
+decisions:
+  - title: 'Process Spawning Strategy'
+    chosen: 'Node.js child_process.spawn with detached:true + unref()'
+    rejected:
+      - 'fork() with IPC channel — fork() is for Node.js modules with IPC messaging; code-server is an external binary, not a .js module. spawn() is the correct API for external executables.'
+      - 'exec() with shell wrapper — exec() buffers all stdout/stderr in memory, inappropriate for a long-running server process that may run for hours. Also lacks detached process support.'
+      - 'Third-party process manager (pm2, forever) — adds unnecessary runtime dependency when Node.js built-in child_process already provides detached process management. The codebase already uses spawn successfully for IDE launchers and agent processes.'
+    rationale: >
+      spawn() with detached:true is the established pattern in this codebase for long-running
+      background processes. The FeatureAgentProcessService (feature-agent-process.service.ts)
+      demonstrates the exact pattern: spawn/fork detached, redirect stdio to log file, call
+      child.unref() so the parent can exit independently. code-server is an external binary
+      (not a Node module), so spawn() (not fork()) is the correct API. The process needs to
+      outlive the spawning request handler and survive daemon restarts, which detached mode
+      provides. Logging stdout/stderr to ~/.shep/logs/code-server-<featureId>.log follows the
+      existing worker log file pattern.
+
+  - title: 'Instance State Persistence'
+    chosen: 'SQLite table via migration (code_server_instances)'
+    rejected:
+      - 'JSON state file (like daemon.json) — while the daemon PID service uses a JSON file, that is for a single singleton record. code-server needs to track multiple concurrent instances with querying capability (find by featureId, list all running). SQLite is the natural choice for multi-record state that supports queries and transactions.'
+      - 'In-memory Map only (no persistence) — loses all instance tracking on daemon restart, making orphan cleanup impossible. The requirement explicitly states state must survive daemon restarts for reconciliation.'
+    rationale: >
+      The codebase uses SQLite (better-sqlite3) as its primary persistence layer with a
+      well-established migration system (22 versions so far). Adding migration v23 for a
+      code_server_instances table follows the exact same pattern. SQLite provides: transactional
+      writes for atomicity (FR-5 requirement), indexed queries by feature_id (UNIQUE constraint),
+      and survival across daemon restarts for reconciliation (FR-12). The existing mapper pattern
+      (toDatabase/fromDatabase) will be used for type conversion.
+
+  - title: 'Port Allocation Strategy'
+    chosen: 'Reuse existing findAvailablePort() starting at port 13370'
+    rejected:
+      - 'Let code-server pick its own port (--bind-addr 127.0.0.1:0) — while code-server supports binding to port 0 for OS-assigned ports, we need to know the port before the process fully starts to return it to the UI immediately. Parsing stdout for the port introduces race conditions and complexity. The existing port service is proven and deterministic.'
+      - 'Fixed port per feature (hash-based) — deterministic but risks collisions if the same feature is restarted rapidly. Sequential probing is simpler and proven in the codebase.'
+    rationale: >
+      The existing port.service.ts provides findAvailablePort() which uses the node:net try-bind
+      pattern (same as Vite). Starting at port 13370 (well above the daemon port range starting
+      at 4050) avoids collisions. The function supports a maxAttempts parameter (default 20),
+      matching NFR-8. This approach is proven in the codebase, avoids race conditions from port 0
+      auto-assignment, and gives us the port synchronously before spawning code-server.
+
+  - title: 'Service Layer Architecture'
+    chosen: 'ICodeServerManagerService interface in application/ports + implementation in infrastructure/services'
+    rejected:
+      - 'Inline logic in use cases — violates single responsibility and makes testing harder. The manager encapsulates process lifecycle, port allocation, and state persistence which are infrastructure concerns that should not leak into use cases.'
+      - 'Extend existing IIdeLauncherService — the IDE launcher is fire-and-forget (spawn and forget). code-server needs lifecycle management (start, stop, status, reconciliation) which is fundamentally different. Forcing this into the IDE launcher interface would violate interface segregation.'
+    rationale: >
+      Clean Architecture requires infrastructure concerns (process management, SQLite queries) to
+      live behind an application-layer interface. The codebase consistently follows this pattern:
+      IDaemonService, IToolInstallerService, IFeatureAgentProcessService all define interfaces in
+      application/ports/output/services/ with implementations in infrastructure/services/. The new
+      ICodeServerManagerService follows the same convention. Use cases depend only on the interface,
+      enabling unit testing with mocks.
+
+  - title: 'Settings Integration for Idle Timeout'
+    chosen: 'New codeServer config section in Settings TypeSpec model'
+    rejected:
+      - 'Hardcoded constant — violates FR-26 which requires the idle timeout to be configurable. Users with different workflows need different timeouts.'
+      - 'Separate config file (~/.shep/code-server-config.json) — fragments configuration across multiple storage mechanisms. The codebase already has a comprehensive Settings entity with TypeSpec model, SQLite persistence, and API routes. Adding a field there is consistent and discoverable.'
+      - 'Environment variable only — not persistent, not discoverable via UI, and inconsistent with how all other settings are managed in the codebase.'
+    rationale: >
+      The Settings entity (tsp/domain/entities/settings.tsp) is the single source of truth for
+      all user-configurable values. Adding a codeServer section with idleTimeoutSeconds follows
+      the pattern of existing nested config objects (models, environment, system, agent, workflow,
+      notifications). The setting will need a new SQLite migration to add the column, a TypeSpec
+      model update, and mapper updates — all following established patterns. The default of 1800
+      seconds (30 minutes) matches code-server's --idle-timeout-seconds behavior.
+
+  - title: 'Tool Metadata Registration Approach'
+    chosen: 'New code-server.json in tools/ directory with standard metadata schema'
+    rejected:
+      - 'Programmatic registration in container.ts — all other tools use JSON metadata files loaded dynamically by tool-metadata.ts. A programmatic exception for code-server would break the data-driven pattern and require code changes to modify tool configuration.'
+      - 'Custom tool type outside existing system — the existing tool metadata system already handles installation detection (verifyCommand), install commands, and directory opening. code-server fits naturally as an IDE-tagged tool.'
+    rationale: >
+      The tool metadata system (tool-metadata.ts) dynamically loads all .json files from the tools/
+      directory. There are currently 10 tool definitions following an identical schema. Adding
+      code-server.json with binary: "code-server", tags: ["ide"], verifyCommand:
+      "code-server --version", and platform-specific install commands follows the exact established
+      pattern. The openDirectory field can be set to enable basic launch-from-tools-page behavior,
+      while the dedicated CodeServerManagerService handles the richer lifecycle management.
+
+  - title: 'Graceful Shutdown Strategy'
+    chosen: 'SIGTERM with 5-second timeout, then SIGKILL fallback'
+    rejected:
+      - 'SIGKILL immediately — does not give code-server time to save state and close connections gracefully. Could corrupt workspace state files.'
+      - 'SIGTERM only with no timeout — if code-server hangs, the process would never terminate, leaking resources indefinitely.'
+      - 'SIGINT (Ctrl+C equivalent) — while code-server handles SIGINT, SIGTERM is the standard signal for graceful termination of server processes. SIGINT is conventionally for interactive terminal processes.'
+    rationale: >
+      SIGTERM → wait → SIGKILL is the industry standard for graceful process termination (used by
+      Docker, Kubernetes, systemd). code-server handles SIGTERM to save state and close connections.
+      The 5-second timeout (FR-9) balances giving code-server time to clean up while not blocking
+      the user. This pattern matches the conceptual approach used by the existing daemon shutdown
+      flow. Implementation: process.kill(pid, 'SIGTERM'), setTimeout 5000ms, check isAlive(),
+      if still alive process.kill(pid, 'SIGKILL').
+
+  - title: 'UI Integration Point'
+    chosen: 'Add "Browser Editor" as new DropdownMenuItem in existing OpenActionMenu'
+    rejected:
+      - 'Separate standalone button in feature drawer — the drawer already has an "Open" dropdown (OpenActionMenu) containing IDE, Terminal, and Specs Folder actions. Adding a separate button would break visual consistency and create redundant UI patterns.'
+      - 'New section/panel in feature drawer — over-engineering for a single action button. The action is conceptually identical to "Open in IDE" — it opens the code in an editor, just browser-based instead of desktop.'
+    rationale: >
+      The feature drawer renders a DrawerActions component that delegates to OpenActionMenu. This
+      dropdown already contains IDE, Terminal, Specs Folder, and Copy Path actions (open-action-menu.tsx).
+      Adding "Browser Editor" as a new DropdownMenuItem is the natural integration point — it is
+      visually consistent, discoverable, and follows the established action menu pattern. The menu
+      item will use the Globe icon from lucide-react (already a dependency) to distinguish it from
+      the desktop IDE action (Code2 icon). When code-server is not installed, the item will be
+      disabled with a tooltip.
+
+  - title: 'API Route Design'
+    chosen: 'Three dedicated routes under /api/code-server/ (start, stop, status)'
+    rejected:
+      - 'Single route with action parameter (/api/code-server?action=start) — conflates different HTTP semantics. Start and stop are mutations (POST), status is a query (GET). A single endpoint would need to handle all methods and actions, making it harder to reason about.'
+      - 'Extend existing /api/tools routes — the tools API handles generic tool listing, installation, and launching. code-server lifecycle management (start with state persistence, stop with graceful shutdown, status with PID liveness) is domain-specific and does not fit the generic tools contract.'
+    rationale: >
+      The codebase uses dedicated route files per operation, following Next.js App Router conventions.
+      Three routes provide clear separation: POST /api/code-server/start (mutation → create instance),
+      POST /api/code-server/stop (mutation → terminate instance), GET /api/code-server/status
+      (query → check liveness). Each route is a thin handler that resolves the corresponding use
+      case via DI and returns JSON. This matches the pattern of existing routes like /api/tools/[id]/
+      install and /api/tools/[id]/launch.
+
+  - title: 'TypeSpec Domain Model Approach'
+    chosen: 'CodeServerInstance as a value object (not entity) in tsp/domain/value-objects/'
+    rejected:
+      - 'Full entity extending BaseEntity — CodeServerInstance is process state tracked by the manager service, not a first-class domain entity with independent business behavior. It does not have domain events or business rules beyond simple state tracking. Entities are reserved for core domain objects like Feature, Repository, Settings.'
+      - 'No TypeSpec model (raw TypeScript types only) — violates the MANDATORY TypeSpec-first rule. All domain types must be defined in TypeSpec and compiled to generated output.ts.'
+    rationale: >
+      CodeServerInstance represents ephemeral process state (PID, port, status, timestamps) managed
+      entirely by the CodeServerManagerService. It has no independent business logic or domain events.
+      In DDD terms, this is a value object — a data structure whose identity comes from the featureId
+      it is associated with, not from its own id. The TypeSpec model defines the shape used in the
+      SQLite mapper, API responses, and UI state. Placing it in tsp/domain/value-objects/ alongside
+      ToolInstallationStatus and ToolInstallCommand follows the established value object pattern.
+
+  - title: 'Process Reconciliation on Startup'
+    chosen: 'Query all "running" instances from SQLite, check PID liveness, mark dead ones as stopped'
+    rejected:
+      - 'No reconciliation (trust persisted state) — after daemon restart, stored PIDs may reference dead processes. Without reconciliation, the UI would show instances as "running" when they are actually stopped, confusing users.'
+      - 'Kill all instances on startup (clean slate) — unnecessarily destroys running instances that survived the daemon restart. code-server processes are detached and can survive daemon restarts — reconciliation should preserve working instances.'
+    rationale: >
+      On service initialization, the manager queries all instances with status "running" from
+      SQLite, then checks each PID with process.kill(pid, 0) — the same isAlive() pattern used
+      by DaemonPidService and FeatureAgentProcessService. Instances with dead PIDs are updated
+      to "stopped" with stopped_at timestamp. This is the minimal correct reconciliation: preserve
+      live instances, clean up dead ones. The reconciliation runs once at service construction
+      time (or first method call), keeping it simple and predictable.
+
+# Open questions (all resolved)
+openQuestions:
+  - question: 'Should the code-server idle timeout setting live in a new codeServer section of Settings, or as a standalone settings field?'
+    resolved: true
+    options:
+      - option: 'New codeServer section in Settings model'
+        description: >
+          Add a CodeServerConfig nested model to Settings with idleTimeoutSeconds field.
+          Follows the pattern of existing nested config objects (models, environment, system,
+          agent, workflow, notifications). Extensible if more code-server settings are added later
+          (e.g., default extensions, theme). Requires TypeSpec model change, migration for new
+          column, and mapper update.
+        selected: true
+      - option: 'Flat field on Settings (codeServerIdleTimeoutSeconds)'
+        description: >
+          Add a single flat column to the settings table. Simpler migration but does not group
+          code-server settings logically. If more code-server settings are added later, they
+          would be scattered as unrelated flat fields.
+        selected: false
+      - option: 'Separate codeServer settings stored in the code_server_instances metadata'
+        description: >
+          Store timeout configuration per-instance rather than globally. Allows per-feature
+          timeouts but adds complexity. Most users want a single global default. Per-feature
+          override can be added later if needed.
+        selected: false
+    selectionRationale: >
+      A new codeServer section follows the established pattern where each functional area gets
+      its own nested config model in Settings (models: ModelConfiguration, agent: AgentConfig,
+      workflow: WorkflowConfig, etc.). This provides a clean namespace for future code-server
+      settings (default extensions, preferred theme, max concurrent instances) without polluting
+      the flat settings namespace. The migration adds a single column (cs_idle_timeout_seconds
+      INTEGER DEFAULT 1800) with a handler for safety.
+
+  - question: 'How should the feature drawer know the featureId to pass to the code-server API?'
+    resolved: true
+    options:
+      - option: 'Use selectedNode.featureId from FeatureDrawerProps (already available)'
+        description: >
+          The FeatureDrawer already receives selectedNode: FeatureNodeData which contains
+          featureId, repositoryPath, and branch. These are exactly the fields needed by the
+          POST /api/code-server/start endpoint. No additional data fetching or prop threading
+          required.
+        selected: true
+      - option: 'Fetch feature details via a separate API call from the drawer'
+        description: >
+          Make a GET /api/features/:id call to retrieve full feature details. Unnecessary
+          since FeatureNodeData already contains all required fields (featureId, repositoryPath,
+          branch).
+        selected: false
+      - option: 'Pass featureId as a URL param to a dedicated code-server page'
+        description: >
+          Navigate to a /code-server?featureId=xxx page that handles the launch. Over-engineered
+          for a single action button. The pattern of calling APIs from the drawer is already
+          established by openIde/openShell actions.
+        selected: false
+    selectionRationale: >
+      FeatureNodeData already contains featureId, repositoryPath, and branch — all the data
+      needed for the start API. The DrawerActions component (feature-drawer.tsx:276-292) receives
+      repositoryPath and branch, and could trivially receive featureId as well. The existing
+      useFeatureActions hook demonstrates the exact pattern: call an API with feature data,
+      manage loading/error state, clear errors after timeout.
+
+  - question: 'Should the code-server status be polled or fetched on-demand in the feature drawer?'
+    resolved: true
+    options:
+      - option: 'Fetch on-demand when drawer opens + after start/stop actions'
+        description: >
+          Call GET /api/code-server/status?featureId=xxx when the drawer opens for a feature,
+          and refetch after start/stop mutations. Simple, predictable, and avoids continuous
+          polling overhead. Status is only relevant when the user is looking at the drawer.
+        selected: true
+      - option: 'Continuous polling via setInterval (every 5 seconds)'
+        description: >
+          Poll status every 5 seconds while the drawer is open. Catches external state changes
+          (e.g., code-server crashes, idle timeout) automatically. But adds network overhead and
+          complexity for a state that changes infrequently.
+        selected: false
+      - option: 'Server-Sent Events (SSE) for real-time status updates'
+        description: >
+          Use the existing /api/agent-events SSE pattern to push code-server status changes.
+          Real-time but significantly more complex — requires adding code-server events to the
+          SSE polling loop, which currently only handles agent run and feature lifecycle events.
+        selected: false
+    selectionRationale: >
+      On-demand fetching is the simplest approach and matches how the feature drawer currently
+      works — it renders data passed via props without continuous polling. Status is fetched
+      when the drawer opens (via useEffect) and refetched after start/stop actions. The NFR-14
+      requirement for 2-second UI updates is naturally met since the user triggers start/stop
+      actions and sees the result immediately. External state changes (crash, idle timeout) are
+      caught on the next drawer open. If real-time updates become important, SSE can be added
+      later without changing the API contract.
+
+content: |
+  ## Technology Decisions
+
+  ### 1. Process Spawning Strategy
+
+  **Chosen:** Node.js child_process.spawn with detached:true + unref()
+
+  **Rejected:**
+  - fork() with IPC channel — code-server is an external binary, not a Node.js module
+  - exec() with shell wrapper — buffers all output in memory, inappropriate for long-running servers
+  - Third-party process manager (pm2) — unnecessary dependency when built-in child_process suffices
+
+  **Rationale:** spawn() with detached:true is the established pattern in this codebase
+  (FeatureAgentProcessService uses fork with detached:true for background workers). code-server
+  is an external binary, so spawn() is the correct API. The process needs to outlive request
+  handlers and survive daemon restarts, which detached mode provides.
+
+  ### 2. Instance State Persistence
+
+  **Chosen:** SQLite table via migration v23 (code_server_instances)
+
+  **Rejected:**
+  - JSON state file — insufficient for multi-record querying and concurrent instance tracking
+  - In-memory Map only — loses state on daemon restart, prevents orphan cleanup
+
+  **Rationale:** The codebase uses SQLite as its primary persistence layer with 22 existing
+  migrations. A new table provides transactional writes, indexed queries by feature_id, and
+  survival across daemon restarts for reconciliation.
+
+  ### 3. Port Allocation Strategy
+
+  **Chosen:** Reuse existing findAvailablePort() starting at port 13370
+
+  **Rejected:**
+  - Let code-server pick its own port (bind to 0) — requires parsing stdout for actual port
+  - Fixed port per feature (hash-based) — risks collisions on rapid restart
+
+  **Rationale:** The existing port.service.ts is proven and deterministic. Starting at 13370
+  avoids the daemon port range (4050+). The port is known before spawning, eliminating race
+  conditions.
+
+  ### 4. Service Layer Architecture
+
+  **Chosen:** ICodeServerManagerService interface in application/ports + implementation in infrastructure/services
+
+  **Rejected:**
+  - Inline logic in use cases — violates SRP, harder to test
+  - Extend IIdeLauncherService — fire-and-forget launcher is fundamentally different from lifecycle management
+
+  **Rationale:** Clean Architecture output port pattern (IDaemonService, IToolInstallerService,
+  IFeatureAgentProcessService) establishes this convention. Use cases depend only on the interface.
+
+  ### 5. Settings Integration for Idle Timeout
+
+  **Chosen:** New codeServer config section in Settings TypeSpec model
+
+  **Rejected:**
+  - Hardcoded constant — violates FR-26 configurability requirement
+  - Separate config file — fragments configuration storage
+  - Environment variable only — not persistent or discoverable via UI
+
+  **Rationale:** Settings entity is the single source of truth for all user configuration.
+  Adding a codeServer section follows the pattern of existing nested config objects.
+
+  ### 6. Tool Metadata Registration
+
+  **Chosen:** New code-server.json in tools/ directory
+
+  **Rejected:**
+  - Programmatic registration — breaks the data-driven JSON loading pattern
+  - Custom tool type — the existing metadata schema already handles all required fields
+
+  **Rationale:** The tool-metadata.ts loader dynamically discovers .json files in tools/.
+  code-server.json with binary: "code-server", tags: ["ide"], and platform-specific install
+  commands follows the exact pattern of the 10 existing tool definitions.
+
+  ### 7. Graceful Shutdown Strategy
+
+  **Chosen:** SIGTERM with 5-second timeout, then SIGKILL fallback
+
+  **Rejected:**
+  - SIGKILL immediately — no graceful cleanup, may corrupt state
+  - SIGTERM only — hangs forever if process is stuck
+  - SIGINT — SIGTERM is the standard for server termination
+
+  **Rationale:** SIGTERM → wait → SIGKILL is industry standard (Docker, Kubernetes, systemd).
+  code-server handles SIGTERM for graceful state saving.
+
+  ### 8. UI Integration Point
+
+  **Chosen:** Add "Browser Editor" as new DropdownMenuItem in existing OpenActionMenu
+
+  **Rejected:**
+  - Separate standalone button — breaks visual consistency with existing drawer pattern
+  - New section/panel — over-engineering for a single action
+
+  **Rationale:** The OpenActionMenu dropdown already contains IDE, Terminal, and Specs Folder
+  actions. Adding "Browser Editor" with a Globe icon is the natural, consistent integration point.
+
+  ### 9. API Route Design
+
+  **Chosen:** Three dedicated routes under /api/code-server/ (start, stop, status)
+
+  **Rejected:**
+  - Single route with action parameter — conflates HTTP semantics
+  - Extend existing /api/tools routes — code-server lifecycle is domain-specific
+
+  **Rationale:** Dedicated routes per operation follow Next.js App Router conventions and
+  match existing route patterns (tools/[id]/install, tools/[id]/launch).
+
+  ### 10. TypeSpec Model Approach
+
+  **Chosen:** CodeServerInstance as a value object in tsp/domain/value-objects/
+
+  **Rejected:**
+  - Full entity extending BaseEntity — it is process state, not a core domain entity
+  - Raw TypeScript types only — violates MANDATORY TypeSpec-first rule
+
+  **Rationale:** CodeServerInstance is ephemeral process state with no independent business logic.
+  It follows the pattern of existing value objects (ToolInstallationStatus, ToolInstallCommand).
+
+  ### 11. Process Reconciliation on Startup
+
+  **Chosen:** Query "running" instances from SQLite, check PID liveness, mark dead ones as stopped
+
+  **Rejected:**
+  - No reconciliation — stale state would confuse users
+  - Kill all instances on restart — destroys surviving instances unnecessarily
+
+  **Rationale:** Minimal correct reconciliation using the existing isAlive() pattern from
+  DaemonPidService and FeatureAgentProcessService.
+
+  ## Library Analysis
+
+  | Library | Purpose | Decision | Reasoning |
+  | ------- | ------- | -------- | --------- |
+  | code-server (coder/code-server) | VS Code in the browser | Use (external binary) | Core requirement. Installed via tool metadata system, not as npm dependency. |
+  | Node.js child_process (built-in) | Process spawning | Use | Already used throughout codebase for agent processes and IDE launchers. No new dependency. |
+  | better-sqlite3 (existing) | Instance state persistence | Use | Already the primary persistence layer. Adding migration v23 follows existing pattern. |
+  | tsyringe (existing) | Dependency injection | Use | All services and use cases registered via tsyringe. No new DI patterns needed. |
+  | lucide-react (existing) | Globe icon for UI | Use | Already used for all drawer icons (Code2, Terminal, FolderOpen). Globe icon available. |
+  | node-pty / xterm.js | Embedded terminal for code-server | Reject | code-server provides its own terminal. No need for additional terminal libraries. |
+  | pm2 / forever | Process management | Reject | Overkill dependency. Built-in child_process with detached mode is sufficient and proven in codebase. |
+  | get-port (npm package) | Port finding | Reject | The existing port.service.ts provides equivalent functionality. No need for external dependency. |
+  | tree-kill (npm package) | Process tree killing | Reject | code-server is a single process, not a process tree. Standard process.kill(pid) with SIGTERM/SIGKILL is sufficient. |
+
+  ## Security Considerations
+
+  ### Localhost-Only Binding (NFR-6)
+  code-server instances MUST bind exclusively to 127.0.0.1 via `--bind-addr 127.0.0.1:<port>`.
+  The manager service hardcodes this — it is never configurable. This ensures code-server is
+  only accessible from the local machine, matching the Shep daemon's own localhost binding.
+
+  ### No Authentication for Localhost (Spec Decision)
+  Using `--auth none` is safe because the bind address is 127.0.0.1. This is the standard
+  pattern for local dev tools (Vite dev server, Storybook, webpack-dev-server). If Shep adds
+  remote/cloud support in the future, authentication must be revisited.
+
+  ### Feature ID Validation (NFR-7)
+  The StartCodeServerUseCase must validate that the requested featureId exists in the features
+  table and has a valid repositoryPath before spawning an instance. This prevents:
+  - Resource exhaustion from invalid feature IDs
+  - Path traversal via crafted worktree paths
+
+  ### Process Isolation
+  Each code-server instance runs with the same OS user as the Shep daemon. There is no
+  additional sandboxing. This is acceptable for a local development tool but should be
+  documented as a limitation.
+
+  ### Port Range Isolation (NFR-8)
+  Starting at port 13370 with up to 20 attempts keeps code-server ports well separated from:
+  - Shep daemon (4050+)
+  - Common development server ports (3000-8080)
+  - Ephemeral OS ports (32768+)
+
+  ## Performance Implications
+
+  ### Resource Consumption
+  Each code-server instance consumes 300-500MB RAM (documented in spec). The service logs a
+  warning when more than 5 instances are running simultaneously (NFR-9). This is a log warning,
+  not a hard limit — users with sufficient resources can run more.
+
+  ### Spawn Latency (NFR-1)
+  The critical path for start is: findAvailablePort() → spawn() → persist to SQLite → return URL.
+  - Port finding: ~10-50ms (sequential net.createServer attempts)
+  - Process spawn: ~100-200ms (OS fork + exec)
+  - SQLite insert: ~1-5ms (WAL mode)
+  - Total: well under the 3-second NFR-1 requirement
+
+  Note: The user may need to wait a few seconds after opening the tab for code-server to fully
+  initialize its HTTP server. The URL is returned immediately after spawn, and code-server's
+  own loading screen handles the initialization wait.
+
+  ### Database Impact
+  The code_server_instances table is expected to have very few rows (typically <10 concurrent
+  instances). Queries are fast even without optimization. A UNIQUE index on feature_id ensures
+  idempotent start operations without table scans.
+
+  ### Reconciliation Cost
+  Startup reconciliation queries all "running" instances and checks PID liveness. With <10
+  instances, this is sub-millisecond. process.kill(pid, 0) is a syscall with negligible overhead.
+
+  ## Architecture Notes
+
+  ### Clean Architecture Layer Mapping
+
+  ```
+  Domain Layer (tsp/domain/value-objects/)
+  ├── CodeServerInstance value object (TypeSpec → generated output.ts)
+  └── CodeServerInstanceStatus enum (running | stopped)
+
+  Application Layer (application/)
+  ├── ports/output/services/code-server-manager.interface.ts
+  │   └── ICodeServerManagerService { start, stop, getStatus, listRunning, stopAll }
+  ├── use-cases/code-server/
+  │   ├── start-code-server.use-case.ts
+  │   ├── stop-code-server.use-case.ts
+  │   └── get-code-server-status.use-case.ts
+
+  Infrastructure Layer (infrastructure/)
+  ├── services/code-server/code-server-manager.service.ts
+  │   └── CodeServerManagerService implements ICodeServerManagerService
+  ├── persistence/sqlite/migrations.ts (add migration v23)
+  ├── persistence/sqlite/mappers/code-server-instance.mapper.ts
+  └── di/container.ts (register service + use cases + string-token aliases)
+
+  Presentation Layer (presentation/)
+  ├── web/app/api/code-server/
+  │   ├── start/route.ts   (POST)
+  │   ├── stop/route.ts    (POST)
+  │   └── status/route.ts  (GET)
+  └── web/components/common/
+      ├── feature-drawer/use-feature-actions.ts (add browser editor action)
+      └── open-action-menu/ (add Browser Editor menu item)
+  ```
+
+  ### Integration with Existing Systems
+
+  **Tool Metadata System**: code-server.json enables the existing tools page to show
+  installation status, and allows users to install code-server via the established install flow.
+  The tool metadata openDirectory field enables basic "launch" from the tools page (though the
+  full lifecycle management goes through the dedicated manager service).
+
+  **DI Container**: New registrations follow the exact pattern of existing services:
+  - Factory registration for CodeServerManagerService (needs Database injection)
+  - Singleton registration for use cases
+  - String-token aliases for web route resolution
+
+  **Settings Service**: The idle timeout setting integrates with the existing Settings entity
+  flow: TypeSpec model → generated types → SQLite migration → mapper → repository → use case.
+
+  **Daemon Lifecycle**: The stopAll() method on the manager service should be called during
+  daemon shutdown to gracefully terminate all running instances. This can be wired into the
+  existing daemon shutdown flow.
+
+  ### SQLite Migration v23 Schema
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS code_server_instances (
+    id TEXT PRIMARY KEY NOT NULL,
+    feature_id TEXT NOT NULL UNIQUE,
+    pid INTEGER NOT NULL,
+    port INTEGER NOT NULL,
+    worktree_path TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'running',
+    started_at TEXT NOT NULL,
+    stopped_at TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_cs_instances_feature ON code_server_instances(feature_id);
+  CREATE INDEX IF NOT EXISTS idx_cs_instances_status ON code_server_instances(status);
+  ```
+
+  The settings migration (v24) adds the idle timeout column:
+  ```sql
+  ALTER TABLE settings ADD COLUMN cs_idle_timeout_seconds INTEGER NOT NULL DEFAULT 1800;
+  ```
+
+  ### TypeSpec Value Object
+
+  ```typespec
+  // tsp/domain/value-objects/code-server-instance.tsp
+  @doc("Status of a code-server instance")
+  enum CodeServerInstanceStatus {
+    running: "running",
+    stopped: "stopped",
+  }
+
+  @doc("State of a managed code-server instance")
+  model CodeServerInstance {
+    id: string;
+    featureId: string;
+    pid: int32;
+    port: int32;
+    worktreePath: string;
+    status: CodeServerInstanceStatus;
+    startedAt: utcDateTime;
+    stoppedAt?: utcDateTime;
+  }
+  ```
+
+  ### code-server.json Tool Metadata
+
+  ```json
+  {
+    "name": "code-server",
+    "summary": "VS Code in the browser — run a full editor from any machine",
+    "description": "code-server allows you to run VS Code on any machine and access it through the browser. Get a consistent development environment with full VS Code functionality including extensions, terminal, and debugging.",
+    "tags": ["ide"],
+    "iconUrl": "https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg",
+    "binary": "code-server",
+    "packageManager": "brew",
+    "commands": {
+      "linux": "curl -fsSL https://code-server.dev/install.sh | sh",
+      "darwin": "brew install code-server"
+    },
+    "timeout": 300000,
+    "documentationUrl": "https://coder.com/docs/code-server",
+    "verifyCommand": "code-server --version",
+    "autoInstall": true,
+    "openDirectory": "code-server --bind-addr 127.0.0.1:0 --auth none {dir}"
+  }
+  ```
+
+  ### ICodeServerManagerService Interface
+
+  ```typescript
+  interface CodeServerStartResult {
+    url: string;
+    port: number;
+    pid: number;
+    featureId: string;
+  }
+
+  interface ICodeServerManagerService {
+    start(featureId: string, worktreePath: string): Promise<CodeServerStartResult>;
+    stop(featureId: string): Promise<void>;
+    getStatus(featureId: string): Promise<CodeServerInstance | null>;
+    listRunning(): Promise<CodeServerInstance[]>;
+    stopAll(): Promise<void>;
+    reconcile(): Promise<void>;
+  }
+  ```
+
+  ### Use Case Contracts
+
+  **StartCodeServerUseCase.execute(input)**:
+  - Input: `{ featureId: string, repositoryPath: string, branch: string }`
+  - Validates feature exists via IFeatureRepository
+  - Checks code-server installed via IToolInstallerService
+  - Computes worktree path from repositoryPath + branch
+  - Delegates to ICodeServerManagerService.start()
+  - Returns: `{ url: string, port: number }` or throws
+
+  **StopCodeServerUseCase.execute(input)**:
+  - Input: `{ featureId: string }`
+  - Delegates to ICodeServerManagerService.stop()
+  - Returns: void or throws
+
+  **GetCodeServerStatusUseCase.execute(input)**:
+  - Input: `{ featureId: string }`
+  - Delegates to ICodeServerManagerService.getStatus()
+  - Returns: `{ status: 'running' | 'stopped' | null, url?: string, port?: number }`
+
+  ### UI State Flow
+
+  1. Drawer opens → useEffect fetches status for featureId
+  2. Status = null/stopped → Show "Browser Editor" menu item (enabled if code-server installed)
+  3. User clicks "Browser Editor" → loading state → POST /api/code-server/start
+  4. Success → window.open(url, '_blank') → refetch status → show green dot + "Stop" option
+  5. User clicks "Stop Browser Editor" → POST /api/code-server/stop → refetch status → green dot removed
+  6. Error → show error state with auto-clear after 5 seconds (existing pattern from useFeatureActions)
+
+  ---
+
+  _Research complete — proceed with planning phase_

--- a/specs/045-code-server-integration/spec.yaml
+++ b/specs/045-code-server-integration/spec.yaml
@@ -1,0 +1,383 @@
+# Feature Specification (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: code-server-integration
+number: 045
+branch: feat/045-code-server-integration
+oneLiner: In-browser VS Code editor per feature/repo via code-server process management
+userQuery: >
+  Feature: Add support to in browser code editor with code-server per feature / repo
+  https://github.com/coder/code-server
+summary: >
+  Integrate code-server (VS Code in the browser) as a managed tool within Shep, enabling users to
+  launch per-feature or per-repo browser-based code editing sessions. This extends the existing
+  JSON-driven tool metadata system with a new code-server manager service that handles instance
+  lifecycle (spawn, track, stop), dynamic port allocation, and provides new-tab access from the
+  web UI feature drawer. Instances are scoped per feature worktree, require manual launch, and
+  auto-shutdown after configurable idle timeout to conserve resources.
+phase: Requirements
+sizeEstimate: L
+
+# Relationships
+relatedFeatures: []
+
+technologies:
+  - code-server (coder/code-server) - VS Code in the browser
+  - Node.js child_process - process spawning and lifecycle management
+  - Next.js API routes - backend endpoints for code-server management
+  - React/shadcn-ui - UI components for launch controls and status display
+  - tsyringe - dependency injection for new service registration
+  - SQLite - persistence of code-server instance state via migration
+  - TypeSpec - domain model definitions for CodeServerInstance state
+
+relatedLinks:
+  - https://github.com/coder/code-server
+  - https://coder.com/docs/code-server
+
+# Open questions (all resolved with AI recommendations)
+openQuestions:
+  - question: 'Should code-server instances be embedded via iframe in the web UI or opened in a new browser tab?'
+    resolved: true
+    options:
+      - option: 'New tab only'
+        description: >
+          Opens code-server in a new browser tab. Simplest to implement, avoids iframe security
+          complications (CSP, X-Frame-Options), provides full-screen VS Code experience, and
+          sidesteps cross-origin keyboard shortcut conflicts. Users get a native VS Code feel.
+        selected: true
+      - option: 'Iframe embed only'
+        description: >
+          Embeds code-server in an iframe within the feature drawer. Keeps users in the Shep UI
+          but creates a cramped editing experience, requires CSP configuration, and VS Code
+          keyboard shortcuts may conflict with the host page.
+        selected: false
+      - option: 'Both (new tab + iframe toggle)'
+        description: >
+          Offers both options via a toggle. Maximum flexibility but doubles the UI surface area,
+          increases complexity, and the iframe experience is inherently limited by viewport size.
+        selected: false
+    selectionRationale: >
+      New tab is recommended because code-server provides a full VS Code experience that benefits
+      from the entire browser viewport. Iframes introduce CSP/X-Frame-Options configuration overhead,
+      keyboard shortcut conflicts, and a cramped editing area. The Shep web UI already opens desktop
+      IDEs externally — opening a browser tab is the natural equivalent for a browser-based editor.
+      Iframe support can be added in a future iteration if demand exists.
+    answer: 'New tab only'
+
+  - question: 'Should code-server instances be scoped per feature worktree, per repo, or both?'
+    resolved: true
+    options:
+      - option: 'Per feature worktree'
+        description: >
+          One code-server instance per feature worktree. Aligns with Shep's per-feature isolation
+          model where each feature gets its own git worktree at ~/.shep/repos/<hash>/wt/<slug>/.
+          Natural 1:1 mapping between features and editor sessions. Users see only the files
+          relevant to their current feature.
+        selected: true
+      - option: 'Per repository'
+        description: >
+          One code-server instance per repository root. Simpler resource usage (fewer instances)
+          but users see the entire repo rather than the feature-specific worktree. Does not align
+          with the per-feature isolation model that is central to Shep.
+        selected: false
+      - option: 'Both (user choice)'
+        description: >
+          Allow users to choose scope at launch time. Maximum flexibility but adds UI complexity
+          and makes the mental model harder to understand.
+        selected: false
+    selectionRationale: >
+      Per feature worktree aligns with Shep's core isolation model. Every feature already gets a
+      dedicated worktree at ~/.shep/repos/<hash>/wt/<slug>/. Launching code-server pointed at this
+      path gives users an editor focused on exactly the files they're working on, consistent with
+      how desktop IDEs are already launched. Per-repo support can be added later if needed.
+    answer: 'Per feature worktree'
+
+  - question: 'What authentication mode should code-server use?'
+    resolved: true
+    options:
+      - option: 'No auth for localhost (--auth none)'
+        description: >
+          Disables authentication when binding to 127.0.0.1. Simplest UX — users click and
+          immediately get VS Code. Safe because code-server is only accessible from the local
+          machine. This is the standard approach for local dev tools (Vite, Storybook, etc.).
+        selected: true
+      - option: 'Password auth always'
+        description: >
+          Requires password authentication even on localhost. Adds friction to every launch.
+          Necessary for remote access but overkill for local-only use. Password must be stored
+          and communicated to the user.
+        selected: false
+      - option: 'Configurable (none for local, password for remote)'
+        description: >
+          Auth mode is configurable in settings. Adds implementation complexity for a setting
+          most users won't need since Shep currently only supports local use.
+        selected: false
+    selectionRationale: >
+      No auth for localhost is the standard pattern for local dev tools. Shep currently only
+      supports local execution — the daemon and web UI bind to 127.0.0.1. Adding authentication
+      for a locally-bound service adds UX friction with no security benefit. When/if remote access
+      is added to Shep, authentication can be enabled at that point.
+    answer: 'No auth for localhost (--auth none)'
+
+  - question: 'Should code-server instances auto-start when a feature is opened, or require manual launch?'
+    resolved: true
+    options:
+      - option: 'Manual launch only'
+        description: >
+          User must explicitly click "Open in Browser Editor" to start a code-server instance.
+          Conserves resources (300-500MB RAM per instance), gives users control, and avoids
+          surprising resource consumption. Consistent with how desktop IDE launch works today.
+        selected: true
+      - option: 'Auto-start on feature open'
+        description: >
+          Automatically starts a code-server instance when a feature is viewed in the drawer.
+          Reduces clicks but consumes significant resources for features the user may only be
+          browsing. Could start many instances if user is reviewing multiple features.
+        selected: false
+      - option: 'Configurable (default manual)'
+        description: >
+          Setting to toggle auto-start behavior. Adds settings complexity for an edge case.
+          Most users will want manual control given the resource cost.
+        selected: false
+    selectionRationale: >
+      Manual launch is recommended because each code-server instance consumes 300-500MB RAM.
+      Auto-starting would create instances for features the user is merely browsing, leading to
+      unexpected resource consumption. The current desktop IDE launch is already manual (click to
+      open). Manual launch keeps the interaction model consistent and resource usage predictable.
+    answer: 'Manual launch only'
+
+  - question: 'Should idle timeouts auto-shutdown inactive code-server instances?'
+    resolved: true
+    options:
+      - option: 'Yes, with configurable timeout (default 30 minutes)'
+        description: >
+          code-server supports --idle-timeout-seconds natively. After no editor activity for the
+          configured duration, the process exits automatically. Prevents resource leaks from
+          forgotten instances. The 30-minute default balances convenience (users stepping away
+          briefly) with resource conservation. Users can override via settings.
+        selected: true
+      - option: 'No idle timeout'
+        description: >
+          Instances run until explicitly stopped or Shep shuts down. Simpler implementation but
+          risks resource leaks. Users who forget to stop instances accumulate memory usage.
+        selected: false
+      - option: 'Fixed timeout (non-configurable)'
+        description: >
+          Hardcoded timeout value. Simpler than configurable but removes user control over a
+          setting that depends on workflow (some users step away frequently).
+        selected: false
+    selectionRationale: >
+      Idle timeout with a sensible default is recommended because code-server natively supports
+      --idle-timeout-seconds, making implementation trivial. Forgotten instances are a real resource
+      leak risk at 300-500MB each. A 30-minute default covers normal work breaks while reclaiming
+      resources from truly abandoned sessions. Making it configurable respects diverse workflows.
+    answer: 'Yes, with configurable timeout (default 30 minutes)'
+
+  - question: 'How should code-server extension and settings isolation work across instances?'
+    resolved: true
+    options:
+      - option: 'Shared extensions, per-instance user data'
+        description: >
+          All instances share a single extensions directory (~/.shep/code-server/extensions/) but
+          each gets its own user-data-dir for workspace state, recently opened files, etc. This
+          means extensions are installed once and available everywhere, while workspace-specific
+          state (open tabs, cursor position) is isolated per feature. Reduces disk usage and
+          install time.
+        selected: true
+      - option: 'Fully isolated (separate extensions and user data per instance)'
+        description: >
+          Each instance gets its own extensions and user data directories. Maximum isolation but
+          means extensions must be installed separately for each feature, consuming more disk space
+          and requiring repeated setup.
+        selected: false
+      - option: 'Fully shared (single extensions and user data directory)'
+        description: >
+          All instances share everything. Simplest but workspace state (open tabs, settings) from
+          one feature leaks into another, creating a confusing experience.
+        selected: false
+    selectionRationale: >
+      Shared extensions with per-instance user data strikes the optimal balance. Extensions are
+      heavyweight (hundreds of MB) and users want the same set everywhere — installing once and
+      sharing avoids redundant disk usage and setup friction. Workspace state (open files, layout,
+      cursor positions) is inherently per-feature and should be isolated so switching between
+      features preserves each workspace's context. code-server supports this via separate
+      --extensions-dir and --user-data-dir flags.
+    answer: 'Shared extensions, per-instance user data'
+
+content: |
+  ## Problem Statement
+
+  Currently, Shep launches external desktop IDEs (VS Code, Cursor, Zed) via the tool launcher system
+  to open feature worktrees. This requires users to have desktop IDEs installed and cannot provide
+  an integrated in-browser editing experience. Users working remotely, on lightweight machines, or
+  who want a browser-native workflow have no option for code editing directly within the Shep web UI.
+
+  code-server (https://github.com/coder/code-server) runs VS Code as a Node.js HTTP server accessible
+  via any browser. By integrating code-server as a managed service, Shep can offer per-feature
+  browser-based editing sessions with full VS Code functionality including extensions, terminal, and
+  debugging — all without requiring a desktop IDE installation.
+
+  ## Success Criteria
+
+  - [ ] code-server appears in the tools page with correct installation status detection
+  - [ ] User can install code-server via the existing tool installer system
+  - [ ] User can click "Open in Browser Editor" in the feature drawer to launch a code-server instance for that feature's worktree
+  - [ ] code-server opens in a new browser tab at the allocated port with no-auth on localhost
+  - [ ] Multiple code-server instances can run simultaneously for different features on different ports
+  - [ ] Feature drawer shows running/stopped status indicator for code-server
+  - [ ] User can stop a running code-server instance from the feature drawer
+  - [ ] Instances auto-shutdown after 30 minutes of idle (configurable)
+  - [ ] Instances are cleaned up when Shep daemon shuts down (graceful SIGTERM, fallback SIGKILL)
+  - [ ] Instance state (PID, port, feature ID) persists across daemon restarts and is reconciled on startup
+  - [ ] All new code covered by unit tests following TDD (red-green-refactor)
+  - [ ] Storybook stories exist for all new/modified web UI components
+
+  ## Functional Requirements
+
+  ### Tool Registration
+
+  - **FR-1**: A `code-server.json` tool metadata file SHALL be added to the tools directory, defining the binary name (`code-server`), platform-specific install commands (brew for macOS, curl script for Linux), verify command, documentation URL, and tags (`["ide"]`).
+  - **FR-2**: The tool metadata SHALL include an `openDirectory` field (e.g., `code-server --bind-addr 127.0.0.1:0 {dir}`) so code-server appears as a launchable IDE in the existing tools system.
+  - **FR-3**: code-server SHALL appear on the tools page with accurate installation status (installed, not installed, unknown) detected via the existing `verifyCommand` mechanism.
+
+  ### Code-Server Manager Service
+
+  - **FR-4**: A new `ICodeServerManagerService` interface SHALL be defined in the application ports layer with operations: `start(featureId, worktreePath)`, `stop(featureId)`, `getStatus(featureId)`, `listRunning()`, and `stopAll()`.
+  - **FR-5**: The `start` operation SHALL allocate an available port via the existing `findAvailablePort()` service, spawn code-server as a detached child process bound to `127.0.0.1:<port>` with `--auth none`, and return the URL and port.
+  - **FR-6**: The `start` operation SHALL pass `--user-data-dir ~/.shep/code-server/user-data/<featureId>/` and `--extensions-dir ~/.shep/code-server/extensions/` to isolate workspace state per feature while sharing extensions.
+  - **FR-7**: The `start` operation SHALL pass `--idle-timeout-seconds <timeout>` where timeout is read from settings (default 1800 seconds / 30 minutes).
+  - **FR-8**: The `start` operation SHALL be idempotent — if an instance is already running for the given feature (verified by PID liveness check), it SHALL return the existing instance's URL rather than spawning a duplicate.
+  - **FR-9**: The `stop` operation SHALL send SIGTERM to the code-server process, wait up to 5 seconds for graceful shutdown, then send SIGKILL if the process is still alive.
+  - **FR-10**: The `getStatus` operation SHALL return the instance state (running, stopped, or unknown) by checking PID liveness and reconciling with persisted state.
+  - **FR-11**: The `stopAll` operation SHALL terminate all tracked code-server instances using the same graceful shutdown sequence as `stop`. This SHALL be called during daemon shutdown.
+  - **FR-12**: On service initialization, the manager SHALL reconcile persisted instance state with actual process liveness — marking instances with dead PIDs as stopped.
+
+  ### Persistence
+
+  - **FR-13**: A new SQLite migration SHALL create a `code_server_instances` table with columns: `id` (TEXT PK), `feature_id` (TEXT, unique), `pid` (INTEGER), `port` (INTEGER), `worktree_path` (TEXT), `status` (TEXT: 'running' | 'stopped'), `started_at` (TEXT ISO 8601), `stopped_at` (TEXT ISO 8601 nullable).
+  - **FR-14**: Instance state (PID, port, feature ID, worktree path, status, timestamps) SHALL be persisted to SQLite so that state survives daemon restarts and can be reconciled on startup.
+
+  ### Use Cases
+
+  - **FR-15**: A `StartCodeServerUseCase` SHALL orchestrate: validate code-server is installed → resolve worktree path for the feature → delegate to the manager service → return the URL or error.
+  - **FR-16**: A `StopCodeServerUseCase` SHALL delegate to the manager service to stop the instance for a given feature ID.
+  - **FR-17**: A `GetCodeServerStatusUseCase` SHALL return the current status (running with URL, or stopped) for a given feature ID.
+
+  ### API Routes
+
+  - **FR-18**: `POST /api/code-server/start` SHALL accept `{ featureId, repositoryPath, branch }`, resolve the worktree path, start a code-server instance, and return `{ url, port }` on success or an appropriate error response.
+  - **FR-19**: `POST /api/code-server/stop` SHALL accept `{ featureId }` and stop the running instance.
+  - **FR-20**: `GET /api/code-server/status?featureId=<id>` SHALL return the current instance status for the given feature.
+
+  ### Web UI Integration
+
+  - **FR-21**: The feature drawer SHALL display an "Open in Browser Editor" button that triggers the start API route and opens the returned URL in a new browser tab.
+  - **FR-22**: The feature drawer SHALL show a status indicator (e.g., green dot for running, no indicator for stopped) next to the browser editor action when a code-server instance is active for that feature.
+  - **FR-23**: When a code-server instance is running, the feature drawer SHALL show a "Stop Browser Editor" button that calls the stop API route and updates the status indicator.
+  - **FR-24**: The "Open in Browser Editor" button SHALL show a loading state while the instance is starting and handle errors with a toast or inline error message.
+  - **FR-25**: If code-server is not installed, the "Open in Browser Editor" button SHALL be disabled with a tooltip indicating that code-server must be installed first (linking to the tools page).
+
+  ### Settings
+
+  - **FR-26**: The idle timeout for code-server instances SHALL be configurable via the existing settings system with a default of 30 minutes (1800 seconds). The setting key SHALL be `codeServer.idleTimeoutSeconds`.
+
+  ### DI Registration
+
+  - **FR-27**: The `ICodeServerManagerService` implementation, all new use cases, and the SQLite migration SHALL be registered in the DI container following existing patterns (string tokens for Turbopack compatibility).
+
+  ## Non-Functional Requirements
+
+  ### Performance
+
+  - **NFR-1**: Port allocation and process spawn SHALL complete within 3 seconds. The API route SHALL return the code-server URL within 5 seconds of the user clicking "Open in Browser Editor".
+  - **NFR-2**: The manager service SHALL support at least 10 simultaneous code-server instances without degradation of Shep's own performance (excluding code-server's own memory footprint).
+
+  ### Reliability
+
+  - **NFR-3**: Orphaned code-server processes (PID alive but not tracked, or tracked but PID dead) SHALL be detected and cleaned up on daemon startup via reconciliation.
+  - **NFR-4**: If code-server crashes unexpectedly, the status SHALL be updated to stopped on the next status check (PID liveness check), and the user SHALL be able to re-launch.
+  - **NFR-5**: Process state persistence SHALL use atomic writes (write-to-temp + rename) consistent with the existing daemon PID service pattern, or SQLite transactions for database persistence.
+
+  ### Security
+
+  - **NFR-6**: code-server instances SHALL bind exclusively to `127.0.0.1` (loopback), never to `0.0.0.0` or any network-accessible interface.
+  - **NFR-7**: The API routes SHALL validate that the requested feature ID exists and belongs to a tracked repository before starting an instance.
+
+  ### Resource Management
+
+  - **NFR-8**: The port range for code-server instances SHALL start at 13370 (well above the Shep daemon port range) with up to 20 attempts, to avoid collisions with other local services.
+  - **NFR-9**: The service SHALL log a warning if more than 5 instances are running simultaneously, alerting users to potential high memory usage.
+
+  ### Maintainability
+
+  - **NFR-10**: The code-server manager service SHALL follow the existing Clean Architecture patterns — interface in application layer, implementation in infrastructure layer, registered via DI.
+  - **NFR-11**: All new components SHALL have corresponding unit tests achieving at minimum the same coverage level as existing services in the codebase.
+  - **NFR-12**: All new web UI components SHALL have colocated Storybook `.stories.tsx` files demonstrating all states (loading, running, stopped, error, not installed).
+
+  ### UX
+
+  - **NFR-13**: The "Open in Browser Editor" action SHALL be visually consistent with existing feature drawer actions (Open in IDE, Open in Terminal) in terms of icon style, button sizing, and placement.
+  - **NFR-14**: Status transitions (starting → running, running → stopped) SHALL be reflected in the UI within 2 seconds without requiring a page refresh.
+
+  ## Product Questions & AI Recommendations
+
+  | # | Question | AI Recommendation | Rationale |
+  | - | -------- | ----------------- | --------- |
+  | 1 | Iframe or new tab for code-server? | New tab only | Full viewport for VS Code, avoids CSP/iframe complexity and keyboard shortcut conflicts. Iframe can be added later. |
+  | 2 | Instance scope: per feature, per repo, or both? | Per feature worktree | Aligns with Shep's core per-feature isolation model. Each worktree gets its own editor session. |
+  | 3 | Authentication mode? | No auth for localhost (--auth none) | Standard pattern for local dev tools. Shep only supports local execution today. |
+  | 4 | Auto-start or manual launch? | Manual launch only | Each instance costs 300-500MB RAM. Manual launch keeps resource usage predictable and matches existing IDE launch UX. |
+  | 5 | Idle timeout for auto-shutdown? | Yes, configurable (default 30 min) | code-server supports --idle-timeout-seconds natively. Prevents resource leaks from forgotten instances. |
+  | 6 | Extension/settings isolation? | Shared extensions, per-instance user data | Install extensions once, reuse everywhere. Workspace state (open tabs, layout) isolated per feature. |
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `infrastructure/services/tool-installer/tools/` | Low | Add code-server.json tool metadata for install/availability checks |
+  | `infrastructure/services/` (new service) | High | New CodeServerManagerService for instance lifecycle (spawn, track, stop, port allocation) |
+  | `application/ports/output/services/` | Medium | New ICodeServerManagerService interface definition |
+  | `application/use-cases/` (new use cases) | High | StartCodeServer, StopCodeServer, GetCodeServerStatus use cases |
+  | `infrastructure/di/container.ts` | Low | Register new service and use cases in DI container |
+  | `presentation/web/app/api/` (new routes) | Medium | API routes for starting/stopping/status of code-server instances |
+  | `presentation/web/components/common/feature-drawer/` | Medium | Add "Open in Browser Editor" action button and status indicator |
+  | `presentation/web/components/features/tools/` | Low | code-server appears in tools page via existing metadata system |
+  | `tsp/domain/` | Low | TypeSpec model for CodeServerInstance state |
+  | `infrastructure/persistence/sqlite/migrations.ts` | Medium | New migration for code_server_instances table |
+
+  ## Dependencies
+
+  **External:**
+  - code-server binary must be installed on the host system (installable via tool metadata system)
+  - Sufficient system resources (300-500MB RAM per code-server instance)
+
+  **Internal (existing code to build on):**
+  - Tool metadata system (`tool-metadata.ts`, `loadToolMetadata()`) — for installation/availability
+  - Port service (`port.service.ts`, `findAvailablePort()`) — for dynamic port allocation
+  - Daemon PID service (`daemon-pid.service.ts`) — atomic state file patterns and PID liveness checks
+  - Feature agent process service — detached child process spawning patterns
+  - IDE launcher service — headless launch and platform resolution patterns
+  - Feature drawer component — UI integration point for launch action
+  - DI container — service registration and resolution
+  - SQLite migration system — versioned schema evolution
+  - Settings service — for configurable idle timeout
+
+  ## Size Estimate
+
+  **L (week+)** — This feature requires:
+  1. Tool metadata registration (code-server.json) — 0.5 day
+  2. TypeSpec model + SQLite migration for instance tracking — 0.5 day
+  3. ICodeServerManagerService interface + implementation with process lifecycle — 2-3 days
+  4. Three use cases (Start, Stop, GetStatus) with TDD — 1-2 days
+  5. API routes (start, stop, status) — 0.5 day
+  6. Web UI integration (feature drawer button, status indicator, error handling) — 1-2 days
+  7. Storybook stories for all new UI components — 0.5 day
+  8. Integration testing, edge cases, reconciliation logic — 1-2 days
+
+  The core complexity is in the process manager service — reliably spawning, tracking, and
+  cleaning up code-server instances across daemon restarts, idle timeouts, and feature deletions.
+  The tool metadata and UI work leverages well-established patterns in the codebase.
+
+  ---
+
+  _Requirements complete — proceed with research phase_

--- a/specs/045-code-server-integration/tasks.yaml
+++ b/specs/045-code-server-integration/tasks.yaml
@@ -1,0 +1,626 @@
+# Task Breakdown (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: code-server-integration
+summary: >
+  20 tasks across 5 phases implementing code-server as a managed browser-based editor per feature
+  worktree. Phases progress from domain foundation through service implementation, use cases, API
+  routes, and web UI integration. Every code task includes TDD cycles (red-green-refactor).
+
+relatedFeatures: []
+technologies:
+  - code-server (coder/code-server v4.x)
+  - Node.js child_process.spawn
+  - better-sqlite3
+  - tsyringe
+  - Next.js App Router
+  - React/shadcn-ui
+  - TypeSpec
+  - Lucide React
+
+relatedLinks:
+  - https://github.com/coder/code-server
+
+tasks:
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Phase 1 — Foundation: Domain Model, Tool Metadata & Persistence
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - id: task-1
+    phaseId: phase-1
+    title: 'Define CodeServerInstance TypeSpec value object'
+    description: >
+      Create the CodeServerInstance value object and CodeServerInstanceStatus enum in TypeSpec.
+      This defines the canonical data shape used by the mapper, service, use cases, and API
+      responses. Add the new file to the value-objects index.tsp and compile.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'CodeServerInstance model defined in tsp/domain/value-objects/code-server-instance.tsp with fields: id, featureId, pid, port, worktreePath, status, startedAt, stoppedAt (optional)'
+      - 'CodeServerInstanceStatus enum defined with running and stopped values'
+      - 'value-objects/index.tsp imports the new file'
+      - 'pnpm tsp:compile succeeds and generates types in domain/generated/output.ts'
+      - 'No modifications to existing TypeSpec models'
+    tdd:
+      red:
+        - 'Run pnpm tsp:compile — should succeed (baseline). Verify CodeServerInstance type does not exist in generated output'
+      green:
+        - 'Create code-server-instance.tsp with @doc annotations, CodeServerInstanceStatus enum, and CodeServerInstance model'
+        - 'Add import to value-objects/index.tsp'
+        - 'Run pnpm tsp:compile — verify CodeServerInstance and CodeServerInstanceStatus appear in generated output.ts'
+      refactor:
+        - 'Review @doc annotations for clarity and consistency with existing value objects'
+    estimatedEffort: '30min'
+
+  - id: task-2
+    phaseId: phase-1
+    title: 'Add code-server.json tool metadata'
+    description: >
+      Create the code-server tool metadata JSON file following the existing schema pattern. This
+      enables installation detection, tools page listing, and basic launch from the tools page.
+      The file is loaded dynamically by tool-metadata.ts — no code changes needed for discovery.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'code-server.json exists in packages/core/src/infrastructure/services/tool-installer/tools/'
+      - 'Fields: name, summary, description, tags (["ide"]), iconUrl, binary ("code-server"), packageManager, commands (darwin: brew, linux: curl), timeout, documentationUrl, verifyCommand ("code-server --version"), autoInstall, openDirectory'
+      - 'code-server appears in tools list when tool metadata is loaded'
+    tdd:
+      red:
+        - 'Write test that loads tool metadata and asserts code-server tool exists with correct binary and tags'
+      green:
+        - 'Create code-server.json with all required fields following the existing tool schema'
+      refactor:
+        - 'Verify description text is clear and consistent with other tool descriptions'
+    estimatedEffort: '20min'
+
+  - id: task-3
+    phaseId: phase-1
+    title: 'Add CodeServerConfig to Settings TypeSpec model'
+    description: >
+      Extend the Settings TypeSpec entity with a new codeServer nested config section containing
+      idleTimeoutSeconds (default 1800). This follows the pattern of existing nested config
+      objects (models, environment, system, agent, workflow, notifications).
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'CodeServerConfig model defined in tsp/domain/entities/settings.tsp with idleTimeoutSeconds: int32 = 1800'
+      - 'Settings model includes codeServer: CodeServerConfig field'
+      - 'pnpm tsp:compile succeeds and generates the new types'
+    tdd:
+      red:
+        - 'Verify CodeServerConfig does not exist in generated output. Run pnpm tsp:compile as baseline'
+      green:
+        - 'Add CodeServerConfig model and codeServer field to Settings in settings.tsp'
+        - 'Run pnpm tsp:compile — verify types appear in output.ts'
+      refactor:
+        - 'Ensure @doc annotation describes the section purpose and default value'
+    estimatedEffort: '20min'
+
+  - id: task-4
+    phaseId: phase-1
+    title: 'Create SQLite migration v23 for code_server_instances table'
+    description: >
+      Add migration version 23 to create the code_server_instances table with columns: id (TEXT PK),
+      feature_id (TEXT UNIQUE), pid (INTEGER), port (INTEGER), worktree_path (TEXT), status (TEXT),
+      started_at (TEXT), stopped_at (TEXT nullable), created_at (INTEGER), updated_at (INTEGER).
+      Includes indexes on feature_id and status.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - 'Migration v23 added to MIGRATIONS array in migrations.ts'
+      - 'Creates code_server_instances table with all specified columns'
+      - 'UNIQUE constraint on feature_id column'
+      - 'Indexes on feature_id and status'
+      - 'Migration is idempotent (IF NOT EXISTS)'
+      - 'Existing tests pass — no regressions'
+    tdd:
+      red:
+        - 'Write test that runs migrations on a fresh in-memory database and asserts code_server_instances table exists with correct schema'
+      green:
+        - 'Add migration v23 to MIGRATIONS array with CREATE TABLE and CREATE INDEX statements'
+      refactor:
+        - 'Verify SQL formatting consistency with existing migrations'
+    estimatedEffort: '30min'
+
+  - id: task-5
+    phaseId: phase-1
+    title: 'Create SQLite migration v24 for settings idle timeout column'
+    description: >
+      Add migration version 24 to add cs_idle_timeout_seconds column to the settings table
+      with a default of 1800 (30 minutes). Update the settings mapper to include the new field
+      in toDatabase/fromDatabase conversions.
+    state: Todo
+    dependencies:
+      - task-3
+      - task-4
+    acceptanceCriteria:
+      - 'Migration v24 added to MIGRATIONS array'
+      - 'ALTER TABLE settings ADD COLUMN cs_idle_timeout_seconds INTEGER NOT NULL DEFAULT 1800'
+      - 'Settings mapper maps codeServer.idleTimeoutSeconds to/from cs_idle_timeout_seconds column'
+      - 'Existing settings tests pass — new field round-trips correctly'
+    tdd:
+      red:
+        - 'Write test that creates settings with codeServer.idleTimeoutSeconds, persists, and reads back — assert value preserved'
+        - 'Test default value (1800) is used when not explicitly set'
+      green:
+        - 'Add migration v24 with ALTER TABLE statement'
+        - 'Update settings mapper toDatabase to write cs_idle_timeout_seconds from codeServer.idleTimeoutSeconds'
+        - 'Update settings mapper fromDatabase to read cs_idle_timeout_seconds into codeServer.idleTimeoutSeconds'
+      refactor:
+        - 'Ensure default value handling is consistent with other settings defaults'
+    estimatedEffort: '30min'
+
+  - id: task-6
+    phaseId: phase-1
+    title: 'Create CodeServerInstance SQLite mapper'
+    description: >
+      Implement toDatabase and fromDatabase mapper functions for CodeServerInstance following the
+      existing mapper pattern. Maps between domain camelCase properties and snake_case SQL columns.
+      Handles date conversions and status enum mapping.
+    state: Todo
+    dependencies:
+      - task-1
+      - task-4
+    acceptanceCriteria:
+      - 'Mapper file exists at packages/core/src/infrastructure/persistence/sqlite/mappers/code-server-instance.mapper.ts'
+      - 'toDatabase maps CodeServerInstance → SQL row object (camelCase → snake_case)'
+      - 'fromDatabase maps SQL row → CodeServerInstance (snake_case → camelCase)'
+      - 'Date fields correctly converted (ISO strings for started_at/stopped_at, unix ms for created_at/updated_at)'
+      - 'Null handling for optional stopped_at field'
+    tdd:
+      red:
+        - 'Write test: create CodeServerInstance object → toDatabase → fromDatabase → assert equals original'
+        - 'Test null stoppedAt round-trip'
+        - 'Test status enum values round-trip correctly'
+      green:
+        - 'Implement toDatabase and fromDatabase functions following existing mapper patterns'
+      refactor:
+        - 'Extract date conversion helpers if duplicated with existing mappers'
+    estimatedEffort: '30min'
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Phase 2 — Service Layer: Interface & Infrastructure Implementation
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - id: task-7
+    phaseId: phase-2
+    title: 'Define ICodeServerManagerService interface'
+    description: >
+      Create the application-layer output port interface for code-server process lifecycle
+      management. Defines the contract: start, stop, getStatus, listRunning, stopAll, reconcile.
+      Includes CodeServerStartResult type. Export from the services index.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - 'Interface file at packages/core/src/application/ports/output/services/code-server-manager-service.interface.ts'
+      - 'ICodeServerManagerService interface with methods: start, stop, getStatus, listRunning, stopAll, reconcile'
+      - 'CodeServerStartResult type with url, port, pid, featureId fields'
+      - 'Exported from services/index.ts'
+      - 'JSDoc describing implementation requirements (consistent with existing interfaces)'
+    tdd: null
+    estimatedEffort: '20min'
+
+  - id: task-8
+    phaseId: phase-2
+    title: 'Implement CodeServerManagerService — start method'
+    description: >
+      Implement the start method: check for existing running instance (idempotent), allocate port
+      via findAvailablePort(13370), spawn code-server as detached child process with --bind-addr,
+      --auth none, --user-data-dir, --extensions-dir, --idle-timeout-seconds flags, persist
+      instance state to SQLite, return URL and port. Log stdout/stderr to file.
+    state: Todo
+    dependencies:
+      - task-6
+      - task-7
+    acceptanceCriteria:
+      - 'Service file at packages/core/src/infrastructure/services/code-server/code-server-manager.service.ts'
+      - 'start() is idempotent — returns existing instance URL if already running (PID alive)'
+      - 'Allocates port starting at 13370 via findAvailablePort()'
+      - 'Spawns code-server with correct flags: --bind-addr 127.0.0.1:<port> --auth none --user-data-dir --extensions-dir --idle-timeout-seconds'
+      - 'Process is detached (detached: true, child.unref())'
+      - 'stdout/stderr redirected to log file (~/.shep/logs/code-server-<featureId>.log)'
+      - 'Instance state persisted to SQLite with status "running"'
+      - 'Returns CodeServerStartResult with url, port, pid, featureId'
+    tdd:
+      red:
+        - 'Write test: call start() with valid featureId and worktreePath → assert returns CodeServerStartResult with url containing port and 127.0.0.1'
+        - 'Write test: call start() twice for same featureId → assert returns same URL (idempotent), spawn called only once'
+        - 'Write test: call start() for running instance with dead PID → assert spawns new instance (re-start after crash)'
+        - 'Write test: assert spawn called with correct flags (--bind-addr, --auth, --user-data-dir, --extensions-dir, --idle-timeout-seconds)'
+      green:
+        - 'Implement start() with port allocation, spawn, SQLite insert, and idempotency check'
+        - 'Mock child_process.spawn, findAvailablePort, and Database for unit tests'
+      refactor:
+        - 'Extract spawn flag construction into a private helper method'
+        - 'Extract log file path construction into a private helper'
+    estimatedEffort: '2h'
+
+  - id: task-9
+    phaseId: phase-2
+    title: 'Implement CodeServerManagerService — stop method'
+    description: >
+      Implement the stop method: find instance by featureId, send SIGTERM, wait up to 5 seconds,
+      send SIGKILL if still alive, update SQLite status to "stopped" with stopped_at timestamp.
+    state: Todo
+    dependencies:
+      - task-8
+    acceptanceCriteria:
+      - 'stop() sends SIGTERM to the process PID'
+      - 'Waits up to 5 seconds for graceful shutdown'
+      - 'Sends SIGKILL if process still alive after timeout'
+      - 'Updates SQLite record: status = "stopped", stopped_at = now'
+      - 'No-op if instance not found or already stopped'
+      - 'Handles case where PID is already dead (process exited between check and signal)'
+    tdd:
+      red:
+        - 'Write test: call stop() for running instance → assert SIGTERM sent, status updated to stopped'
+        - 'Write test: call stop() when process does not respond to SIGTERM within 5s → assert SIGKILL sent'
+        - 'Write test: call stop() for non-existent featureId → assert no error (no-op)'
+        - 'Write test: call stop() for already-stopped instance → assert no-op'
+      green:
+        - 'Implement stop() with SIGTERM, setTimeout, SIGKILL fallback, and SQLite update'
+      refactor:
+        - 'Extract signal-and-wait logic into a private gracefulKill() helper'
+    estimatedEffort: '1h'
+
+  - id: task-10
+    phaseId: phase-2
+    title: 'Implement CodeServerManagerService — getStatus, listRunning, stopAll'
+    description: >
+      Implement the remaining service methods: getStatus queries SQLite and checks PID liveness,
+      listRunning returns all instances with status "running", stopAll calls stop() for each
+      running instance.
+    state: Todo
+    dependencies:
+      - task-9
+    acceptanceCriteria:
+      - 'getStatus() returns CodeServerInstance with live PID check, or null if not found'
+      - 'getStatus() auto-reconciles: if PID is dead but status is "running", updates to "stopped"'
+      - 'listRunning() returns all instances with status "running" from SQLite'
+      - 'stopAll() calls stop() for each running instance'
+      - 'stopAll() handles partial failures (logs errors, continues stopping remaining)'
+    tdd:
+      red:
+        - 'Write test: getStatus() for running instance with live PID → returns instance with status "running"'
+        - 'Write test: getStatus() for instance with dead PID → returns updated instance with status "stopped"'
+        - 'Write test: getStatus() for non-existent featureId → returns null'
+        - 'Write test: listRunning() returns only running instances (not stopped)'
+        - 'Write test: stopAll() stops all running instances'
+      green:
+        - 'Implement getStatus with SQLite query + PID liveness check'
+        - 'Implement listRunning with SQLite query WHERE status = "running"'
+        - 'Implement stopAll with loop over listRunning + stop()'
+      refactor:
+        - 'Extract PID liveness check into a private isAlive() method (matching DaemonPidService pattern)'
+    estimatedEffort: '1h'
+
+  - id: task-11
+    phaseId: phase-2
+    title: 'Implement CodeServerManagerService — reconcile method'
+    description: >
+      Implement startup reconciliation: query all instances with status "running" from SQLite,
+      check each PID liveness, mark dead ones as "stopped". This runs once on service
+      initialization to clean up stale state from daemon restarts.
+    state: Todo
+    dependencies:
+      - task-10
+    acceptanceCriteria:
+      - 'reconcile() queries all "running" instances from SQLite'
+      - 'Checks PID liveness for each instance via process.kill(pid, 0)'
+      - 'Marks instances with dead PIDs as "stopped" with stopped_at timestamp'
+      - 'Preserves instances with live PIDs (no changes)'
+      - 'Logs reconciliation results (N instances checked, M marked stopped)'
+    tdd:
+      red:
+        - 'Write test: 3 "running" instances in DB, 1 has dead PID → reconcile marks only the dead one as stopped'
+        - 'Write test: all instances alive → reconcile makes no changes'
+        - 'Write test: all instances dead → reconcile marks all as stopped'
+      green:
+        - 'Implement reconcile() with SQLite query, PID check loop, and batch update'
+      refactor:
+        - 'Ensure reconcile is called in constructor or init method for automatic startup cleanup'
+    estimatedEffort: '45min'
+
+  - id: task-12
+    phaseId: phase-2
+    title: 'Register CodeServerManagerService in DI container'
+    description: >
+      Register the CodeServerManagerService in the DI container using a factory pattern (needs
+      Database injection). Add string-token alias for web route resolution.
+    state: Todo
+    dependencies:
+      - task-11
+    acceptanceCriteria:
+      - 'container.ts registers CodeServerManagerService with factory pattern (receives Database)'
+      - 'String token "ICodeServerManagerService" resolves to the service'
+      - 'Service can be resolved via container.resolve("ICodeServerManagerService")'
+    tdd:
+      red:
+        - 'Write test: resolve "ICodeServerManagerService" from container → assert returns instance of CodeServerManagerService'
+      green:
+        - 'Add factory registration to container.ts following existing service patterns'
+      refactor:
+        - 'Verify registration order is consistent with existing services (grouped by layer)'
+    estimatedEffort: '20min'
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Phase 3 — Use Cases: Business Logic Orchestration
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - id: task-13
+    phaseId: phase-3
+    title: 'Implement StartCodeServerUseCase'
+    description: >
+      Create the StartCodeServer use case that orchestrates: validate feature exists (via
+      IFeatureRepository), check code-server is installed (via tool availability), resolve worktree
+      path, read idle timeout from settings, delegate to ICodeServerManagerService.start(), return
+      URL and port.
+    state: Todo
+    dependencies:
+      - task-12
+    acceptanceCriteria:
+      - 'Use case at packages/core/src/application/use-cases/code-server/start-code-server.use-case.ts'
+      - '@injectable() class with execute() method'
+      - 'Validates feature exists via IFeatureRepository.findById()'
+      - 'Throws descriptive error if feature not found'
+      - 'Throws descriptive error if code-server not installed'
+      - 'Reads idle timeout from settings (ISettingsRepository)'
+      - 'Delegates to ICodeServerManagerService.start() with featureId and worktreePath'
+      - 'Returns { url, port } on success'
+    tdd:
+      red:
+        - 'Write test: valid feature + installed code-server → returns { url, port }'
+        - 'Write test: non-existent featureId → throws "Feature not found" error'
+        - 'Write test: code-server not installed → throws "code-server is not installed" error'
+        - 'Write test: verifies idle timeout is read from settings and passed to manager'
+      green:
+        - 'Implement use case with @inject dependencies and validation logic'
+        - 'Mock IFeatureRepository, ICodeServerManagerService, ISettingsRepository for tests'
+      refactor:
+        - 'Ensure error messages are user-friendly and actionable'
+    estimatedEffort: '1h'
+
+  - id: task-14
+    phaseId: phase-3
+    title: 'Implement StopCodeServerUseCase'
+    description: >
+      Create the StopCodeServer use case that delegates to ICodeServerManagerService.stop()
+      for a given feature ID.
+    state: Todo
+    dependencies:
+      - task-12
+    acceptanceCriteria:
+      - 'Use case at packages/core/src/application/use-cases/code-server/stop-code-server.use-case.ts'
+      - '@injectable() class with execute({ featureId }) method'
+      - 'Delegates to ICodeServerManagerService.stop(featureId)'
+      - 'Returns void on success'
+    tdd:
+      red:
+        - 'Write test: call execute with featureId → assert manager.stop() called with same featureId'
+      green:
+        - 'Implement thin use case with @inject and delegation'
+      refactor:
+        - 'Verify consistent pattern with other simple delegation use cases in codebase'
+    estimatedEffort: '20min'
+
+  - id: task-15
+    phaseId: phase-3
+    title: 'Implement GetCodeServerStatusUseCase'
+    description: >
+      Create the GetCodeServerStatus use case that delegates to
+      ICodeServerManagerService.getStatus() and returns structured status information.
+    state: Todo
+    dependencies:
+      - task-12
+    acceptanceCriteria:
+      - 'Use case at packages/core/src/application/use-cases/code-server/get-code-server-status.use-case.ts'
+      - '@injectable() class with execute({ featureId }) method'
+      - 'Delegates to ICodeServerManagerService.getStatus(featureId)'
+      - 'Returns { status, url?, port? } — null if no instance found'
+    tdd:
+      red:
+        - 'Write test: running instance → returns { status: "running", url, port }'
+        - 'Write test: stopped instance → returns { status: "stopped" }'
+        - 'Write test: no instance → returns null'
+      green:
+        - 'Implement use case with @inject and delegation'
+      refactor:
+        - 'Ensure return type is consistent and well-documented'
+    estimatedEffort: '20min'
+
+  - id: task-16
+    phaseId: phase-3
+    title: 'Register use cases in DI container'
+    description: >
+      Register all three code-server use cases in the DI container with string-token aliases
+      for web route resolution via resolve().
+    state: Todo
+    dependencies:
+      - task-13
+      - task-14
+      - task-15
+    acceptanceCriteria:
+      - 'StartCodeServerUseCase registered with string token'
+      - 'StopCodeServerUseCase registered with string token'
+      - 'GetCodeServerStatusUseCase registered with string token'
+      - 'All three resolvable via resolve() in web routes'
+    tdd:
+      red:
+        - 'Write test: resolve each use case string token from container → assert returns correct class instance'
+      green:
+        - 'Add registerSingleton entries to container.ts for all three use cases'
+      refactor:
+        - 'Group registrations with existing use case section in container.ts'
+    estimatedEffort: '15min'
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Phase 4 — API Routes: Web Endpoints
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - id: task-17
+    phaseId: phase-4
+    title: 'Create POST /api/code-server/start route'
+    description: >
+      Create the Next.js API route that accepts { featureId, repositoryPath, branch }, resolves
+      StartCodeServerUseCase via DI, executes it, and returns { url, port } or error response.
+    state: Todo
+    dependencies:
+      - task-16
+    acceptanceCriteria:
+      - 'Route file at src/presentation/web/app/api/code-server/start/route.ts'
+      - 'Exports POST handler'
+      - 'Parses JSON body for featureId, repositoryPath, branch'
+      - 'Returns 400 if required fields missing'
+      - 'Returns 200 with { url, port } on success'
+      - 'Returns 404 if feature not found'
+      - 'Returns 500 with { error } on unexpected errors'
+    tdd:
+      red:
+        - 'Write test: POST with valid body → assert 200 with { url, port }'
+        - 'Write test: POST with missing featureId → assert 400'
+        - 'Write test: POST with non-existent feature → assert 404'
+      green:
+        - 'Implement route handler following existing route patterns (resolve, validate, execute, respond)'
+      refactor:
+        - 'Ensure error responses are consistent with existing API error format'
+    estimatedEffort: '30min'
+
+  - id: task-18
+    phaseId: phase-4
+    title: 'Create POST /api/code-server/stop and GET /api/code-server/status routes'
+    description: >
+      Create the stop and status API routes. Stop accepts { featureId } and delegates to
+      StopCodeServerUseCase. Status accepts featureId query param and delegates to
+      GetCodeServerStatusUseCase.
+    state: Todo
+    dependencies:
+      - task-16
+    acceptanceCriteria:
+      - 'Stop route at src/presentation/web/app/api/code-server/stop/route.ts — POST handler'
+      - 'Status route at src/presentation/web/app/api/code-server/status/route.ts — GET handler'
+      - 'Stop returns 200 on success, 400 if featureId missing'
+      - 'Status returns 200 with instance data or null, 400 if featureId query param missing'
+      - 'Both handle errors with 500 and { error } response'
+    tdd:
+      red:
+        - 'Write test: POST /stop with featureId → assert 200'
+        - 'Write test: GET /status?featureId=xxx → assert 200 with status data'
+        - 'Write test: GET /status without featureId → assert 400'
+      green:
+        - 'Implement both routes following the same pattern as the start route'
+      refactor:
+        - 'Verify response shapes are consistent across all three code-server routes'
+    estimatedEffort: '30min'
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Phase 5 — Web UI: Feature Drawer Integration & Storybook
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - id: task-19
+    phaseId: phase-5
+    title: 'Extend useFeatureActions hook and OpenActionMenu with browser editor'
+    description: >
+      Add browser editor actions to the useFeatureActions hook (start, stop, status fetch) and
+      extend OpenActionMenu with a "Browser Editor" DropdownMenuItem. The menu item shows a Globe
+      icon, supports loading/error/running states, opens code-server URL in new tab on start,
+      shows green dot when running, and is disabled when code-server is not installed.
+    state: Todo
+    dependencies:
+      - task-17
+      - task-18
+    acceptanceCriteria:
+      - 'useFeatureActions exposes: openBrowserEditor(), stopBrowserEditor(), browserEditorStatus, browserEditorLoading, browserEditorError'
+      - 'Status fetched on hook mount (GET /api/code-server/status) and after start/stop actions'
+      - 'OpenActionMenu shows "Browser Editor" item with Globe icon from lucide-react'
+      - 'Clicking "Browser Editor" calls POST /api/code-server/start and opens URL in new tab via window.open()'
+      - 'When running: menu item shows green dot indicator and changes to "Stop Browser Editor"'
+      - 'Loading state shows spinner icon (Loader2 with animate-spin)'
+      - 'Error state shows alert icon with auto-clear after 5 seconds'
+      - 'Disabled with tooltip when code-server is not installed'
+      - 'featureId passed from FeatureDrawerProps.selectedNode.featureId'
+    tdd:
+      red:
+        - 'Write test: render OpenActionMenu with browserEditorStatus = "stopped" → assert "Browser Editor" menu item visible with Globe icon'
+        - 'Write test: render with browserEditorStatus = "running" → assert "Stop Browser Editor" visible with green dot'
+        - 'Write test: render with browserEditorLoading = true → assert spinner icon shown'
+        - 'Write test: render with code-server not installed → assert menu item is disabled'
+        - 'Write test: click "Browser Editor" → assert start API called and window.open triggered'
+      green:
+        - 'Add browserEditor state to useFeatureActions (loading, error, status, actions)'
+        - 'Add status fetch on mount via useEffect'
+        - 'Add "Browser Editor" / "Stop Browser Editor" DropdownMenuItem to OpenActionMenu'
+        - 'Update config.ts with new action type'
+      refactor:
+        - 'Ensure loading/error pattern matches existing IDE/Terminal/Specs actions exactly'
+        - 'Extract browser editor menu item into a sub-component if it grows complex'
+    estimatedEffort: '2h'
+
+  - id: task-20
+    phaseId: phase-5
+    title: 'Create Storybook stories for OpenActionMenu and update feature drawer stories'
+    description: >
+      Create comprehensive Storybook stories for the OpenActionMenu component covering all browser
+      editor states. Update existing feature drawer stories to include browser editor state
+      variations. All states must be demonstrated: loading, running, stopped, error, not installed.
+    state: Todo
+    dependencies:
+      - task-19
+    acceptanceCriteria:
+      - 'OpenActionMenu stories file at src/presentation/web/components/common/open-action-menu/open-action-menu.stories.tsx'
+      - 'Stories cover: default (stopped), loading, running, error, not-installed states'
+      - 'Feature drawer stories updated to include browser editor state in fixtures'
+      - 'All stories render without errors in Storybook'
+      - 'Colocated with the component (same directory)'
+    tdd:
+      red:
+        - 'Run Storybook build — no new stories should exist yet for OpenActionMenu'
+      green:
+        - 'Create stories with fixture data for all browser editor states'
+        - 'Add DrawerTrigger helpers for interactive testing'
+        - 'Update feature drawer story fixtures to include browserEditorStatus variations'
+      refactor:
+        - 'Ensure story organization follows existing pattern (fixtures → helpers → stories → matrix)'
+    estimatedEffort: '1h'
+
+totalEstimate: '13h'
+
+openQuestions: []
+
+content: |
+  ## Summary
+
+  The implementation is broken into 20 tasks across 5 phases, totaling approximately 13 hours
+  of estimated effort.
+
+  **Phase 1 (Foundation)** establishes the data layer: TypeSpec value object for instance state,
+  code-server tool metadata JSON, Settings model extension for idle timeout, SQLite migrations
+  for the instances table and settings column, and the database mapper. These 6 tasks have minimal
+  interdependencies and produce the types and schema consumed by all subsequent phases.
+
+  **Phase 2 (Service Layer)** is the most complex phase with 6 tasks building the
+  CodeServerManagerService. The interface is defined first, then start/stop/getStatus/listRunning/
+  stopAll/reconcile methods are implemented incrementally with thorough TDD. Each method builds
+  on the previous. The service is registered in the DI container at the end of the phase.
+
+  **Phase 3 (Use Cases)** adds 3 thin use cases (Start, Stop, GetStatus) plus DI registration.
+  These orchestrate validation (feature exists, tool installed) before delegating to the service
+  interface. They are the seam between presentation and infrastructure layers.
+
+  **Phase 4 (API Routes)** exposes 3 Next.js endpoints (start, stop, status) that resolve use
+  cases via DI. These are straightforward request → validate → execute → respond handlers.
+
+  **Phase 5 (Web UI)** integrates the browser editor into the feature drawer's OpenActionMenu
+  with full state management (loading, running, stopped, error, not-installed) and comprehensive
+  Storybook stories. This is the user-facing culmination of all previous phases.
+
+  The ordering ensures each phase can be developed and tested independently — Phase 1 types are
+  verified by tsp:compile, Phase 2 services by unit tests with mocked dependencies, Phase 3 use
+  cases by unit tests with mocked services, Phase 4 routes by integration tests, and Phase 5 UI
+  by Storybook stories and component tests.
+
+  ---
+
+  _Task breakdown complete — ready for implementation_

--- a/src/presentation/web/app/api/code-server/start/route.ts
+++ b/src/presentation/web/app/api/code-server/start/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { resolve } from '@/lib/server-container';
+import type { StartCodeServerUseCase } from '@shepai/core/application/use-cases/code-server/start-code-server.use-case';
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { featureId, repositoryPath, branch } = body;
+
+  if (!featureId || typeof featureId !== 'string') {
+    return NextResponse.json({ error: 'Missing required field: featureId' }, { status: 400 });
+  }
+  if (!repositoryPath || typeof repositoryPath !== 'string') {
+    return NextResponse.json({ error: 'Missing required field: repositoryPath' }, { status: 400 });
+  }
+  if (!branch || typeof branch !== 'string') {
+    return NextResponse.json({ error: 'Missing required field: branch' }, { status: 400 });
+  }
+
+  try {
+    const useCase = resolve<StartCodeServerUseCase>('StartCodeServerUseCase');
+    const result = await useCase.execute({ featureId, repositoryPath, branch });
+    return NextResponse.json({ url: result.url, port: result.port });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to start code-server';
+
+    if (message.includes('Feature not found')) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/presentation/web/app/api/code-server/status/route.ts
+++ b/src/presentation/web/app/api/code-server/status/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { resolve } from '@/lib/server-container';
+import type { GetCodeServerStatusUseCase } from '@shepai/core/application/use-cases/code-server/get-code-server-status.use-case';
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const url = new URL(request.url);
+  const featureId = url.searchParams.get('featureId');
+
+  if (!featureId) {
+    return NextResponse.json(
+      { error: 'Missing required query parameter: featureId' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const useCase = resolve<GetCodeServerStatusUseCase>('GetCodeServerStatusUseCase');
+    const result = await useCase.execute({ featureId });
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to get code-server status';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/presentation/web/app/api/code-server/stop/route.ts
+++ b/src/presentation/web/app/api/code-server/stop/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { resolve } from '@/lib/server-container';
+import type { StopCodeServerUseCase } from '@shepai/core/application/use-cases/code-server/stop-code-server.use-case';
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { featureId } = body;
+
+  if (!featureId || typeof featureId !== 'string') {
+    return NextResponse.json({ error: 'Missing required field: featureId' }, { status: 400 });
+  }
+
+  try {
+    const useCase = resolve<StopCodeServerUseCase>('StopCodeServerUseCase');
+    await useCase.execute({ featureId });
+    return NextResponse.json({ ok: true });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to stop code-server';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
+++ b/src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
@@ -79,6 +79,7 @@ export function FeatureDrawer({
                 repositoryPath={selectedNode.repositoryPath}
                 branch={selectedNode.branch}
                 specPath={selectedNode.specPath}
+                featureId={selectedNode.featureId}
               />
             ) : null}
 
@@ -277,12 +278,14 @@ function DrawerActions({
   repositoryPath,
   branch,
   specPath,
+  featureId,
 }: {
   repositoryPath: string;
   branch: string;
   specPath?: string;
+  featureId: string;
 }) {
-  const actions = useFeatureActions({ repositoryPath, branch, specPath });
+  const actions = useFeatureActions({ repositoryPath, branch, specPath, featureId });
 
   return (
     <div className="flex gap-2 px-4 pb-3">

--- a/src/presentation/web/components/common/feature-drawer/use-feature-actions.ts
+++ b/src/presentation/web/components/common/feature-drawer/use-feature-actions.ts
@@ -9,18 +9,26 @@ export interface FeatureActionsInput {
   repositoryPath: string;
   branch: string;
   specPath?: string;
+  featureId?: string;
 }
+
+export type BrowserEditorStatus = 'running' | 'stopped' | null;
 
 export interface FeatureActionsState {
   openInIde: () => Promise<void>;
   openInShell: () => Promise<void>;
   openSpecsFolder: () => Promise<void>;
+  openBrowserEditor: () => Promise<void>;
+  stopBrowserEditor: () => Promise<void>;
   ideLoading: boolean;
   shellLoading: boolean;
   specsLoading: boolean;
+  browserEditorLoading: boolean;
   ideError: string | null;
   shellError: string | null;
   specsError: string | null;
+  browserEditorError: string | null;
+  browserEditorStatus: BrowserEditorStatus;
 }
 
 const ERROR_CLEAR_DELAY = 5000;
@@ -29,25 +37,62 @@ export function useFeatureActions(input: FeatureActionsInput | null): FeatureAct
   const [ideLoading, setIdeLoading] = useState(false);
   const [shellLoading, setShellLoading] = useState(false);
   const [specsLoading, setSpecsLoading] = useState(false);
+  const [browserEditorLoading, setBrowserEditorLoading] = useState(false);
   const [ideError, setIdeError] = useState<string | null>(null);
   const [shellError, setShellError] = useState<string | null>(null);
   const [specsError, setSpecsError] = useState<string | null>(null);
+  const [browserEditorError, setBrowserEditorError] = useState<string | null>(null);
+  const [browserEditorStatus, setBrowserEditorStatus] = useState<BrowserEditorStatus>(null);
 
   const ideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const specsTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const browserEditorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Clear timers on unmount
   useEffect(() => {
     const ideTimer = ideTimerRef.current;
     const shellTimer = shellTimerRef.current;
     const specsTimer = specsTimerRef.current;
+    const browserEditorTimer = browserEditorTimerRef.current;
     return () => {
       if (ideTimer) clearTimeout(ideTimer);
       if (shellTimer) clearTimeout(shellTimer);
       if (specsTimer) clearTimeout(specsTimer);
+      if (browserEditorTimer) clearTimeout(browserEditorTimer);
     };
   }, []);
+
+  // Fetch browser editor status on mount / when featureId changes
+  useEffect(() => {
+    if (!input?.featureId) {
+      setBrowserEditorStatus(null);
+      return;
+    }
+
+    const featureId = input.featureId;
+    let cancelled = false;
+
+    async function fetchStatus() {
+      try {
+        const res = await fetch(
+          `/api/code-server/status?featureId=${encodeURIComponent(featureId)}`
+        );
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        if (!cancelled) {
+          setBrowserEditorStatus(data?.status === 'running' ? 'running' : 'stopped');
+        }
+      } catch {
+        // Silently fail — status will show as null (unknown)
+      }
+    }
+
+    void fetchStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [input?.featureId]);
 
   const performAction = useCallback(
     async (
@@ -125,15 +170,122 @@ export function useFeatureActions(input: FeatureActionsInput | null): FeatureAct
     }
   }, [input, specsLoading]);
 
+  const fetchBrowserEditorStatus = useCallback(async () => {
+    if (!input?.featureId) return;
+    try {
+      const res = await fetch(
+        `/api/code-server/status?featureId=${encodeURIComponent(input.featureId)}`
+      );
+      if (!res.ok) return;
+      const data = await res.json();
+      setBrowserEditorStatus(data?.status === 'running' ? 'running' : 'stopped');
+    } catch {
+      // Silently fail
+    }
+  }, [input?.featureId]);
+
+  const handleOpenBrowserEditor = useCallback(async () => {
+    if (!input?.featureId || browserEditorLoading) return;
+
+    if (browserEditorTimerRef.current) clearTimeout(browserEditorTimerRef.current);
+
+    setBrowserEditorLoading(true);
+    setBrowserEditorError(null);
+
+    try {
+      const res = await fetch('/api/code-server/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          featureId: input.featureId,
+          repositoryPath: input.repositoryPath,
+          branch: input.branch,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        const errorMessage = data?.error ?? 'Failed to start browser editor';
+        setBrowserEditorError(errorMessage);
+        browserEditorTimerRef.current = setTimeout(
+          () => setBrowserEditorError(null),
+          ERROR_CLEAR_DELAY
+        );
+        return;
+      }
+
+      // Open code-server in a new tab
+      if (data?.url) {
+        window.open(data.url, '_blank');
+      }
+
+      await fetchBrowserEditorStatus();
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to start browser editor';
+      setBrowserEditorError(errorMessage);
+      browserEditorTimerRef.current = setTimeout(
+        () => setBrowserEditorError(null),
+        ERROR_CLEAR_DELAY
+      );
+    } finally {
+      setBrowserEditorLoading(false);
+    }
+  }, [input, browserEditorLoading, fetchBrowserEditorStatus]);
+
+  const handleStopBrowserEditor = useCallback(async () => {
+    if (!input?.featureId || browserEditorLoading) return;
+
+    if (browserEditorTimerRef.current) clearTimeout(browserEditorTimerRef.current);
+
+    setBrowserEditorLoading(true);
+    setBrowserEditorError(null);
+
+    try {
+      const res = await fetch('/api/code-server/stop', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ featureId: input.featureId }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        const errorMessage = data?.error ?? 'Failed to stop browser editor';
+        setBrowserEditorError(errorMessage);
+        browserEditorTimerRef.current = setTimeout(
+          () => setBrowserEditorError(null),
+          ERROR_CLEAR_DELAY
+        );
+        return;
+      }
+
+      await fetchBrowserEditorStatus();
+    } catch (err: unknown) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to stop browser editor';
+      setBrowserEditorError(errorMessage);
+      browserEditorTimerRef.current = setTimeout(
+        () => setBrowserEditorError(null),
+        ERROR_CLEAR_DELAY
+      );
+    } finally {
+      setBrowserEditorLoading(false);
+    }
+  }, [input, browserEditorLoading, fetchBrowserEditorStatus]);
+
   return {
     openInIde: handleOpenIde,
     openInShell: handleOpenShell,
     openSpecsFolder: handleOpenSpecsFolder,
+    openBrowserEditor: handleOpenBrowserEditor,
+    stopBrowserEditor: handleStopBrowserEditor,
     ideLoading,
     shellLoading,
     specsLoading,
+    browserEditorLoading,
     ideError,
     shellError,
     specsError,
+    browserEditorError,
+    browserEditorStatus,
   };
 }

--- a/src/presentation/web/components/common/open-action-menu/open-action-menu.stories.tsx
+++ b/src/presentation/web/components/common/open-action-menu/open-action-menu.stories.tsx
@@ -3,17 +3,38 @@ import { fn } from '@storybook/test';
 import { OpenActionMenu } from './open-action-menu';
 import type { FeatureActionsState } from '@/components/common/feature-drawer/use-feature-actions';
 
-const defaultActions: FeatureActionsState = {
-  openInIde: fn().mockName('openInIde'),
-  openInShell: fn().mockName('openInShell'),
-  openSpecsFolder: fn().mockName('openSpecsFolder'),
-  ideLoading: false,
-  shellLoading: false,
-  specsLoading: false,
-  ideError: null,
-  shellError: null,
-  specsError: null,
+/* ---------------------------------------------------------------------------
+ * Fixture helpers
+ * ------------------------------------------------------------------------- */
+
+function makeActions(overrides: Partial<FeatureActionsState> = {}): FeatureActionsState {
+  return {
+    openInIde: fn().mockName('openInIde'),
+    openInShell: fn().mockName('openInShell'),
+    openSpecsFolder: fn().mockName('openSpecsFolder'),
+    openBrowserEditor: fn().mockName('openBrowserEditor'),
+    stopBrowserEditor: fn().mockName('stopBrowserEditor'),
+    ideLoading: false,
+    shellLoading: false,
+    specsLoading: false,
+    browserEditorLoading: false,
+    ideError: null,
+    shellError: null,
+    specsError: null,
+    browserEditorError: null,
+    browserEditorStatus: 'stopped',
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  repositoryPath: '/Users/dev/my-project',
+  showSpecs: true,
 };
+
+/* ---------------------------------------------------------------------------
+ * Meta
+ * ------------------------------------------------------------------------- */
 
 const meta: Meta<typeof OpenActionMenu> = {
   title: 'Composed/OpenActionMenu',
@@ -27,38 +48,114 @@ const meta: Meta<typeof OpenActionMenu> = {
 export default meta;
 type Story = StoryObj<typeof OpenActionMenu>;
 
+/* ---------------------------------------------------------------------------
+ * Default / baseline stories
+ * ------------------------------------------------------------------------- */
+
 /** Default menu with all actions including specs folder. */
 export const Default: Story = {
   args: {
-    actions: defaultActions,
-    repositoryPath: '/Users/dev/my-project',
-    showSpecs: true,
+    ...defaultProps,
+    actions: makeActions(),
   },
 };
 
 /** Menu without specs folder action. */
 export const WithoutSpecs: Story = {
   args: {
-    actions: defaultActions,
-    repositoryPath: '/Users/dev/my-project',
+    ...defaultProps,
     showSpecs: false,
+    actions: makeActions(),
   },
 };
 
 /** Menu while IDE action is loading. */
 export const Loading: Story = {
   args: {
-    actions: { ...defaultActions, ideLoading: true },
-    repositoryPath: '/Users/dev/my-project',
-    showSpecs: true,
+    ...defaultProps,
+    actions: makeActions({ ideLoading: true }),
   },
 };
 
 /** Menu with an error on the IDE action. */
 export const WithError: Story = {
   args: {
-    actions: { ...defaultActions, ideError: 'Editor not found' },
-    repositoryPath: '/Users/dev/my-project',
-    showSpecs: true,
+    ...defaultProps,
+    actions: makeActions({ ideError: 'Editor not found' }),
+  },
+};
+
+/* ---------------------------------------------------------------------------
+ * Browser editor state stories
+ * ------------------------------------------------------------------------- */
+
+/** Browser editor is running — shows "Stop Browser Editor" with green dot. */
+export const BrowserEditorRunning: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({ browserEditorStatus: 'running' }),
+  },
+};
+
+/** Browser editor is loading (starting up). */
+export const BrowserEditorLoading: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({ browserEditorLoading: true }),
+  },
+};
+
+/** Browser editor stop in progress — shows spinner on "Stop Browser Editor". */
+export const BrowserEditorStopLoading: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({
+      browserEditorStatus: 'running',
+      browserEditorLoading: true,
+    }),
+  },
+};
+
+/** Browser editor has an error — shows alert icon. */
+export const BrowserEditorError: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({
+      browserEditorError: 'Failed to start: code-server binary not found',
+    }),
+  },
+};
+
+/** Browser editor status is null (not yet fetched). */
+export const BrowserEditorUnknown: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({ browserEditorStatus: null }),
+  },
+};
+
+/* ---------------------------------------------------------------------------
+ * Combined state stories
+ * ------------------------------------------------------------------------- */
+
+/** Multiple errors — trigger button shows warning icon. */
+export const MultipleErrors: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({
+      ideError: 'IDE not found',
+      browserEditorError: 'code-server not installed',
+    }),
+  },
+};
+
+/** Shell error with browser editor running. */
+export const ShellErrorEditorRunning: Story = {
+  args: {
+    ...defaultProps,
+    actions: makeActions({
+      shellError: 'Terminal failed to open',
+      browserEditorStatus: 'running',
+    }),
   },
 };

--- a/src/presentation/web/components/common/open-action-menu/open-action-menu.tsx
+++ b/src/presentation/web/components/common/open-action-menu/open-action-menu.tsx
@@ -10,6 +10,8 @@ import {
   Check,
   Loader2,
   CircleAlert,
+  Globe,
+  Square,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -33,8 +35,15 @@ export function OpenActionMenu({ actions, repositoryPath, showSpecs }: OpenActio
     setTimeout(() => setCopied(false), COPY_FEEDBACK_DELAY);
   };
 
-  const anyLoading = actions.ideLoading || actions.shellLoading || actions.specsLoading;
-  const anyError = actions.ideError ?? actions.shellError ?? actions.specsError;
+  const anyLoading =
+    actions.ideLoading ||
+    actions.shellLoading ||
+    actions.specsLoading ||
+    actions.browserEditorLoading;
+  const anyError =
+    actions.ideError ?? actions.shellError ?? actions.specsError ?? actions.browserEditorError;
+
+  const isEditorRunning = actions.browserEditorStatus === 'running';
 
   return (
     <DropdownMenu modal={false}>
@@ -98,6 +107,41 @@ export function OpenActionMenu({ actions, repositoryPath, showSpecs }: OpenActio
           )}
           Specs Folder
         </DropdownMenuItem>
+
+        {isEditorRunning ? (
+          <DropdownMenuItem
+            onClick={actions.stopBrowserEditor}
+            disabled={actions.browserEditorLoading}
+            className="gap-2"
+          >
+            {actions.browserEditorLoading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : actions.browserEditorError ? (
+              <CircleAlert className="text-destructive size-4" />
+            ) : (
+              <Square className="size-4" />
+            )}
+            <span className="flex items-center gap-1.5">
+              Stop Browser Editor
+              <span className="size-2 rounded-full bg-green-500" />
+            </span>
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuItem
+            onClick={actions.openBrowserEditor}
+            disabled={actions.browserEditorLoading}
+            className="gap-2"
+          >
+            {actions.browserEditorLoading ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : actions.browserEditorError ? (
+              <CircleAlert className="text-destructive size-4" />
+            ) : (
+              <Globe className="size-4" />
+            )}
+            Browser Editor
+          </DropdownMenuItem>
+        )}
 
         <DropdownMenuSeparator />
 

--- a/tests/integration/api/code-server-start.test.ts
+++ b/tests/integration/api/code-server-start.test.ts
@@ -1,0 +1,173 @@
+/**
+ * POST /api/code-server/start — Integration Tests
+ *
+ * Tests the start route handler: validates input, delegates to
+ * StartCodeServerUseCase, and returns the code-server URL/port.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Mock DI container ---
+
+const mockStartUseCase = {
+  execute: vi.fn(),
+};
+
+vi.mock('@/lib/server-container', () => ({
+  resolve: vi.fn((token: string) => {
+    if (token === 'StartCodeServerUseCase') return mockStartUseCase;
+    throw new Error(`Unknown token: ${token}`);
+  }),
+}));
+
+// --- Import route handler after mocks ---
+import { POST } from '@/app/api/code-server/start/route';
+
+describe('POST /api/code-server/start', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with url and port on success', async () => {
+    mockStartUseCase.execute.mockResolvedValue({
+      url: 'http://127.0.0.1:13370',
+      port: 13370,
+    });
+
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        featureId: 'feat-1',
+        repositoryPath: '/tmp/repo',
+        branch: 'feat/my-feature',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ url: 'http://127.0.0.1:13370', port: 13370 });
+    expect(mockStartUseCase.execute).toHaveBeenCalledWith({
+      featureId: 'feat-1',
+      repositoryPath: '/tmp/repo',
+      branch: 'feat/my-feature',
+    });
+  });
+
+  it('returns 400 when featureId is missing', async () => {
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        repositoryPath: '/tmp/repo',
+        branch: 'feat/my-feature',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toHaveProperty('error');
+    expect(mockStartUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when repositoryPath is missing', async () => {
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        featureId: 'feat-1',
+        branch: 'feat/my-feature',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toHaveProperty('error');
+    expect(mockStartUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when branch is missing', async () => {
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        featureId: 'feat-1',
+        repositoryPath: '/tmp/repo',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toHaveProperty('error');
+    expect(mockStartUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when feature is not found', async () => {
+    mockStartUseCase.execute.mockRejectedValue(new Error('Feature not found: feat-unknown'));
+
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        featureId: 'feat-unknown',
+        repositoryPath: '/tmp/repo',
+        branch: 'feat/my-feature',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toHaveProperty('error');
+  });
+
+  it('returns 500 on unexpected errors', async () => {
+    mockStartUseCase.execute.mockRejectedValue(new Error('Spawn failed'));
+
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        featureId: 'feat-1',
+        repositoryPath: '/tmp/repo',
+        branch: 'feat/my-feature',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toHaveProperty('error', 'Spawn failed');
+  });
+
+  it('returns 500 with fallback message for non-Error exceptions', async () => {
+    mockStartUseCase.execute.mockRejectedValue('something went wrong');
+
+    const request = new Request('http://localhost/api/code-server/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        featureId: 'feat-1',
+        repositoryPath: '/tmp/repo',
+        branch: 'feat/my-feature',
+      }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/tests/integration/api/code-server-status.test.ts
+++ b/tests/integration/api/code-server-status.test.ts
@@ -1,0 +1,113 @@
+/**
+ * GET /api/code-server/status — Integration Tests
+ *
+ * Tests the status route handler: validates featureId query param,
+ * delegates to GetCodeServerStatusUseCase, and returns instance data.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Mock DI container ---
+
+const mockStatusUseCase = {
+  execute: vi.fn(),
+};
+
+vi.mock('@/lib/server-container', () => ({
+  resolve: vi.fn((token: string) => {
+    if (token === 'GetCodeServerStatusUseCase') return mockStatusUseCase;
+    throw new Error(`Unknown token: ${token}`);
+  }),
+}));
+
+// --- Import route handler after mocks ---
+import { GET } from '@/app/api/code-server/status/route';
+
+describe('GET /api/code-server/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with running status data', async () => {
+    mockStatusUseCase.execute.mockResolvedValue({
+      status: 'running',
+      url: 'http://127.0.0.1:13370',
+      port: 13370,
+    });
+
+    const request = new Request('http://localhost/api/code-server/status?featureId=feat-1');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      status: 'running',
+      url: 'http://127.0.0.1:13370',
+      port: 13370,
+    });
+    expect(mockStatusUseCase.execute).toHaveBeenCalledWith({ featureId: 'feat-1' });
+  });
+
+  it('returns 200 with null when no instance exists', async () => {
+    mockStatusUseCase.execute.mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/code-server/status?featureId=feat-1');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toBeNull();
+  });
+
+  it('returns 200 with stopped status', async () => {
+    mockStatusUseCase.execute.mockResolvedValue({
+      status: 'stopped',
+    });
+
+    const request = new Request('http://localhost/api/code-server/status?featureId=feat-1');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: 'stopped' });
+  });
+
+  it('returns 400 when featureId query param is missing', async () => {
+    const request = new Request('http://localhost/api/code-server/status');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toHaveProperty('error');
+    expect(mockStatusUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 on unexpected errors', async () => {
+    mockStatusUseCase.execute.mockRejectedValue(new Error('DB connection failed'));
+
+    const request = new Request('http://localhost/api/code-server/status?featureId=feat-1');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toHaveProperty('error', 'DB connection failed');
+  });
+
+  it('returns 500 with fallback message for non-Error exceptions', async () => {
+    mockStatusUseCase.execute.mockRejectedValue('unexpected');
+
+    const request = new Request('http://localhost/api/code-server/status?featureId=feat-1');
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/tests/integration/api/code-server-stop.test.ts
+++ b/tests/integration/api/code-server-stop.test.ts
@@ -1,0 +1,95 @@
+/**
+ * POST /api/code-server/stop — Integration Tests
+ *
+ * Tests the stop route handler: validates input, delegates to
+ * StopCodeServerUseCase, and returns success or error response.
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// --- Mock DI container ---
+
+const mockStopUseCase = {
+  execute: vi.fn(),
+};
+
+vi.mock('@/lib/server-container', () => ({
+  resolve: vi.fn((token: string) => {
+    if (token === 'StopCodeServerUseCase') return mockStopUseCase;
+    throw new Error(`Unknown token: ${token}`);
+  }),
+}));
+
+// --- Import route handler after mocks ---
+import { POST } from '@/app/api/code-server/stop/route';
+
+describe('POST /api/code-server/stop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 on successful stop', async () => {
+    mockStopUseCase.execute.mockResolvedValue(undefined);
+
+    const request = new Request('http://localhost/api/code-server/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featureId: 'feat-1' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(mockStopUseCase.execute).toHaveBeenCalledWith({ featureId: 'feat-1' });
+  });
+
+  it('returns 400 when featureId is missing', async () => {
+    const request = new Request('http://localhost/api/code-server/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body).toHaveProperty('error');
+    expect(mockStopUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 on unexpected errors', async () => {
+    mockStopUseCase.execute.mockRejectedValue(new Error('Process not found'));
+
+    const request = new Request('http://localhost/api/code-server/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featureId: 'feat-1' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toHaveProperty('error', 'Process not found');
+  });
+
+  it('returns 500 with fallback message for non-Error exceptions', async () => {
+    mockStopUseCase.execute.mockRejectedValue('unexpected');
+
+    const request = new Request('http://localhost/api/code-server/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featureId: 'feat-1' }),
+    });
+
+    const response = await POST(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toHaveProperty('error');
+  });
+});

--- a/tests/integration/infrastructure/persistence/sqlite/migration-015.test.ts
+++ b/tests/integration/infrastructure/persistence/sqlite/migration-015.test.ts
@@ -25,8 +25,8 @@ describe('Migration 015 — onboarding and approval gate defaults', () => {
     db.close();
   });
 
-  it('should set LATEST_SCHEMA_VERSION to 22', () => {
-    expect(LATEST_SCHEMA_VERSION).toBe(22);
+  it('should set LATEST_SCHEMA_VERSION to 24', () => {
+    expect(LATEST_SCHEMA_VERSION).toBe(24);
   });
 
   it('should add all 5 new columns to settings table', () => {

--- a/tests/integration/infrastructure/repositories/sqlite-settings.repository.test.ts
+++ b/tests/integration/infrastructure/repositories/sqlite-settings.repository.test.ts
@@ -75,6 +75,9 @@ describe('SQLiteSettingsRepository', () => {
         pushOnImplementationComplete: false,
       },
     },
+    codeServer: {
+      idleTimeoutSeconds: 1800,
+    },
     onboardingComplete: false,
   });
 

--- a/tests/unit/application/use-cases/code-server/get-code-server-status.use-case.test.ts
+++ b/tests/unit/application/use-cases/code-server/get-code-server-status.use-case.test.ts
@@ -1,0 +1,93 @@
+/**
+ * GetCodeServerStatusUseCase Unit Tests
+ *
+ * Tests for querying code-server instance status by delegating to
+ * ICodeServerManagerService.getStatus().
+ *
+ * TDD Phase: RED-GREEN
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetCodeServerStatusUseCase } from '@/application/use-cases/code-server/get-code-server-status.use-case.js';
+import type { ICodeServerManagerService } from '@/application/ports/output/services/code-server-manager-service.interface.js';
+import type { CodeServerInstance } from '@/domain/generated/output.js';
+import { CodeServerInstanceStatus } from '@/domain/generated/output.js';
+
+describe('GetCodeServerStatusUseCase', () => {
+  let useCase: GetCodeServerStatusUseCase;
+  let mockCodeServerManager: ICodeServerManagerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCodeServerManager = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi
+        .fn<(featureId: string) => Promise<CodeServerInstance | null>>()
+        .mockResolvedValue(null),
+      listRunning: vi.fn(),
+      stopAll: vi.fn(),
+      reconcile: vi.fn(),
+    };
+
+    useCase = new GetCodeServerStatusUseCase(mockCodeServerManager);
+  });
+
+  it('should return running status with url and port when instance is running', async () => {
+    const runningInstance: CodeServerInstance = {
+      id: 'inst-1',
+      featureId: 'feat-123',
+      pid: 12345,
+      port: 13370,
+      worktreePath: '/mock/wt/feat/my-feature',
+      status: CodeServerInstanceStatus.Running,
+      startedAt: new Date(),
+    };
+    vi.mocked(mockCodeServerManager.getStatus).mockResolvedValue(runningInstance);
+
+    const result = await useCase.execute({ featureId: 'feat-123' });
+
+    expect(result).toEqual({
+      status: 'running',
+      url: 'http://127.0.0.1:13370',
+      port: 13370,
+    });
+  });
+
+  it('should return stopped status when instance is stopped', async () => {
+    const stoppedInstance: CodeServerInstance = {
+      id: 'inst-1',
+      featureId: 'feat-123',
+      pid: 12345,
+      port: 13370,
+      worktreePath: '/mock/wt/feat/my-feature',
+      status: CodeServerInstanceStatus.Stopped,
+      startedAt: new Date(),
+      stoppedAt: new Date(),
+    };
+    vi.mocked(mockCodeServerManager.getStatus).mockResolvedValue(stoppedInstance);
+
+    const result = await useCase.execute({ featureId: 'feat-123' });
+
+    expect(result).toEqual({
+      status: 'stopped',
+    });
+  });
+
+  it('should return null when no instance exists for the feature', async () => {
+    vi.mocked(mockCodeServerManager.getStatus).mockResolvedValue(null);
+
+    const result = await useCase.execute({ featureId: 'feat-999' });
+
+    expect(result).toBeNull();
+  });
+
+  it('should delegate to manager.getStatus() with the provided featureId', async () => {
+    await useCase.execute({ featureId: 'feat-123' });
+
+    expect(mockCodeServerManager.getStatus).toHaveBeenCalledWith('feat-123');
+    expect(mockCodeServerManager.getStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/application/use-cases/code-server/start-code-server.use-case.test.ts
+++ b/tests/unit/application/use-cases/code-server/start-code-server.use-case.test.ts
@@ -1,0 +1,192 @@
+/**
+ * StartCodeServerUseCase Unit Tests
+ *
+ * Tests for code-server instance start orchestration: validates feature exists,
+ * checks code-server availability, computes worktree path, and delegates to
+ * ICodeServerManagerService.
+ *
+ * TDD Phase: RED-GREEN
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StartCodeServerUseCase } from '@/application/use-cases/code-server/start-code-server.use-case.js';
+import type { ICodeServerManagerService } from '@/application/ports/output/services/code-server-manager-service.interface.js';
+import type { CodeServerStartResult } from '@/application/ports/output/services/code-server-manager-service.interface.js';
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import type { IToolInstallerService } from '@/application/ports/output/services/tool-installer.service.js';
+import type { Feature, ToolInstallationStatus } from '@/domain/generated/output.js';
+
+vi.mock('@/infrastructure/services/ide-launchers/compute-worktree-path.js', () => ({
+  computeWorktreePath: vi.fn((_repoPath: string, branch: string) => `/mock/wt/${branch}`),
+}));
+
+import { computeWorktreePath } from '@/infrastructure/services/ide-launchers/compute-worktree-path.js';
+
+describe('StartCodeServerUseCase', () => {
+  let useCase: StartCodeServerUseCase;
+  let mockFeatureRepository: IFeatureRepository;
+  let mockToolInstallerService: IToolInstallerService;
+  let mockCodeServerManager: ICodeServerManagerService;
+
+  const mockFeature = {
+    id: 'feat-123',
+    slug: 'my-feature',
+    name: 'My Feature',
+    description: 'A test feature',
+    userQuery: 'test',
+    repositoryPath: '/repo/path',
+    branch: 'feat/my-feature',
+    lifecycle: 'Requirements' as Feature['lifecycle'],
+    messages: [],
+    relatedArtifacts: [],
+    push: false,
+    openPr: false,
+    approvalGates: {} as Feature['approvalGates'],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } as Feature;
+
+  const mockStartResult: CodeServerStartResult = {
+    url: 'http://127.0.0.1:13370',
+    port: 13370,
+    pid: 12345,
+    featureId: 'feat-123',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFeatureRepository = {
+      findById: vi.fn<(id: string) => Promise<Feature | null>>().mockResolvedValue(mockFeature),
+      findByIdPrefix: vi.fn(),
+      findBySlug: vi.fn(),
+      list: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      findByParentId: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    mockToolInstallerService = {
+      checkAvailability: vi
+        .fn<(toolName: string) => Promise<ToolInstallationStatus>>()
+        .mockResolvedValue({
+          status: 'available',
+          toolName: 'code-server',
+        }),
+      getInstallCommand: vi.fn(),
+      executeInstall: vi.fn(),
+    };
+
+    mockCodeServerManager = {
+      start: vi
+        .fn<(featureId: string, worktreePath: string) => Promise<CodeServerStartResult>>()
+        .mockResolvedValue(mockStartResult),
+      stop: vi.fn(),
+      getStatus: vi.fn(),
+      listRunning: vi.fn(),
+      stopAll: vi.fn(),
+      reconcile: vi.fn(),
+    };
+
+    useCase = new StartCodeServerUseCase(
+      mockFeatureRepository,
+      mockToolInstallerService,
+      mockCodeServerManager
+    );
+  });
+
+  describe('successful start', () => {
+    it('should return url and port when feature exists and code-server is installed', async () => {
+      const result = await useCase.execute({
+        featureId: 'feat-123',
+        repositoryPath: '/repo/path',
+        branch: 'feat/my-feature',
+      });
+
+      expect(result).toEqual({
+        url: 'http://127.0.0.1:13370',
+        port: 13370,
+      });
+    });
+
+    it('should compute worktree path from repositoryPath and branch', async () => {
+      await useCase.execute({
+        featureId: 'feat-123',
+        repositoryPath: '/repo/path',
+        branch: 'feat/my-feature',
+      });
+
+      expect(computeWorktreePath).toHaveBeenCalledWith('/repo/path', 'feat/my-feature');
+    });
+
+    it('should delegate to manager service with featureId and computed worktree path', async () => {
+      await useCase.execute({
+        featureId: 'feat-123',
+        repositoryPath: '/repo/path',
+        branch: 'feat/my-feature',
+      });
+
+      expect(mockCodeServerManager.start).toHaveBeenCalledWith(
+        'feat-123',
+        '/mock/wt/feat/my-feature'
+      );
+    });
+  });
+
+  describe('feature validation', () => {
+    it('should throw error when feature is not found', async () => {
+      vi.mocked(mockFeatureRepository.findById).mockResolvedValue(null);
+
+      await expect(
+        useCase.execute({
+          featureId: 'non-existent',
+          repositoryPath: '/repo/path',
+          branch: 'feat/my-feature',
+        })
+      ).rejects.toThrow('Feature not found');
+
+      expect(mockCodeServerManager.start).not.toHaveBeenCalled();
+    });
+
+    it('should call findById with the provided featureId', async () => {
+      await useCase.execute({
+        featureId: 'feat-123',
+        repositoryPath: '/repo/path',
+        branch: 'feat/my-feature',
+      });
+
+      expect(mockFeatureRepository.findById).toHaveBeenCalledWith('feat-123');
+    });
+  });
+
+  describe('tool availability validation', () => {
+    it('should throw error when code-server is not installed', async () => {
+      vi.mocked(mockToolInstallerService.checkAvailability).mockResolvedValue({
+        status: 'missing',
+        toolName: 'code-server',
+      });
+
+      await expect(
+        useCase.execute({
+          featureId: 'feat-123',
+          repositoryPath: '/repo/path',
+          branch: 'feat/my-feature',
+        })
+      ).rejects.toThrow('code-server is not installed');
+
+      expect(mockCodeServerManager.start).not.toHaveBeenCalled();
+    });
+
+    it('should check availability for code-server tool', async () => {
+      await useCase.execute({
+        featureId: 'feat-123',
+        repositoryPath: '/repo/path',
+        branch: 'feat/my-feature',
+      });
+
+      expect(mockToolInstallerService.checkAvailability).toHaveBeenCalledWith('code-server');
+    });
+  });
+});

--- a/tests/unit/application/use-cases/code-server/stop-code-server.use-case.test.ts
+++ b/tests/unit/application/use-cases/code-server/stop-code-server.use-case.test.ts
@@ -1,0 +1,54 @@
+/**
+ * StopCodeServerUseCase Unit Tests
+ *
+ * Tests for stopping a code-server instance by delegating to
+ * ICodeServerManagerService.stop().
+ *
+ * TDD Phase: RED-GREEN
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StopCodeServerUseCase } from '@/application/use-cases/code-server/stop-code-server.use-case.js';
+import type { ICodeServerManagerService } from '@/application/ports/output/services/code-server-manager-service.interface.js';
+
+describe('StopCodeServerUseCase', () => {
+  let useCase: StopCodeServerUseCase;
+  let mockCodeServerManager: ICodeServerManagerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockCodeServerManager = {
+      start: vi.fn(),
+      stop: vi.fn<(featureId: string) => Promise<void>>().mockResolvedValue(undefined),
+      getStatus: vi.fn(),
+      listRunning: vi.fn(),
+      stopAll: vi.fn(),
+      reconcile: vi.fn(),
+    };
+
+    useCase = new StopCodeServerUseCase(mockCodeServerManager);
+  });
+
+  it('should delegate to manager.stop() with the provided featureId', async () => {
+    await useCase.execute({ featureId: 'feat-456' });
+
+    expect(mockCodeServerManager.stop).toHaveBeenCalledWith('feat-456');
+    expect(mockCodeServerManager.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return void on success', async () => {
+    const result = await useCase.execute({ featureId: 'feat-456' });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should propagate errors from the manager service', async () => {
+    vi.mocked(mockCodeServerManager.stop).mockRejectedValue(new Error('Failed to stop instance'));
+
+    await expect(useCase.execute({ featureId: 'feat-456' })).rejects.toThrow(
+      'Failed to stop instance'
+    );
+  });
+});

--- a/tests/unit/application/use-cases/settings/complete-onboarding.use-case.test.ts
+++ b/tests/unit/application/use-cases/settings/complete-onboarding.use-case.test.ts
@@ -51,6 +51,9 @@ function createTestSettings(overrides: Partial<Settings> = {}): Settings {
         pushOnImplementationComplete: false,
       },
     },
+    codeServer: {
+      idleTimeoutSeconds: 1800,
+    },
     onboardingComplete: false,
     ...overrides,
   };

--- a/tests/unit/infrastructure/persistence/sqlite/mappers/settings.mapper.test.ts
+++ b/tests/unit/infrastructure/persistence/sqlite/mappers/settings.mapper.test.ts
@@ -75,6 +75,9 @@ function createTestSettings(overrides: Partial<Settings> = {}): Settings {
         pushOnImplementationComplete: false,
       },
     },
+    codeServer: {
+      idleTimeoutSeconds: 1800,
+    },
     onboardingComplete: false,
     ...overrides,
   };
@@ -121,6 +124,7 @@ function createTestRow(overrides: Partial<SettingsRow> = {}): SettingsRow {
     approval_gate_allow_plan: 0,
     approval_gate_allow_merge: 0,
     approval_gate_push_on_impl_complete: 0,
+    cs_idle_timeout_seconds: 1800,
     ...overrides,
   };
 }

--- a/tests/unit/infrastructure/services/code-server/code-server-manager.service.test.ts
+++ b/tests/unit/infrastructure/services/code-server/code-server-manager.service.test.ts
@@ -1,0 +1,515 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type Database from 'better-sqlite3';
+
+// Hoist mocks before imports
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockCreateWriteStream = vi.hoisted(() => vi.fn());
+const mockMkdir = vi.hoisted(() => vi.fn());
+const mockFindAvailablePort = vi.hoisted(() => vi.fn());
+const mockGetShepHomeDir = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    spawn: mockSpawn,
+  };
+});
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createWriteStream: mockCreateWriteStream,
+  };
+});
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    mkdir: mockMkdir,
+  };
+});
+
+vi.mock('@/infrastructure/services/port.service', () => ({
+  findAvailablePort: mockFindAvailablePort,
+}));
+
+vi.mock('@/infrastructure/services/filesystem/shep-directory.service', () => ({
+  getShepHomeDir: mockGetShepHomeDir,
+}));
+
+import { createDatabaseWithMigrations } from '../../../../helpers/database.helper.js';
+import { runSQLiteMigrations } from '@/infrastructure/persistence/sqlite/migrations.js';
+import { CodeServerManagerService } from '@/infrastructure/services/code-server/code-server-manager.service.js';
+import { CodeServerInstanceStatus } from '@/domain/generated/output.js';
+
+describe('CodeServerManagerService', () => {
+  let db: Database.Database;
+  let service: CodeServerManagerService;
+
+  const FEATURE_ID = 'test-feature-123';
+  const WORKTREE_PATH = '/home/user/.shep/repos/abc/wt/my-feature';
+  const SHEP_HOME = '/home/user/.shep';
+
+  function createMockChildProcess(pid: number) {
+    return {
+      pid,
+      unref: vi.fn(),
+      on: vi.fn(),
+    };
+  }
+
+  function insertRunningInstance(
+    featureId: string,
+    pid: number,
+    port: number,
+    worktreePath = WORKTREE_PATH
+  ) {
+    db.prepare(
+      `
+      INSERT INTO code_server_instances (
+        id, feature_id, pid, port, worktree_path, status,
+        started_at, stopped_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+    `
+    ).run(
+      `id-${featureId}`,
+      featureId,
+      pid,
+      port,
+      worktreePath,
+      CodeServerInstanceStatus.Running,
+      new Date().toISOString(),
+      Date.now(),
+      Date.now()
+    );
+  }
+
+  function insertStoppedInstance(featureId: string, pid: number, port: number) {
+    db.prepare(
+      `
+      INSERT INTO code_server_instances (
+        id, feature_id, pid, port, worktree_path, status,
+        started_at, stopped_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `
+    ).run(
+      `id-${featureId}`,
+      featureId,
+      pid,
+      port,
+      WORKTREE_PATH,
+      CodeServerInstanceStatus.Stopped,
+      new Date().toISOString(),
+      new Date().toISOString(),
+      Date.now(),
+      Date.now()
+    );
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    db = await createDatabaseWithMigrations(runSQLiteMigrations);
+    service = new CodeServerManagerService(db);
+
+    // Default mock returns
+    mockGetShepHomeDir.mockReturnValue(SHEP_HOME);
+    mockFindAvailablePort.mockResolvedValue(13370);
+    mockMkdir.mockResolvedValue(undefined);
+    mockCreateWriteStream.mockReturnValue({
+      write: vi.fn(),
+      end: vi.fn(),
+      on: vi.fn(),
+    });
+    mockSpawn.mockReturnValue(createMockChildProcess(12345));
+  });
+
+  afterEach(() => {
+    db.close();
+    vi.restoreAllMocks();
+  });
+
+  // ─── task-8: start() ──────────────────────────────────────────
+
+  describe('start()', () => {
+    it('returns CodeServerStartResult with url containing port and 127.0.0.1', async () => {
+      mockFindAvailablePort.mockResolvedValue(13375);
+      mockSpawn.mockReturnValue(createMockChildProcess(9999));
+
+      const result = await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      expect(result).toEqual({
+        url: 'http://127.0.0.1:13375',
+        port: 13375,
+        pid: 9999,
+        featureId: FEATURE_ID,
+      });
+    });
+
+    it('persists instance state to SQLite with status "running"', async () => {
+      await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      const row = db
+        .prepare('SELECT * FROM code_server_instances WHERE feature_id = ?')
+        .get(FEATURE_ID) as Record<string, unknown>;
+
+      expect(row).toBeDefined();
+      expect(row.status).toBe('running');
+      expect(row.pid).toBe(12345);
+      expect(row.port).toBe(13370);
+      expect(row.worktree_path).toBe(WORKTREE_PATH);
+    });
+
+    it('spawns code-server with correct flags', async () => {
+      mockFindAvailablePort.mockResolvedValue(13371);
+
+      await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      expect(mockSpawn).toHaveBeenCalledOnce();
+      const [command, args, opts] = mockSpawn.mock.calls[0];
+      expect(command).toBe('code-server');
+      expect(args).toContain('--bind-addr');
+      expect(args).toContain('127.0.0.1:13371');
+      expect(args).toContain('--auth');
+      expect(args).toContain('none');
+      expect(args).toContain('--user-data-dir');
+      expect(args).toContain(`${SHEP_HOME}/code-server/user-data/${FEATURE_ID}`);
+      expect(args).toContain('--extensions-dir');
+      expect(args).toContain(`${SHEP_HOME}/code-server/extensions`);
+      expect(args).toContain('--idle-timeout');
+      expect(args).toContain(WORKTREE_PATH);
+      expect(opts.detached).toBe(true);
+    });
+
+    it('calls child.unref() to detach the process', async () => {
+      const mockChild = createMockChildProcess(12345);
+      mockSpawn.mockReturnValue(mockChild);
+
+      await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      expect(mockChild.unref).toHaveBeenCalledOnce();
+    });
+
+    it('is idempotent — returns existing instance URL when already running', async () => {
+      // Insert a running instance with a PID that is "alive" (current process PID)
+      insertRunningInstance(FEATURE_ID, process.pid, 13380);
+
+      const result = await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      expect(result.url).toBe('http://127.0.0.1:13380');
+      expect(result.port).toBe(13380);
+      expect(result.pid).toBe(process.pid);
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('spawns new instance when existing instance has dead PID', async () => {
+      // Insert a running instance with a dead PID
+      insertRunningInstance(FEATURE_ID, 999999999, 13380);
+
+      mockFindAvailablePort.mockResolvedValue(13381);
+      mockSpawn.mockReturnValue(createMockChildProcess(55555));
+
+      const result = await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      expect(result.port).toBe(13381);
+      expect(result.pid).toBe(55555);
+      expect(mockSpawn).toHaveBeenCalledOnce();
+    });
+
+    it('reads idle timeout from settings table', async () => {
+      // Insert settings with custom timeout
+      db.prepare(
+        `
+        INSERT INTO settings (
+          id, created_at, updated_at,
+          model_analyze, model_requirements, model_plan, model_implement,
+          env_default_editor, env_shell_preference,
+          sys_auto_update, sys_log_level,
+          agent_type, agent_auth_method,
+          notif_in_app_enabled, notif_browser_enabled, notif_desktop_enabled,
+          notif_evt_agent_started, notif_evt_phase_completed, notif_evt_waiting_approval,
+          notif_evt_agent_completed, notif_evt_agent_failed,
+          workflow_open_pr_on_impl_complete, onboarding_complete,
+          approval_gate_allow_prd, approval_gate_allow_plan,
+          approval_gate_allow_merge, approval_gate_push_on_impl_complete,
+          cs_idle_timeout_seconds
+        ) VALUES (
+          'settings-1', '2026-01-01', '2026-01-01',
+          'model1', 'model2', 'model3', 'model4',
+          'vscode', 'bash',
+          0, 'info',
+          'claude-code', 'api_key',
+          1, 0, 0,
+          1, 1, 1,
+          1, 1,
+          0, 1,
+          1, 1, 1, 1,
+          900
+        )
+      `
+      ).run();
+
+      await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      const args = mockSpawn.mock.calls[0][1] as string[];
+      const idleIdx = args.indexOf('--idle-timeout');
+      expect(args[idleIdx + 1]).toBe('900');
+    });
+
+    it('uses default idle timeout (1800) when settings are not initialized', async () => {
+      await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      const args = mockSpawn.mock.calls[0][1] as string[];
+      const idleIdx = args.indexOf('--idle-timeout');
+      expect(args[idleIdx + 1]).toBe('1800');
+    });
+
+    it('throws when spawn returns no PID', async () => {
+      mockSpawn.mockReturnValue({ pid: undefined, unref: vi.fn() });
+
+      await expect(service.start(FEATURE_ID, WORKTREE_PATH)).rejects.toThrow(
+        'Failed to spawn code-server process: no PID returned'
+      );
+    });
+
+    it('creates required directories before spawning', async () => {
+      await service.start(FEATURE_ID, WORKTREE_PATH);
+
+      expect(mockMkdir).toHaveBeenCalledWith(`${SHEP_HOME}/code-server/user-data/${FEATURE_ID}`, {
+        recursive: true,
+      });
+      expect(mockMkdir).toHaveBeenCalledWith(`${SHEP_HOME}/code-server/extensions`, {
+        recursive: true,
+      });
+      expect(mockMkdir).toHaveBeenCalledWith(`${SHEP_HOME}/logs`, { recursive: true });
+    });
+  });
+
+  // ─── task-9: stop() ──────────────────────────────────────────
+
+  describe('stop()', () => {
+    it('sends SIGTERM to a running instance and updates status to stopped', async () => {
+      // Use current process PID so isAlive returns true initially
+      insertRunningInstance(FEATURE_ID, process.pid, 13370);
+
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, signal) => {
+        if (signal === 0) {
+          // First call: alive. After SIGTERM: still alive briefly. Then dead.
+          throw new Error('ESRCH');
+        }
+        return true;
+      });
+
+      await service.stop(FEATURE_ID);
+
+      // Verify status was updated to stopped
+      const row = db
+        .prepare('SELECT status, stopped_at FROM code_server_instances WHERE feature_id = ?')
+        .get(FEATURE_ID) as { status: string; stopped_at: string | null };
+
+      expect(row.status).toBe('stopped');
+      expect(row.stopped_at).not.toBeNull();
+
+      killSpy.mockRestore();
+    });
+
+    it('is a no-op for non-existent featureId', async () => {
+      // Should not throw
+      await expect(service.stop('non-existent')).resolves.not.toThrow();
+    });
+
+    it('is a no-op for already-stopped instance', async () => {
+      insertStoppedInstance(FEATURE_ID, 12345, 13370);
+
+      await expect(service.stop(FEATURE_ID)).resolves.not.toThrow();
+    });
+
+    it('handles case where PID is already dead', async () => {
+      // Insert with a dead PID
+      insertRunningInstance(FEATURE_ID, 999999999, 13370);
+
+      await service.stop(FEATURE_ID);
+
+      const row = db
+        .prepare('SELECT status FROM code_server_instances WHERE feature_id = ?')
+        .get(FEATURE_ID) as { status: string };
+
+      expect(row.status).toBe('stopped');
+    });
+  });
+
+  // ─── task-10: getStatus(), listRunning(), stopAll() ──────────
+
+  describe('getStatus()', () => {
+    it('returns instance with status "running" when PID is alive', async () => {
+      insertRunningInstance(FEATURE_ID, process.pid, 13370);
+
+      const result = await service.getStatus(FEATURE_ID);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(CodeServerInstanceStatus.Running);
+      expect(result!.featureId).toBe(FEATURE_ID);
+      expect(result!.port).toBe(13370);
+    });
+
+    it('auto-reconciles: returns stopped status when PID is dead', async () => {
+      insertRunningInstance(FEATURE_ID, 999999999, 13370);
+
+      const result = await service.getStatus(FEATURE_ID);
+
+      expect(result).not.toBeNull();
+      expect(result!.status).toBe(CodeServerInstanceStatus.Stopped);
+      expect(result!.stoppedAt).toBeDefined();
+    });
+
+    it('updates SQLite when auto-reconciling dead PID', async () => {
+      insertRunningInstance(FEATURE_ID, 999999999, 13370);
+
+      await service.getStatus(FEATURE_ID);
+
+      const row = db
+        .prepare('SELECT status FROM code_server_instances WHERE feature_id = ?')
+        .get(FEATURE_ID) as { status: string };
+
+      expect(row.status).toBe('stopped');
+    });
+
+    it('returns null for non-existent featureId', async () => {
+      const result = await service.getStatus('non-existent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('listRunning()', () => {
+    it('returns only running instances (not stopped)', async () => {
+      insertRunningInstance('feature-1', process.pid, 13370);
+      insertRunningInstance('feature-2', process.pid, 13371);
+      insertStoppedInstance('feature-3', 12345, 13372);
+
+      const running = await service.listRunning();
+
+      expect(running).toHaveLength(2);
+      expect(running.map((r) => r.featureId).sort()).toEqual(['feature-1', 'feature-2']);
+    });
+
+    it('returns empty array when no instances exist', async () => {
+      const running = await service.listRunning();
+      expect(running).toEqual([]);
+    });
+  });
+
+  describe('stopAll()', () => {
+    it('stops all running instances', async () => {
+      // Insert instances with dead PIDs for easy stopping
+      insertRunningInstance('feature-1', 999999991, 13370);
+      insertRunningInstance('feature-2', 999999992, 13371);
+
+      await service.stopAll();
+
+      const rows = db
+        .prepare('SELECT status FROM code_server_instances WHERE status = ?')
+        .all(CodeServerInstanceStatus.Running);
+
+      expect(rows).toHaveLength(0);
+    });
+
+    it('handles partial failures gracefully', async () => {
+      insertRunningInstance('feature-1', 999999991, 13370);
+      insertRunningInstance('feature-2', 999999992, 13371);
+
+      // Mock console.error to verify it's called on failures
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      // Even if one stop fails somehow, the others should still be attempted
+      await expect(service.stopAll()).resolves.not.toThrow();
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ─── task-11: reconcile() ────────────────────────────────────
+
+  describe('reconcile()', () => {
+    it('marks instances with dead PIDs as stopped', async () => {
+      insertRunningInstance('feature-1', process.pid, 13370); // alive
+      insertRunningInstance('feature-2', 999999991, 13371); // dead
+      insertRunningInstance('feature-3', 999999992, 13372); // dead
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await service.reconcile();
+
+      // feature-1 should remain running (current process is alive)
+      const f1 = db
+        .prepare('SELECT status FROM code_server_instances WHERE feature_id = ?')
+        .get('feature-1') as { status: string };
+      expect(f1.status).toBe('running');
+
+      // feature-2 and feature-3 should be stopped
+      const f2 = db
+        .prepare('SELECT status FROM code_server_instances WHERE feature_id = ?')
+        .get('feature-2') as { status: string };
+      expect(f2.status).toBe('stopped');
+
+      const f3 = db
+        .prepare('SELECT status FROM code_server_instances WHERE feature_id = ?')
+        .get('feature-3') as { status: string };
+      expect(f3.status).toBe('stopped');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('makes no changes when all instances are alive', async () => {
+      insertRunningInstance('feature-1', process.pid, 13370);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await service.reconcile();
+
+      const row = db
+        .prepare('SELECT status FROM code_server_instances WHERE feature_id = ?')
+        .get('feature-1') as { status: string };
+      expect(row.status).toBe('running');
+
+      // Should log that 0 were marked stopped
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('marked 0 as stopped'));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('marks all instances as stopped when all PIDs are dead', async () => {
+      insertRunningInstance('feature-1', 999999991, 13370);
+      insertRunningInstance('feature-2', 999999992, 13371);
+      insertRunningInstance('feature-3', 999999993, 13372);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await service.reconcile();
+
+      const rows = db
+        .prepare('SELECT status FROM code_server_instances WHERE status = ?')
+        .all(CodeServerInstanceStatus.Running);
+      expect(rows).toHaveLength(0);
+
+      // Should log that 3 were marked stopped
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('marked 3 as stopped'));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('does nothing when no instances exist', async () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      await service.reconcile();
+
+      // Should not log anything (no instances to reconcile)
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/tool-installer/tool-metadata.test.ts
+++ b/tests/unit/infrastructure/services/tool-installer/tool-metadata.test.ts
@@ -22,6 +22,35 @@ describe('ToolMetadata', () => {
     });
   });
 
+  describe('code-server tool metadata', () => {
+    it('loads code-server tool with correct binary and tags', () => {
+      const meta = TOOL_METADATA['code-server'];
+      expect(meta).toBeDefined();
+      expect(meta.binary).toBe('code-server');
+      expect(meta.tags).toContain('ide');
+    });
+
+    it('has openDirectory with {dir} placeholder and localhost binding', () => {
+      const meta = TOOL_METADATA['code-server'];
+      expect(meta).toBeDefined();
+      expect(typeof meta.openDirectory).toBe('string');
+      expect(meta.openDirectory).toContain('{dir}');
+      expect(meta.openDirectory).toContain('127.0.0.1');
+      expect(meta.openDirectory).toContain('--auth none');
+    });
+
+    it('has platform-specific install commands', () => {
+      const meta = TOOL_METADATA['code-server'];
+      expect(meta.commands).toHaveProperty('linux');
+      expect(meta.commands).toHaveProperty('darwin');
+    });
+
+    it('has correct verifyCommand', () => {
+      const meta = TOOL_METADATA['code-server'];
+      expect(meta.verifyCommand).toBe('code-server --version');
+    });
+  });
+
   describe('openDirectory {dir} placeholder', () => {
     it.each(['vscode', 'cursor', 'windsurf', 'zed'])(
       '%s has {dir} in openDirectory string',

--- a/tsp/domain/entities/settings.tsp
+++ b/tsp/domain/entities/settings.tsp
@@ -267,6 +267,29 @@ model WorkflowConfig {
   ciLogMaxChars?: int32;
 }
 
+/**
+ * Code Server Configuration
+ *
+ * Configuration for managed code-server (VS Code in the browser) instances.
+ * Controls idle timeout behavior for automatic resource cleanup.
+ *
+ * ## Idle Timeout
+ *
+ * code-server supports native --idle-timeout-seconds for automatic shutdown
+ * after a period of inactivity. The default of 1800 seconds (30 minutes)
+ * balances convenience with resource conservation (each instance uses
+ * 300-500MB RAM).
+ */
+@doc("code-server instance configuration")
+model CodeServerConfig {
+  /**
+   * Idle timeout in seconds before a code-server instance auto-shuts down.
+   * Set to 0 to disable idle timeout. Default: 1800 (30 minutes).
+   */
+  @doc("Idle timeout in seconds for code-server instances (default: 1800)")
+  idleTimeoutSeconds: int32 = 1800;
+}
+
 @doc("AI coding agent configuration")
 model AgentConfig {
   /**
@@ -497,6 +520,13 @@ model Settings extends BaseEntity {
    */
   @doc("Global workflow configuration defaults")
   workflow: WorkflowConfig;
+
+  /**
+   * Code-server (VS Code in the browser) configuration.
+   * Controls idle timeout and other code-server instance settings.
+   */
+  @doc("code-server instance configuration")
+  codeServer: CodeServerConfig;
 
   /**
    * Whether the first-run onboarding wizard has been completed.

--- a/tsp/domain/value-objects/code-server-instance.tsp
+++ b/tsp/domain/value-objects/code-server-instance.tsp
@@ -1,0 +1,136 @@
+/**
+ * @module Shep.Domain.ValueObjects.CodeServerInstance
+ *
+ * Defines the CodeServerInstance value object and CodeServerInstanceStatus enum
+ * for tracking managed code-server (VS Code in the browser) process state.
+ *
+ * This is a value object (not an entity) - it does NOT extend BaseEntity.
+ * It is managed entirely by the CodeServerManagerService and has no
+ * independent business logic or domain events. Identity comes from the
+ * featureId it is associated with.
+ *
+ * ## Usage
+ *
+ * Import this module to access code-server instance state:
+ *
+ * ```typespec
+ * import "./code-server-instance.tsp";
+ *
+ * model CodeServerManagerState {
+ *   instances: CodeServerInstance[];
+ * }
+ * ```
+ */
+/**
+ * Status of a managed code-server instance.
+ *
+ * Represents the lifecycle state of a code-server process:
+ * - running: Process is alive and serving on its allocated port
+ * - stopped: Process has been terminated (gracefully or via idle timeout)
+ */
+@doc("Status of a code-server instance")
+enum CodeServerInstanceStatus {
+  @doc("Process is alive and serving")
+  Running: "running",
+
+  @doc("Process has been terminated")
+  Stopped: "stopped",
+}
+
+/**
+ * Represents the state of a managed code-server instance.
+ *
+ * CodeServerInstance is a value object that captures the process state of a
+ * code-server instance bound to a specific feature worktree. It tracks the
+ * PID, port, worktree path, and lifecycle timestamps needed for process
+ * management, reconciliation, and UI status display.
+ *
+ * Note: This is a value object, NOT an entity. It does not extend
+ * BaseEntity and has no independent lifecycle outside the
+ * CodeServerManagerService.
+ *
+ * ## Properties
+ *
+ * | Property     | Type                       | Required | Description                                |
+ * |--------------|----------------------------|----------|--------------------------------------------|
+ * | id           | string                     | Yes      | Unique identifier for this instance record |
+ * | featureId    | string                     | Yes      | Feature ID this instance is scoped to      |
+ * | pid          | int32                      | Yes      | OS process ID of the code-server process   |
+ * | port         | int32                      | Yes      | Port code-server is bound to on localhost  |
+ * | worktreePath | string                     | Yes      | Absolute path to the feature worktree      |
+ * | status       | CodeServerInstanceStatus   | Yes      | Current lifecycle status                   |
+ * | startedAt    | utcDateTime                | Yes      | When the instance was started              |
+ * | stoppedAt    | utcDateTime                | No       | When the instance was stopped (if stopped) |
+ *
+ * @example
+ * ```json
+ * {
+ *   "id": "550e8400-e29b-41d4-a716-446655440000",
+ *   "featureId": "feat-123",
+ *   "pid": 12345,
+ *   "port": 13370,
+ *   "worktreePath": "/home/user/.shep/repos/abc123/wt/my-feature",
+ *   "status": "running",
+ *   "startedAt": "2026-02-25T10:00:00Z"
+ * }
+ * ```
+ */
+@doc("State of a managed code-server instance")
+model CodeServerInstance {
+  /**
+   * Unique identifier for this instance record
+   * @example "550e8400-e29b-41d4-a716-446655440000"
+   */
+  @doc("Unique identifier for this instance record")
+  id: string;
+
+  /**
+   * Feature ID this code-server instance is scoped to.
+   * One instance per feature (enforced by UNIQUE constraint).
+   * @example "feat-123"
+   */
+  @doc("Feature ID this instance is scoped to")
+  featureId: string;
+
+  /**
+   * OS process ID of the running code-server process
+   * @example 12345
+   */
+  @doc("OS process ID of the code-server process")
+  pid: int32;
+
+  /**
+   * Port number code-server is bound to on 127.0.0.1
+   * @example 13370
+   */
+  @doc("Port code-server is bound to on localhost")
+  port: int32;
+
+  /**
+   * Absolute path to the feature worktree directory
+   * @example "/home/user/.shep/repos/abc123/wt/my-feature"
+   */
+  @doc("Absolute path to the feature worktree")
+  worktreePath: string;
+
+  /**
+   * Current lifecycle status of the code-server instance
+   * @example "running"
+   */
+  @doc("Current lifecycle status")
+  status: CodeServerInstanceStatus;
+
+  /**
+   * Timestamp when the instance was started
+   * @example "2026-02-25T10:00:00Z"
+   */
+  @doc("When the instance was started")
+  startedAt: utcDateTime;
+
+  /**
+   * Timestamp when the instance was stopped (null if still running)
+   * @example "2026-02-25T10:30:00Z"
+   */
+  @doc("When the instance was stopped (if stopped)")
+  stoppedAt?: utcDateTime;
+}

--- a/tsp/domain/value-objects/index.tsp
+++ b/tsp/domain/value-objects/index.tsp
@@ -43,3 +43,4 @@ import "./tool-install-command.tsp";
 import "./ci-fix-record.tsp";
 import "./pull-request.tsp";
 import "./feature-status-metadata.tsp";
+import "./code-server-instance.tsp";


### PR DESCRIPTION
## Summary

Integrates [code-server](https://github.com/coder/code-server) (VS Code in the browser) as a managed tool within Shep, enabling users to launch per-feature browser-based code editing sessions directly from the feature drawer.

- **Code-server manager service** — Full process lifecycle management: detached spawning with dynamic port allocation (13370+), localhost-only binding (`--auth none`), shared extensions / per-feature user-data isolation, configurable idle timeout (default 30 min), graceful SIGTERM→SIGKILL shutdown, PID liveness checks, and startup reconciliation of stale state
- **TypeSpec domain models** — `CodeServerInstance` value object, `CodeServerInstanceStatus` enum, `CodeServerConfig` settings model with `idleTimeoutSeconds`
- **SQLite persistence** — Migration v23 creates `code_server_instances` table with feature_id UNIQUE constraint and indexes; migration v24 adds `cs_idle_timeout_seconds` settings column
- **Clean Architecture layers** — `ICodeServerManagerService` output port, `StartCodeServer`/`StopCodeServer`/`GetCodeServerStatus` use cases, DI registration with string tokens
- **API routes** — `POST /api/code-server/start`, `POST /api/code-server/stop`, `GET /api/code-server/status` with input validation and structured error responses
- **Web UI** — "Browser Editor" action in the feature drawer open-action-menu with start/stop toggle, green running-status dot, loading spinners, and error indicators; opens code-server in a new browser tab
- **Tool metadata** — `code-server.json` for install detection and availability checks via existing tool installer system
- **Storybook stories** — All browser editor states: running, loading, stopped, error, unknown, and combined states
- **Comprehensive tests** — Unit tests for all 3 use cases and the manager service (mocked process spawning, PID liveness, SQLite state), integration tests for all 3 API routes and both SQLite migrations

Spec: `specs/045-code-server-integration/`

## Test plan

- [ ] Verify `pnpm test:unit` passes for new use case and service tests
- [ ] Verify `pnpm test:int` passes for new migration and API route tests
- [ ] Verify `pnpm validate` passes (lint, format, typecheck, tsp compile)
- [ ] Verify code-server appears in tools page when installed
- [ ] Verify "Browser Editor" button appears in feature drawer open menu
- [ ] Verify clicking "Browser Editor" starts code-server and opens new tab
- [ ] Verify green dot status indicator shows when instance is running
- [ ] Verify "Stop Browser Editor" terminates the code-server process
- [ ] Verify Storybook stories render all browser editor states correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)