### PR TITLE
fix(agents): persist pr data to db before merge approval gate

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
@@ -165,6 +165,24 @@ export function createMergeNode(deps: MergeNodeDeps) {
           ciFixStatus = ciResult.ciFixStatus;
         }
 
+        // --- Persist PR data before approval gate so feat show displays it ---
+        if (feature && prUrl && prNumber) {
+          await deps.featureRepository.update({
+            ...feature,
+            pr: {
+              url: prUrl,
+              number: prNumber,
+              status: PrStatus.Open,
+              ...(commitHash ? { commitHash } : {}),
+              ...(ciStatus ? { ciStatus: ciStatus as CiStatus } : {}),
+              ...(ciFixAttempts > 0 ? { ciFixAttempts } : {}),
+              ...(ciFixHistory.length > 0 ? { ciFixHistory } : {}),
+            },
+            updatedAt: new Date(),
+          });
+          log.info(`Persisted PR data (${prUrl}) to feature record`);
+        }
+
         // --- Merge approval gate ---
         if (shouldInterrupt('merge', state.approvalGates)) {
           log.info('Interrupting for merge approval');


### PR DESCRIPTION
## Summary
- PR URL and metadata were only saved to the feature DB record **after** the merge approval gate completed
- This meant `shep feat show` couldn't display the PR URL while a feature was awaiting merge approval
- Now persists PR data (url, number, status, CI info) to the DB immediately after CI watch completes, before the approval interrupt

## Test plan
- [x] All 54 merge node tests pass (26 merge + 28 CI watch)
- [x] Full unit test suite passes (2839 tests)
- [x] Build succeeds
- [ ] Manual: run `shep feat new` with approval gates, verify `shep feat show` displays PR URL while awaiting approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)