### PR TITLE
fix(web): prevent setstate-in-render in use-sound-enabled

### DIFF
--- a/src/presentation/web/hooks/use-sound-enabled.ts
+++ b/src/presentation/web/hooks/use-sound-enabled.ts
@@ -26,13 +26,11 @@ export function useSoundEnabled(): UseSoundEnabledResult {
   }, []);
 
   const toggle = useCallback(() => {
-    setEnabled((prev) => {
-      const next = !prev;
-      localStorage.setItem(STORAGE_KEY, String(next));
-      window.dispatchEvent(new CustomEvent(SYNC_EVENT, { detail: next }));
-      return next;
-    });
-  }, []);
+    const next = !enabled;
+    localStorage.setItem(STORAGE_KEY, String(next));
+    setEnabled(next);
+    window.dispatchEvent(new CustomEvent(SYNC_EVENT, { detail: next }));
+  }, [enabled]);
 
   return { enabled, toggle };
 }


### PR DESCRIPTION
## Summary

- Dispatching `CustomEvent` inside `setEnabled`'s updater function caused React to warn _"Cannot update a component (`SidebarCollapseToggle`) while rendering a different component (`SoundToggle`)"_
- The synchronous event dispatch triggered `setState` on all other `useSoundEnabled` consumers during an active React state transition
- Fix moves `localStorage.setItem` and `dispatchEvent` into the callback body and adds `enabled` to `useCallback` deps to avoid stale closure

## Test plan

- [ ] Toggle sound on/off via the `SoundToggle` button — no React warning in console
- [ ] Verify sidebar collapse toggle still plays correct sound after toggling sounds on/off
- [ ] Verify sound state persists across page reloads (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)