### PR TITLE
fix(web): suppress background refresh while drawer has unsaved changes

### DIFF
--- a/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
+++ b/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
@@ -99,8 +99,9 @@ export function FeatureDrawerClient({ view: initialView }: FeatureDrawerClientPr
       const newState = mapEventTypeToState(event.eventType);
       const newLifecycle = mapPhaseNameToLifecycle(event.phaseName);
 
-      // Trigger a server refresh to get the latest drawer view
-      router.refresh();
+      // Trigger a server refresh to get the latest drawer view,
+      // but skip when the user has unsaved changes to avoid losing form state.
+      if (!isDirtyRef.current) router.refresh();
 
       // Optimistically update the node data for immediate UI feedback
       setView((prev) => {
@@ -293,6 +294,11 @@ export function FeatureDrawerClient({ view: initialView }: FeatureDrawerClientPr
     view.type === 'prd-review' &&
     Object.keys(prdDefaultSelections).some((k) => prdDefaultSelections[k] !== prdSelections[k]);
   const isDirty = isChatDirty || isPrdDirty;
+
+  // Keep dirty state in a ref so the SSE handler can read the latest value
+  // without re-running the effect on every keystroke.
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
 
   const onReset = useCallback(() => {
     setChatInput('');

--- a/src/presentation/web/components/features/control-center/control-center-inner.tsx
+++ b/src/presentation/web/components/features/control-center/control-center-inner.tsx
@@ -28,7 +28,7 @@ export function ControlCenterInner({ initialNodes, initialEdges }: ControlCenter
   const pathname = usePathname();
   const selectedFeatureId = useSelectedFeatureId();
   const clickSound = useSoundAction('click');
-  const { guardedNavigate } = useDrawerCloseGuard();
+  const { guardedNavigate, getIsDirty } = useDrawerCloseGuard();
 
   const {
     nodes,
@@ -39,7 +39,7 @@ export function ControlCenterInner({ initialNodes, initialEdges }: ControlCenter
     handleDeleteFeature,
     handleDeleteRepository,
     createFeatureNode,
-  } = useControlCenterState(initialNodes, initialEdges);
+  } = useControlCenterState(initialNodes, initialEdges, getIsDirty);
 
   // Publish sidebar features to context whenever feature node data changes
   const { setFeatures: setSidebarFeatures } = useSidebarFeaturesContext();

--- a/src/presentation/web/components/features/control-center/use-control-center-state.ts
+++ b/src/presentation/web/components/features/control-center/use-control-center-state.ts
@@ -37,7 +37,9 @@ let nextFeatureId = 0;
 
 export function useControlCenterState(
   initialNodes: CanvasNodeType[],
-  initialEdges: Edge[]
+  initialEdges: Edge[],
+  /** When true, background router.refresh() calls (polling / SSE debounce) are suppressed. */
+  isRefreshBlocked?: () => boolean
 ): ControlCenterState {
   const router = useRouter();
   const [nodes, setNodes] = useState<CanvasNodeType[]>(initialNodes);
@@ -202,8 +204,10 @@ export function useControlCenterState(
 
     // Debounced background reconciliation (3s after last SSE event)
     clearTimeout(reconcileTimerRef.current);
-    reconcileTimerRef.current = setTimeout(() => router.refresh(), 3000);
-  }, [events, router]);
+    reconcileTimerRef.current = setTimeout(() => {
+      if (!isRefreshBlocked?.()) router.refresh();
+    }, 3000);
+  }, [events, router, isRefreshBlocked]);
 
   // Periodic polling fallback: refresh server data every 5s when any feature
   // is in an active state (running/action-required). This ensures the UI stays
@@ -219,9 +223,11 @@ export function useControlCenterState(
 
     if (!hasActiveFeature) return;
 
-    const interval = setInterval(() => router.refresh(), 5_000);
+    const interval = setInterval(() => {
+      if (!isRefreshBlocked?.()) router.refresh();
+    }, 5_000);
     return () => clearInterval(interval);
-  }, [nodes, router]);
+  }, [nodes, router, isRefreshBlocked]);
 
   const onNodesChange = useCallback((changes: NodeChange<CanvasNodeType>[]) => {
     setNodes((ns) => applyNodeChanges(changes, ns));

--- a/src/presentation/web/hooks/drawer-close-guard.tsx
+++ b/src/presentation/web/hooks/drawer-close-guard.tsx
@@ -29,6 +29,8 @@ interface DrawerCloseGuardContextValue {
   setGuard: (guard: { isDirty: boolean; onReset: () => void } | null) => void;
   /** Navigate only if no dirty drawer is registered; otherwise show confirmation. */
   guardedNavigate: (navigate: () => void) => void;
+  /** Returns true when any drawer has unsaved changes. Safe to call from effects/intervals. */
+  getIsDirty: () => boolean;
 }
 
 const DrawerCloseGuardContext = createContext<DrawerCloseGuardContextValue | null>(null);
@@ -69,8 +71,10 @@ export function DrawerCloseGuardProvider({ children }: { children: ReactNode }) 
     pendingNavigateRef.current = null;
   }, []);
 
+  const getIsDirty = useCallback(() => guardRef.current?.isDirty ?? false, []);
+
   return (
-    <DrawerCloseGuardContext value={{ setGuard, guardedNavigate }}>
+    <DrawerCloseGuardContext value={{ setGuard, guardedNavigate, getIsDirty }}>
       {children}
 
       <AlertDialog open={showConfirmation}>

--- a/tests/unit/presentation/web/features/control-center/use-control-center-state.test.tsx
+++ b/tests/unit/presentation/web/features/control-center/use-control-center-state.test.tsx
@@ -89,12 +89,14 @@ function HookTestHarness({
   initialNodes = [],
   initialEdges = [],
   onStateChange,
+  isRefreshBlocked,
 }: {
   initialNodes?: CanvasNodeType[];
   initialEdges?: Edge[];
   onStateChange?: (state: ControlCenterState) => void;
+  isRefreshBlocked?: () => boolean;
 }) {
-  const state = useControlCenterState(initialNodes, initialEdges);
+  const state = useControlCenterState(initialNodes, initialEdges, isRefreshBlocked);
 
   if (onStateChange) {
     onStateChange(state);
@@ -890,6 +892,67 @@ describe('useControlCenterState', () => {
         // Both edges were connected to feat-1, so 0 edges remain
         expect(capturedState!.edges).toHaveLength(0);
       });
+    });
+  });
+
+  describe('isRefreshBlocked suppresses background refresh', () => {
+    it('polling does not call router.refresh() when isRefreshBlocked returns true', () => {
+      vi.useFakeTimers();
+
+      const isRefreshBlocked = vi.fn(() => true);
+      render(
+        <HookTestHarness
+          initialNodes={[mockFeatureNode] as CanvasNodeType[]}
+          initialEdges={[]}
+          isRefreshBlocked={isRefreshBlocked}
+        />
+      );
+
+      // mockFeatureNode has state 'running', so polling starts
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+
+      expect(mockRefresh).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('polling calls router.refresh() when isRefreshBlocked returns false', () => {
+      vi.useFakeTimers();
+
+      const isRefreshBlocked = vi.fn(() => false);
+      render(
+        <HookTestHarness
+          initialNodes={[mockFeatureNode] as CanvasNodeType[]}
+          initialEdges={[]}
+          isRefreshBlocked={isRefreshBlocked}
+        />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(mockRefresh).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('polling calls router.refresh() when isRefreshBlocked is not provided', () => {
+      vi.useFakeTimers();
+
+      render(
+        <HookTestHarness initialNodes={[mockFeatureNode] as CanvasNodeType[]} initialEdges={[]} />
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(5_000);
+      });
+
+      expect(mockRefresh).toHaveBeenCalled();
+
+      vi.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Background `router.refresh()` calls (5s polling, 3s SSE debounce, per-event SSE handler) now check whether any drawer has unsaved changes before firing
- Adds `getIsDirty()` to `DrawerCloseGuardContext` so polling/SSE logic can query dirty state without re-renders
- Prevents form state loss (feature name, description, chat input, PRD selections) when drawers are open during active feature processing

Closes #189

## Test plan
- [x] 3 new unit tests verify polling suppression when `isRefreshBlocked` returns true, allows refresh when false, and defaults to refresh when not provided
- [x] All 3059 existing tests pass
- [x] `pnpm validate` (lint + format + typecheck + tsp) passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)