### PR TITLE
fix(agents): fix verify merge failing after squash merge

### DIFF
--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -333,13 +333,54 @@ export class GitPrService implements IGitPrService {
   }
 
   async verifyMerge(cwd: string, featureBranch: string, baseBranch: string): Promise<boolean> {
+    // Resolve the feature branch ref — the local branch may have been deleted
+    // after a squash merge (git branch -d succeeds when pushed to remote).
+    // Fall back to the remote tracking branch if the local ref is gone.
+    const resolvedRef = await this.resolveRef(cwd, featureBranch);
+    if (!resolvedRef) return false;
+
+    // First try: true merge (feature branch is ancestor of base)
     try {
-      await this.execFile('git', ['merge-base', '--is-ancestor', featureBranch, baseBranch], {
+      await this.execFile('git', ['merge-base', '--is-ancestor', resolvedRef, baseBranch], {
         cwd,
       });
       return true;
     } catch {
+      // Not a true merge — check for squash merge by comparing tree content.
+      // After a squash merge, all changes from the feature branch are on the base
+      // branch, so `git diff featureBranch baseBranch` should produce no output.
+    }
+
+    try {
+      await this.execFile('git', ['diff', '--quiet', resolvedRef, baseBranch], { cwd });
+      // --quiet exits 0 when there's no diff → squash merge verified
+      return true;
+    } catch {
+      // Exit code 1 = diff exists (not merged), other errors also mean unverified
       return false;
+    }
+  }
+
+  /**
+   * Resolve a branch name to a valid git ref, falling back to the remote
+   * tracking branch if the local ref has been deleted.
+   */
+  private async resolveRef(cwd: string, branch: string): Promise<string | null> {
+    // Try local ref first
+    try {
+      await this.execFile('git', ['rev-parse', '--verify', branch], { cwd });
+      return branch;
+    } catch {
+      // Local ref doesn't exist
+    }
+
+    // Try remote tracking branch
+    const remoteRef = `origin/${branch}`;
+    try {
+      await this.execFile('git', ['rev-parse', '--verify', remoteRef], { cwd });
+      return remoteRef;
+    } catch {
+      return null;
     }
   }
 

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/fixtures.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/fixtures.ts
@@ -1,5 +1,12 @@
 import { vi } from 'vitest';
-import type { IAgentExecutor } from '@/application/ports/output/agents/agent-executor.interface.js';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import type {
+  IAgentExecutor,
+  AgentExecutionOptions,
+} from '@/application/ports/output/agents/agent-executor.interface.js';
+
+const execFileAsync = promisify(execFileCb);
 
 /** Fake PR URL used by all PR-path tests. Intercepted by makeSelectiveExec. */
 export const FAKE_PR_URL = 'https://github.com/test/repo/pull/42';
@@ -14,6 +21,66 @@ export function makeMockExecutor(output: string): IAgentExecutor {
   return {
     agentType: 'claude-code' as never,
     execute: vi.fn().mockResolvedValue({ result: output }),
+    executeStream: vi.fn() as IAgentExecutor['executeStream'],
+    supportsFeature: vi.fn().mockReturnValue(false),
+  } as IAgentExecutor;
+}
+
+/**
+ * Creates an IAgentExecutor that runs real git commands based on the prompt.
+ *
+ * Detects the agent call type by matching prompt keywords and executes
+ * the corresponding git operations:
+ * - Call 1 (commit/push/PR): stages + commits on the feature branch
+ * - Call 2 (merge/squash): squash-merges the feature branch into base
+ *
+ * Used by local-merge and push-merge integration tests to verify real
+ * git state after the merge node completes.
+ */
+export function makeGitExecutor(featureBranch: string): IAgentExecutor {
+  const git = (args: string[], cwd: string) =>
+    execFileAsync('git', args, { cwd }) as Promise<{ stdout: string; stderr: string }>;
+
+  return {
+    agentType: 'claude-code' as never,
+    execute: vi.fn().mockImplementation(async (prompt: string, options?: AgentExecutionOptions) => {
+      const cwd = options?.cwd ?? '';
+
+      if (prompt.includes('git operations in a feature worktree')) {
+        // Call 1: commit on the feature branch (may already be committed)
+        const { stdout: status } = await git(['status', '--porcelain'], cwd);
+        if (status.trim()) {
+          await git(['add', '-A'], cwd);
+          await git(['commit', '-m', 'feat: test implementation'], cwd);
+        }
+        return { result: '[feat/test abc1234] feat: test implementation' };
+      }
+
+      if (prompt.includes('local merge in the original repository')) {
+        // Call 2: squash merge into base branch
+        // Fetch from remote if available (ignore errors for local-only repos)
+        try {
+          await git(['fetch', 'origin'], cwd);
+        } catch {
+          // No remote — expected for local-only repos
+        }
+        await git(['checkout', 'main'], cwd);
+        try {
+          await git(['pull', 'origin', 'main'], cwd);
+        } catch {
+          // No remote — expected for local-only repos
+        }
+        await git(['merge', '--squash', featureBranch], cwd);
+        await git(['commit', '-m', 'feat: squash merge feature'], cwd);
+        // Do NOT delete the feature branch — verifyMerge needs it to exist
+        // for diff comparison. The real agent prompt says to delete, but
+        // git branch -d after squash merge may succeed when the branch has
+        // been pushed to a remote, removing the ref before verification.
+        return { result: '[main def5678] feat: squash merge feature' };
+      }
+
+      return { result: 'unknown prompt' };
+    }),
     executeStream: vi.fn() as IAgentExecutor['executeStream'],
     supportsFeature: vi.fn().mockReturnValue(false),
   } as IAgentExecutor;

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/helpers.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/helpers.ts
@@ -2,6 +2,7 @@ import { expect } from 'vitest';
 
 /**
  * Asserts that featureBranch has been merged into baseBranch using real git.
+ * Supports both true merges (--is-ancestor) and squash merges (no diff).
  * Fails the test with a descriptive message if the merge did not land.
  */
 export async function assertMergeLanded(
@@ -9,16 +10,26 @@ export async function assertMergeLanded(
   featureBranch: string,
   baseBranch: string
 ): Promise<void> {
-  let landed = false;
+  // Check true merge first
   try {
     await runGit(['merge-base', '--is-ancestor', featureBranch, baseBranch]);
-    landed = true;
+    return; // true merge confirmed
   } catch {
-    landed = false;
+    // Not a true merge — check squash merge
   }
+
+  // Check squash merge: no diff means all changes are incorporated
+  let squashMerged = false;
+  try {
+    await runGit(['diff', '--quiet', featureBranch, baseBranch]);
+    squashMerged = true;
+  } catch {
+    squashMerged = false;
+  }
+
   expect(
-    landed,
-    `Expected ${featureBranch} to be an ancestor of ${baseBranch} after merge, but it was not`
+    squashMerged,
+    `Expected ${featureBranch} to be merged into ${baseBranch} (true merge or squash), but changes are still missing`
   ).toBe(true);
 }
 

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/local-merge.test.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/local-merge.test.ts
@@ -1,9 +1,8 @@
 /**
- * Local merge tests (KNOWN BUGS — all it.fails).
+ * Local merge tests — real git operations via makeGitExecutor.
  *
- * These tests verify that the merge node performs a real local git merge.
- * They currently fail because the mock executor doesn't run real git merge
- * and verifyMerge() throws "Merge verification failed".
+ * These tests verify that the merge node performs a real local git merge
+ * using an executor that runs actual git commands (squash merge).
  *
  * - local-merge-no-push:       push=false, openPr=false, allowMerge=true, remote=yes
  * - no-remote-override-merge:  push=true,  openPr=true,  allowMerge=true, remote=no
@@ -28,7 +27,7 @@ import {
 } from './setup.js';
 import { assertMergeLanded } from './helpers.js';
 
-describe('Merge Step — Local Merge (Known Bugs)', () => {
+describe('Merge Step — Local Merge', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
   let harnessToCleanup: string[] = [];
@@ -50,79 +49,40 @@ describe('Merge Step — Local Merge (Known Bugs)', () => {
     harnessToCleanup = [];
   });
 
-  it.fails(
-    'local-merge-no-push: feature branch should be merged into main after node completes',
-    async () => {
-      const harness = await createGitHarness();
-      harnessToCleanup.push(harness.bareDir, harness.cloneDir);
+  it('local-merge-no-push: feature branch should be merged into main after node completes', async () => {
+    const harness = await createGitHarness();
+    harnessToCleanup.push(harness.bareDir, harness.cloneDir);
 
-      const tempDir = mkdtempSync(join(tmpdir(), 'shep-test-spec-'));
-      harnessToCleanup.push(tempDir);
-      const specDir = makeSpecDir(tempDir);
+    const tempDir = mkdtempSync(join(tmpdir(), 'shep-test-spec-'));
+    harnessToCleanup.push(tempDir);
+    const specDir = makeSpecDir(tempDir);
 
-      const { deps, featureRepository } = buildDeps({
-        featureBranch: harness.featureBranch,
-      });
+    const { deps, featureRepository } = buildDeps({
+      featureBranch: harness.featureBranch,
+      useRealGit: true,
+    });
 
-      const state = makeState({
-        repositoryPath: harness.cloneDir,
-        worktreePath: harness.cloneDir,
-        specDir,
-        push: false,
-        openPr: false,
-        approvalGates: { allowPrd: true, allowPlan: true, allowMerge: true },
-      });
+    const state = makeState({
+      repositoryPath: harness.cloneDir,
+      worktreePath: harness.cloneDir,
+      specDir,
+      push: false,
+      openPr: false,
+      approvalGates: { allowPrd: true, allowPlan: true, allowMerge: true },
+    });
 
-      const mergeNode = createMergeNode(deps);
+    const mergeNode = createMergeNode(deps);
 
-      // RED: Mock executor does not run real git merge. verifyMerge() throws.
-      await mergeNode(state);
+    await mergeNode(state);
 
-      await assertMergeLanded(harness.runGit, harness.featureBranch, 'main');
+    await assertMergeLanded(harness.runGit, harness.featureBranch, 'main');
 
-      expect(featureRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ lifecycle: 'Maintain' })
-      );
-    }
-  );
+    expect(featureRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: 'Maintain' })
+    );
+  });
 
-  it.fails(
-    'no-remote-override-merge: should merge locally when remote unavailable (push+openPr overridden)',
-    async () => {
-      const { repoDir, featureBranch, runGit } = await createLocalOnlyHarness();
-      harnessToCleanup.push(repoDir);
-
-      const tempDir = mkdtempSync(join(tmpdir(), 'shep-test-spec-'));
-      harnessToCleanup.push(tempDir);
-      const specDir = makeSpecDir(tempDir);
-
-      const { deps, featureRepository } = buildDeps({
-        featureBranch,
-      });
-
-      const state = makeState({
-        repositoryPath: repoDir,
-        worktreePath: repoDir,
-        specDir,
-        // push+openPr=true, but remote is unavailable → effectiveState overrides both to false
-        push: true,
-        openPr: true,
-        approvalGates: { allowPrd: true, allowPlan: true, allowMerge: true },
-      });
-
-      const mergeNode = createMergeNode(deps);
-
-      // RED: Mock executor does not run real git merge. verifyMerge() throws.
-      await mergeNode(state);
-
-      await assertMergeLanded(runGit, featureBranch, 'main');
-      expect(featureRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ lifecycle: 'Maintain' })
-      );
-    }
-  );
-
-  it.fails('no-remote-local-merge: should merge locally without any remote', async () => {
+  it('no-remote-override-merge: should merge locally when remote unavailable (push+openPr overridden)', async () => {
     const { repoDir, featureBranch, runGit } = await createLocalOnlyHarness();
     harnessToCleanup.push(repoDir);
 
@@ -132,6 +92,40 @@ describe('Merge Step — Local Merge (Known Bugs)', () => {
 
     const { deps, featureRepository } = buildDeps({
       featureBranch,
+      useRealGit: true,
+    });
+
+    const state = makeState({
+      repositoryPath: repoDir,
+      worktreePath: repoDir,
+      specDir,
+      // push+openPr=true, but remote is unavailable → effectiveState overrides both to false
+      push: true,
+      openPr: true,
+      approvalGates: { allowPrd: true, allowPlan: true, allowMerge: true },
+    });
+
+    const mergeNode = createMergeNode(deps);
+
+    await mergeNode(state);
+
+    await assertMergeLanded(runGit, featureBranch, 'main');
+    expect(featureRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: 'Maintain' })
+    );
+  });
+
+  it('no-remote-local-merge: should merge locally without any remote', async () => {
+    const { repoDir, featureBranch, runGit } = await createLocalOnlyHarness();
+    harnessToCleanup.push(repoDir);
+
+    const tempDir = mkdtempSync(join(tmpdir(), 'shep-test-spec-'));
+    harnessToCleanup.push(tempDir);
+    const specDir = makeSpecDir(tempDir);
+
+    const { deps, featureRepository } = buildDeps({
+      featureBranch,
+      useRealGit: true,
     });
 
     const state = makeState({
@@ -145,7 +139,6 @@ describe('Merge Step — Local Merge (Known Bugs)', () => {
 
     const mergeNode = createMergeNode(deps);
 
-    // RED: Mock executor does not run real git merge. verifyMerge() throws.
     await mergeNode(state);
 
     await assertMergeLanded(runGit, featureBranch, 'main');

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/push-merge.test.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/push-merge.test.ts
@@ -1,9 +1,11 @@
 /**
- * Push + merge test (KNOWN BUG — it.fails).
+ * Push + merge test — real git operations via makeGitExecutor.
  *
  * push=true, openPr=false, allowMerge=true, remote=yes
- * Expected: push via agent + local merge into base branch.
- * Bug: mock executor doesn't run real git merge → verifyMerge() throws.
+ * Expected: commit via agent + local squash merge into base branch.
+ *
+ * Uses makeSelectiveExec to intercept `gh` CLI commands (for CI status checks)
+ * while allowing real git operations through.
  */
 
 import 'reflect-metadata';
@@ -25,7 +27,7 @@ import {
 } from './setup.js';
 import { assertMergeLanded } from './helpers.js';
 
-describe('Merge Step — Push Merge (Known Bug)', () => {
+describe('Merge Step — Push Merge', () => {
   let stdoutSpy: ReturnType<typeof vi.spyOn>;
   let stderrSpy: ReturnType<typeof vi.spyOn>;
   let harnessToCleanup: string[] = [];
@@ -47,42 +49,39 @@ describe('Merge Step — Push Merge (Known Bug)', () => {
     harnessToCleanup = [];
   });
 
-  it.fails(
-    'push-no-pr-merge: feature branch should be merged into main after push+merge',
-    async () => {
-      const harness = await createGitHarness();
-      harnessToCleanup.push(harness.bareDir, harness.cloneDir);
+  it('push-no-pr-merge: feature branch should be merged into main after push+merge', async () => {
+    const harness = await createGitHarness();
+    harnessToCleanup.push(harness.bareDir, harness.cloneDir);
 
-      const tempDir = mkdtempSync(join(tmpdir(), 'shep-test-spec-'));
-      harnessToCleanup.push(tempDir);
-      const specDir = makeSpecDir(tempDir);
+    const tempDir = mkdtempSync(join(tmpdir(), 'shep-test-spec-'));
+    harnessToCleanup.push(tempDir);
+    const specDir = makeSpecDir(tempDir);
 
-      const realExec = makeRealExec();
-      const selectiveExec = makeSelectiveExec(realExec);
+    const realExec = makeRealExec();
+    const selectiveExec = makeSelectiveExec(realExec);
 
-      const { deps, featureRepository } = buildDeps({
-        execFn: selectiveExec,
-        featureBranch: harness.featureBranch,
-      });
+    const { deps, featureRepository } = buildDeps({
+      execFn: selectiveExec,
+      featureBranch: harness.featureBranch,
+      useRealGit: true,
+    });
 
-      const state = makeState({
-        repositoryPath: harness.cloneDir,
-        worktreePath: harness.cloneDir,
-        specDir,
-        push: true,
-        openPr: false,
-        approvalGates: { allowPrd: true, allowPlan: true, allowMerge: true },
-      });
+    const state = makeState({
+      repositoryPath: harness.cloneDir,
+      worktreePath: harness.cloneDir,
+      specDir,
+      push: true,
+      openPr: false,
+      approvalGates: { allowPrd: true, allowPlan: true, allowMerge: true },
+    });
 
-      const mergeNode = createMergeNode(deps);
+    const mergeNode = createMergeNode(deps);
 
-      // RED: Mock executor does not run real git merge. verifyMerge() throws.
-      await mergeNode(state);
+    await mergeNode(state);
 
-      await assertMergeLanded(harness.runGit, harness.featureBranch, 'main');
-      expect(featureRepository.update).toHaveBeenCalledWith(
-        expect.objectContaining({ lifecycle: 'Maintain' })
-      );
-    }
-  );
+    await assertMergeLanded(harness.runGit, harness.featureBranch, 'main');
+    expect(featureRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({ lifecycle: 'Maintain' })
+    );
+  });
 });

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/setup.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/setup.ts
@@ -11,7 +11,7 @@ import type { IAgentExecutor } from '@/application/ports/output/agents/agent-exe
 import type { ExecFunction } from '@/infrastructure/services/git/worktree.service.js';
 import type { FeatureAgentState } from '@/infrastructure/services/agents/feature-agent/state.js';
 import type { DiffSummary } from '@/application/ports/output/services/git-pr-service.interface.js';
-import { FAKE_PR_URL, makeMockExecutor } from './fixtures.js';
+import { FAKE_PR_URL, makeMockExecutor, makeGitExecutor } from './fixtures.js';
 
 const execFileRaw = promisify(execFileCb);
 
@@ -204,6 +204,8 @@ export interface BuildDepsOptions {
   execFn?: ExecFunction;
   executorOutput?: string;
   featureBranch?: string;
+  /** When true, uses makeGitExecutor that runs real git commands instead of the mock. */
+  useRealGit?: boolean;
 }
 
 export interface BuiltDeps {
@@ -214,7 +216,7 @@ export interface BuiltDeps {
 
 /**
  * Builds MergeNodeDeps with a real GitPrService (using the provided ExecFunction)
- * and a mock IAgentExecutor. The featureRepository is fully mocked.
+ * and a mock or real-git IAgentExecutor. The featureRepository is fully mocked.
  */
 export function buildDeps(opts: BuildDepsOptions = {}): BuiltDeps {
   const execFn = opts.execFn ?? makeRealExec();
@@ -229,9 +231,9 @@ export function buildDeps(opts: BuildDepsOptions = {}): BuiltDeps {
     update: vi.fn().mockResolvedValue(undefined),
   } as unknown as MergeNodeDeps['featureRepository'];
 
-  const executorOutput =
-    opts.executorOutput ?? '[feat/test abc1234] feat: implement feature\nDone.';
-  const executor = makeMockExecutor(executorOutput);
+  const executor = opts.useRealGit
+    ? makeGitExecutor(opts.featureBranch ?? 'feat/test-branch')
+    : makeMockExecutor(opts.executorOutput ?? '[feat/test abc1234] feat: implement feature\nDone.');
 
   const deps: MergeNodeDeps = {
     executor,

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/verify-merge.test.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/verify-merge.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Integration tests for GitPrService.verifyMerge() with real git repos.
+ *
+ * Validates that verifyMerge correctly detects:
+ * - True merges (feature branch is ancestor of base)
+ * - Squash merges (no ancestry link, but all changes incorporated)
+ * - Unmerged branches (neither ancestor nor squash-equivalent)
+ */
+
+import 'reflect-metadata';
+import { describe, it, expect, afterEach } from 'vitest';
+import { GitPrService } from '@/infrastructure/services/git/git-pr.service.js';
+import { createGitHarness, createLocalOnlyHarness, destroyHarness, makeRealExec } from './setup.js';
+
+describe('GitPrService.verifyMerge — real git', () => {
+  let harnessToCleanup: string[] = [];
+  const realExec = makeRealExec();
+  const service = new GitPrService(realExec);
+
+  afterEach(() => {
+    destroyHarness(harnessToCleanup);
+    harnessToCleanup = [];
+  });
+
+  it('should return true after a true merge (git merge)', async () => {
+    const { repoDir, featureBranch, runGit } = await createLocalOnlyHarness();
+    harnessToCleanup.push(repoDir);
+
+    await runGit(['merge', featureBranch]);
+
+    const result = await service.verifyMerge(repoDir, featureBranch, 'main');
+    expect(result).toBe(true);
+  });
+
+  it('should return true after a squash merge (git merge --squash)', async () => {
+    const { repoDir, featureBranch, runGit } = await createLocalOnlyHarness();
+    harnessToCleanup.push(repoDir);
+
+    await runGit(['merge', '--squash', featureBranch]);
+    await runGit(['commit', '-m', 'squash merge feature']);
+
+    const result = await service.verifyMerge(repoDir, featureBranch, 'main');
+    expect(result).toBe(true);
+  });
+
+  it('should return false when branch has not been merged', async () => {
+    const { repoDir, featureBranch } = await createLocalOnlyHarness();
+    harnessToCleanup.push(repoDir);
+
+    const result = await service.verifyMerge(repoDir, featureBranch, 'main');
+    expect(result).toBe(false);
+  });
+
+  it('should return false when main has extra commits after squash but feature has diverged', async () => {
+    const { repoDir, featureBranch, runGit } = await createLocalOnlyHarness();
+    harnessToCleanup.push(repoDir);
+
+    // Add a different file on main so there's a diff between branches
+    const { writeFileSync } = await import('node:fs');
+    const { join } = await import('node:path');
+    writeFileSync(join(repoDir, 'main-only.ts'), '// main only\n');
+    await runGit(['add', 'main-only.ts']);
+    await runGit(['commit', '-m', 'main-only commit']);
+
+    // Feature branch doesn't have main-only.ts, and main doesn't have feature.ts
+    const result = await service.verifyMerge(repoDir, featureBranch, 'main');
+    expect(result).toBe(false);
+  });
+
+  it('should return true after squash merge even when local branch is deleted (remote fallback)', async () => {
+    const harness = await createGitHarness();
+    harnessToCleanup.push(harness.bareDir, harness.cloneDir);
+
+    // Squash merge the feature branch
+    await harness.runGit(['merge', '--squash', harness.featureBranch]);
+    await harness.runGit(['commit', '-m', 'squash merge feature']);
+
+    // Delete the local branch (succeeds because it was pushed to remote)
+    await harness.runGit(['branch', '-d', harness.featureBranch]);
+
+    // verifyMerge should fall back to origin/<branch> and still detect the merge
+    const result = await service.verifyMerge(harness.cloneDir, harness.featureBranch, 'main');
+    expect(result).toBe(true);
+  });
+});

--- a/tests/unit/infrastructure/services/git/git-pr.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.test.ts
@@ -746,8 +746,10 @@ describe('GitPrService', () => {
   });
 
   describe('verifyMerge', () => {
-    it('should return true when feature branch is ancestor of base branch', async () => {
-      vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
+    it('should return true when feature branch is ancestor of base branch (true merge)', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse --verify (resolveRef)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // merge-base --is-ancestor
 
       const result = await service.verifyMerge('/repo', 'feat/test', 'main');
 
@@ -759,8 +761,52 @@ describe('GitPrService', () => {
       );
     });
 
-    it('should return false when feature branch is NOT ancestor of base branch', async () => {
-      vi.mocked(mockExec).mockRejectedValue(new Error('exit code 1'));
+    it('should return true for squash merge (not ancestor but no diff)', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse --verify (resolveRef)
+        .mockRejectedValueOnce(new Error('exit code 1')) // merge-base --is-ancestor fails
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git diff --quiet succeeds (no diff)
+
+      const result = await service.verifyMerge('/repo', 'feat/test', 'main');
+
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith('git', ['diff', '--quiet', 'feat/test', 'main'], {
+        cwd: '/repo',
+      });
+    });
+
+    it('should return false when neither true merge nor squash merge', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse --verify (resolveRef)
+        .mockRejectedValueOnce(new Error('exit code 1')) // merge-base --is-ancestor fails
+        .mockRejectedValueOnce(new Error('exit code 1')); // git diff --quiet fails (has diff)
+
+      const result = await service.verifyMerge('/repo', 'feat/test', 'main');
+
+      expect(result).toBe(false);
+    });
+
+    it('should fall back to remote tracking branch when local ref is deleted', async () => {
+      vi.mocked(mockExec)
+        .mockRejectedValueOnce(new Error('unknown revision')) // rev-parse local fails
+        .mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse origin/feat/test
+        .mockRejectedValueOnce(new Error('exit code 1')) // merge-base --is-ancestor fails
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git diff --quiet succeeds
+
+      const result = await service.verifyMerge('/repo', 'feat/test', 'main');
+
+      expect(result).toBe(true);
+      expect(mockExec).toHaveBeenCalledWith(
+        'git',
+        ['diff', '--quiet', 'origin/feat/test', 'main'],
+        { cwd: '/repo' }
+      );
+    });
+
+    it('should return false when both local and remote refs are gone', async () => {
+      vi.mocked(mockExec)
+        .mockRejectedValueOnce(new Error('unknown revision')) // rev-parse local fails
+        .mockRejectedValueOnce(new Error('unknown revision')); // rev-parse origin/ fails
 
       const result = await service.verifyMerge('/repo', 'feat/test', 'main');
 


### PR DESCRIPTION
## Summary

- **verifyMerge** used `git merge-base --is-ancestor` which only works for true merges — squash merges always failed verification despite succeeding
- Added `git diff --quiet` fallback to detect squash merges (no content difference = merged)
- Added `resolveRef` fallback to use `origin/<branch>` when local ref is deleted after squash merge (`git branch -d` succeeds when branch was pushed to remote)
- Added `makeGitExecutor` test fixture that runs real git commands, converting 4 `it.fails` integration tests into passing green tests
- Added `verify-merge.test.ts` integration test suite (5 scenarios including deleted-branch remote fallback)

## Test plan

- [x] Unit tests: 52 pass (5 verifyMerge scenarios including remote fallback)
- [x] Integration tests: 20 pass (all merge-step-real-git tests including former `it.fails`)
- [x] Pre-commit hooks pass (lint, typecheck, format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)