### PR TITLE
fix(web): derive drawer open state from url pathname

### DIFF
--- a/src/presentation/web/components/common/control-center-drawer/create-drawer-client.tsx
+++ b/src/presentation/web/components/common/control-center-drawer/create-drawer-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { toast } from 'sonner';
 import { createFeature } from '@/app/actions/create-feature';
 import { FeatureCreateDrawer } from '@/components/common/feature-create-drawer';
@@ -26,6 +26,13 @@ export function CreateDrawerClient({
   const router = useRouter();
   const createSound = useSoundAction('create');
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Derive open state from the URL. Next.js parallel routes preserve slot
+  // content during soft navigation, so this component is NOT unmounted when
+  // navigating to `/`. We watch the pathname and let Vaul handle the close
+  // animation when the path no longer matches the create route.
+  const pathname = usePathname();
+  const isOpen = pathname.startsWith('/create');
 
   const onClose = useCallback(() => {
     router.push('/');
@@ -74,7 +81,7 @@ export function CreateDrawerClient({
 
   return (
     <FeatureCreateDrawer
-      open
+      open={isOpen}
       onClose={onClose}
       onSubmit={onSubmit}
       repositoryPath={repositoryPath}

--- a/src/presentation/web/components/common/control-center-drawer/repository-drawer-client.tsx
+++ b/src/presentation/web/components/common/control-center-drawer/repository-drawer-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { Code2, Terminal, FolderOpen } from 'lucide-react';
 import { BaseDrawer } from '@/components/common/base-drawer';
 import { ActionButton } from '@/components/common/action-button';
@@ -17,6 +17,8 @@ export interface RepositoryDrawerClientProps {
 
 export function RepositoryDrawerClient({ data }: RepositoryDrawerClientProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const isOpen = pathname.startsWith('/repository/');
   const repoActions = useRepositoryActions(
     data.repositoryPath ? { repositoryPath: data.repositoryPath } : null
   );
@@ -46,7 +48,7 @@ export function RepositoryDrawerClient({ data }: RepositoryDrawerClientProps) {
 
   return (
     <BaseDrawer
-      open
+      open={isOpen}
       onClose={onClose}
       size="md"
       modal={false}


### PR DESCRIPTION
## Summary

- **Create drawer** and **repository drawer** were not closeable because they hardcoded `open={true}` — after `router.push('/')` the component stayed mounted (Next.js parallel routes preserve slot content) and never received `open={false}`
- Derive `isOpen` from `usePathname()` matching the route prefix (`/create`, `/repository/`), consistent with the existing `feature-drawer-client` pattern

Closes #188

## Test plan

- [ ] Open the "New Feature" create drawer → click outside or press X → drawer should close
- [ ] Open a repository drawer → click outside or press X → drawer should close
- [ ] Verify feature drawer still closes correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)