### PR TITLE
fix(web): prevent drawer close when clicked element is unmounted

### DIFF
--- a/src/presentation/web/components/common/base-drawer/base-drawer.tsx
+++ b/src/presentation/web/components/common/base-drawer/base-drawer.tsx
@@ -63,6 +63,10 @@ export function BaseDrawer({
 
     const handleClick = (e: MouseEvent) => {
       const target = e.target as Element;
+      // If the clicked element was unmounted by React before the event reached
+      // the document (e.g. a "Next" button removed on the last step), it is no
+      // longer in the DOM tree — treat it as an internal click, not an outside one.
+      if (!document.body.contains(target)) return;
       if (contentRef.current?.contains(target)) return;
       // Don't close when clicking inside the canvas or other Radix overlays
       if (


### PR DESCRIPTION
## Summary
- Fixes drawer closing unexpectedly when navigating to the last questionnaire step via the "Next" button
- Root cause: the "Next" button is conditionally unmounted (`{!isLastStep ? ... : null}`) by React before the document-level `click` handler fires, so `contains(target)` returns `false` and the handler treats it as an outside click
- Fix: skip the close logic when `document.body.contains(target)` is `false` (element was unmounted, not a real outside click)

## Test plan
- [ ] Open a feature with a PRD questionnaire
- [ ] Click "Next" through all steps — verify drawer stays open on the last step
- [ ] Click outside the drawer — verify it still closes correctly
- [ ] Click inside the drawer on other buttons — verify no spurious closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)