### PR TITLE
fix(domain): cascade delete sub-features when parent is deleted

### DIFF
--- a/packages/core/src/application/use-cases/features/delete-feature.use-case.ts
+++ b/packages/core/src/application/use-cases/features/delete-feature.use-case.ts
@@ -2,19 +2,21 @@
  * Delete Feature Use Case
  *
  * Orchestrates feature deletion including:
+ * - Cascade deleting all sub-features (children, grandchildren, etc.)
  * - Cancelling any running/pending agent runs
  * - Removing the git worktree
  * - Deleting the feature record
  *
  * Business Rules:
  * - Throws if the feature does not exist
+ * - Cascade deletes all sub-features before deleting the parent
  * - Cancels running/pending agent runs before deletion
  * - Gracefully handles worktree removal failures
  */
 
 import { injectable, inject } from 'tsyringe';
 import type { Feature } from '../../../domain/generated/output.js';
-import { AgentRunStatus, SdlcLifecycle } from '../../../domain/generated/output.js';
+import { AgentRunStatus } from '../../../domain/generated/output.js';
 import type { IFeatureRepository } from '../../ports/output/repositories/feature-repository.interface.js';
 import type { IWorktreeService } from '../../ports/output/services/worktree-service.interface.js';
 import type { IFeatureAgentProcessService } from '../../ports/output/agents/feature-agent-process.interface.js';
@@ -39,23 +41,29 @@ export class DeleteFeatureUseCase {
       throw new Error(`Feature not found: "${featureId}"`);
     }
 
-    // 2. Guard: reject deletion if blocked children exist (FR-29)
-    const blockedChildren = (await this.featureRepo.findByParentId(feature.id)).filter(
-      (child) => child.lifecycle === SdlcLifecycle.Blocked
-    );
-    if (blockedChildren.length > 0) {
-      const list = blockedChildren.map((c) => `${c.id} (${c.name})`).join(', ');
-      throw new Error(
-        `Cannot delete feature "${feature.name}" because it has blocked children: ${list}. ` +
-          `Remove or re-parent the blocked children before deleting this feature.`
-      );
-    }
+    // 2. Cascade delete all sub-features (depth-first)
+    await this.cascadeDeleteChildren(feature.id);
 
-    // 3. Cancel running/pending agent run if present
+    // 3. Delete the feature itself
+    await this.deleteSingleFeature(feature);
+
+    return feature;
+  }
+
+  private async cascadeDeleteChildren(parentId: string): Promise<void> {
+    const children = await this.featureRepo.findByParentId(parentId);
+    for (const child of children) {
+      // Recurse into grandchildren first (depth-first)
+      await this.cascadeDeleteChildren(child.id);
+      await this.deleteSingleFeature(child);
+    }
+  }
+
+  private async deleteSingleFeature(feature: Feature): Promise<void> {
+    // Cancel running/pending agent run if present
     if (feature.agentRunId) {
       const run = await this.runRepo.findById(feature.agentRunId);
       if (run && (run.status === AgentRunStatus.running || run.status === AgentRunStatus.pending)) {
-        // Kill the OS process if still alive
         if (run.pid && this.processService.isAlive(run.pid)) {
           try {
             process.kill(run.pid);
@@ -67,7 +75,7 @@ export class DeleteFeatureUseCase {
       }
     }
 
-    // 4. Remove worktree (ignore errors if already removed)
+    // Remove worktree (ignore errors if already removed)
     const worktreePath = this.worktreeService.getWorktreePath(
       feature.repositoryPath,
       feature.branch
@@ -78,9 +86,7 @@ export class DeleteFeatureUseCase {
       // Worktree might already be removed - that's fine
     }
 
-    // 5. Delete feature record
+    // Delete feature record
     await this.featureRepo.delete(feature.id);
-
-    return feature;
   }
 }

--- a/tests/unit/application/use-cases/features/delete-feature.use-case.test.ts
+++ b/tests/unit/application/use-cases/features/delete-feature.use-case.test.ts
@@ -217,64 +217,109 @@ describe('DeleteFeatureUseCase', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Deletion guard — blocked children
+  // Cascade delete — sub-features
   // -------------------------------------------------------------------------
 
-  it('should throw when the feature has blocked children', async () => {
+  it('should cascade delete blocked children instead of throwing', async () => {
     const feature = createMockFeature();
     const blockedChild1 = createMockFeature({
       id: 'child-001',
       name: 'Child One',
       lifecycle: SdlcLifecycle.Blocked,
+      repositoryPath: '/repo',
+      branch: 'feat/child-one',
     });
     const blockedChild2 = createMockFeature({
       id: 'child-002',
       name: 'Child Two',
       lifecycle: SdlcLifecycle.Blocked,
+      repositoryPath: '/repo',
+      branch: 'feat/child-two',
     });
     mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
-    mockFeatureRepo.findByParentId = vi.fn().mockResolvedValue([blockedChild1, blockedChild2]);
-
-    await expect(useCase.execute('feat-123-full-uuid')).rejects.toThrow('child-001');
-    await expect(useCase.execute('feat-123-full-uuid')).rejects.toThrow('child-002');
-  });
-
-  it('should include the blocked child names in the error message', async () => {
-    const feature = createMockFeature();
-    const blockedChild = createMockFeature({
-      id: 'child-abc',
-      name: 'My Blocked Child',
-      lifecycle: SdlcLifecycle.Blocked,
-    });
-    mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
-    mockFeatureRepo.findByParentId = vi.fn().mockResolvedValue([blockedChild]);
-
-    await expect(useCase.execute('feat-123-full-uuid')).rejects.toThrow('My Blocked Child');
-  });
-
-  it('should not call delete when blocked children exist', async () => {
-    const feature = createMockFeature();
-    const blockedChild = createMockFeature({ id: 'child-001', lifecycle: SdlcLifecycle.Blocked });
-    mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
-    mockFeatureRepo.findByParentId = vi.fn().mockResolvedValue([blockedChild]);
-
-    await expect(useCase.execute('feat-123-full-uuid')).rejects.toThrow();
-    expect(mockFeatureRepo.delete).not.toHaveBeenCalled();
-  });
-
-  it('should succeed when children exist but none are Blocked (all Started)', async () => {
-    const feature = createMockFeature();
-    const startedChild = createMockFeature({
-      id: 'child-001',
-      lifecycle: SdlcLifecycle.Started,
-    });
-    mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
-    mockFeatureRepo.findByParentId = vi.fn().mockResolvedValue([startedChild]);
+    mockFeatureRepo.findByParentId = vi
+      .fn()
+      .mockResolvedValueOnce([blockedChild1, blockedChild2])
+      .mockResolvedValue([]);
 
     const result = await useCase.execute('feat-123-full-uuid');
 
     expect(result.id).toBe('feat-123-full-uuid');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('child-001');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('child-002');
     expect(mockFeatureRepo.delete).toHaveBeenCalledWith('feat-123-full-uuid');
+  });
+
+  it('should cascade delete children in any lifecycle state', async () => {
+    const feature = createMockFeature();
+    const startedChild = createMockFeature({
+      id: 'child-001',
+      lifecycle: SdlcLifecycle.Started,
+      repositoryPath: '/repo',
+      branch: 'feat/child-started',
+    });
+    mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
+    mockFeatureRepo.findByParentId = vi
+      .fn()
+      .mockResolvedValueOnce([startedChild])
+      .mockResolvedValue([]);
+
+    const result = await useCase.execute('feat-123-full-uuid');
+
+    expect(result.id).toBe('feat-123-full-uuid');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('child-001');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('feat-123-full-uuid');
+  });
+
+  it('should recursively delete grandchildren', async () => {
+    const feature = createMockFeature();
+    const child = createMockFeature({
+      id: 'child-001',
+      name: 'Child',
+      lifecycle: SdlcLifecycle.Blocked,
+      repositoryPath: '/repo',
+      branch: 'feat/child',
+    });
+    const grandchild = createMockFeature({
+      id: 'grandchild-001',
+      name: 'Grandchild',
+      lifecycle: SdlcLifecycle.Blocked,
+      repositoryPath: '/repo',
+      branch: 'feat/grandchild',
+    });
+    mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
+    mockFeatureRepo.findByParentId = vi
+      .fn()
+      .mockResolvedValueOnce([child]) // children of parent
+      .mockResolvedValueOnce([grandchild]) // children of child
+      .mockResolvedValue([]); // children of grandchild
+
+    const result = await useCase.execute('feat-123-full-uuid');
+
+    expect(result.id).toBe('feat-123-full-uuid');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('grandchild-001');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('child-001');
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('feat-123-full-uuid');
+  });
+
+  it('should cancel agent runs on children during cascade delete', async () => {
+    const feature = createMockFeature();
+    const child = createMockFeature({
+      id: 'child-001',
+      agentRunId: 'child-run-1',
+      lifecycle: SdlcLifecycle.Started,
+      repositoryPath: '/repo',
+      branch: 'feat/child',
+    });
+    const childRun = createMockAgentRun({ id: 'child-run-1', status: AgentRunStatus.running });
+    mockFeatureRepo.findById = vi.fn().mockResolvedValue(feature);
+    mockFeatureRepo.findByParentId = vi.fn().mockResolvedValueOnce([child]).mockResolvedValue([]);
+    mockRunRepo.findById = vi.fn().mockResolvedValue(childRun);
+
+    await useCase.execute('feat-123-full-uuid');
+
+    expect(mockRunRepo.updateStatus).toHaveBeenCalledWith('child-run-1', AgentRunStatus.cancelled);
+    expect(mockFeatureRepo.delete).toHaveBeenCalledWith('child-001');
   });
 
   it('should succeed when there are no children at all', async () => {


### PR DESCRIPTION
## Summary
Changed the delete feature use case to cascade delete all sub-features (children, grandchildren, etc.) instead of throwing an error when blocked children exist. This allows parent features to be deleted along with their entire feature tree.

## Key Changes
- **Removed blocking guard**: Eliminated the check that prevented deletion when blocked children existed
- **Implemented cascade deletion**: Added recursive `cascadeDeleteChildren()` method that deletes all descendants depth-first before deleting the parent
- **Refactored deletion logic**: Extracted `deleteSingleFeature()` method to handle individual feature deletion (cancelling runs, removing worktree, deleting record)
- **Updated business rules**: Modified documentation to reflect that cascade deletion is now the expected behavior
- **Removed lifecycle filtering**: Deleted the `SdlcLifecycle.Blocked` import and filter since all children are now deleted regardless of state

## Implementation Details
- Cascade deletion uses depth-first traversal to ensure grandchildren are deleted before children, and children before parents
- Agent runs are cancelled for each deleted feature before its record is removed
- Worktree removal failures are gracefully handled (non-blocking)
- The use case now returns the deleted parent feature after the entire cascade completes

https://claude.ai/code/session_01NFprZBs7aPtFmCerz9zj4B