### PR TITLE
fix(web): stop drawer-open sound firing on every re-render

### DIFF
--- a/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
+++ b/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
@@ -103,11 +103,12 @@ export function FeatureCreateDrawer({
   const [parentId, setParentId] = useState<string | undefined>(undefined);
 
   // Play drawer-open sound when the drawer opens
+  const playDrawerOpen = drawerOpenSound.play;
   useEffect(() => {
     if (open) {
-      drawerOpenSound.play();
+      playDrawerOpen();
     }
-  }, [open, drawerOpenSound]);
+  }, [open, playDrawerOpen]);
 
   // Sync state when workflowDefaults load asynchronously
   useEffect(() => {

--- a/src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
+++ b/src/presentation/web/components/common/feature-drawer/feature-drawer.tsx
@@ -45,9 +45,10 @@ export function FeatureDrawer({
   const drawerCloseSound = useSoundAction('drawer-close');
 
   const isOpen = selectedNode !== null;
+  const playDrawerOpen = drawerOpenSound.play;
   useEffect(() => {
-    if (isOpen) drawerOpenSound.play();
-  }, [isOpen, drawerOpenSound]);
+    if (isOpen) playDrawerOpen();
+  }, [isOpen, playDrawerOpen]);
 
   const handleClose = useCallback(() => {
     drawerCloseSound.play();


### PR DESCRIPTION
## Summary

- `useSoundAction` returns a new object on every render; including it in `useEffect` deps caused the effect to re-run on every state change (e.g. each keystroke in the description field), playing the drawer-open sound repeatedly
- Fix: extract the stable `play` callback into the dependency array instead of the whole sound object
- Affected components: `FeatureCreateDrawer` and `FeatureDrawer`

## Test plan

- [ ] Open the New Feature drawer and type in the Description field — no sound should play while typing
- [ ] Close and reopen the drawer — the open sound should play exactly once
- [ ] Same check for the Feature drawer (click a feature node)

🤖 Generated with [Claude Code](https://claude.com/claude-code)