### PR TITLE
fix(web): add polling fallback, fresh settings from db, and stale drawer fix

### DIFF
--- a/packages/core/src/application/ports/output/agents/agent-executor-provider.interface.ts
+++ b/packages/core/src/application/ports/output/agents/agent-executor-provider.interface.ts
@@ -1,5 +1,5 @@
 import type { IAgentExecutor } from './agent-executor.interface.js';
 
 export interface IAgentExecutorProvider {
-  getExecutor(): IAgentExecutor;
+  getExecutor(): Promise<IAgentExecutor>;
 }

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -226,7 +226,8 @@ export async function initializeContainer(): Promise<typeof container> {
   container.register<IAgentExecutorProvider>('IAgentExecutorProvider', {
     useFactory: (c) => {
       const factory = c.resolve<IAgentExecutorFactory>('IAgentExecutorFactory');
-      return new AgentExecutorProvider(factory);
+      const settingsRepo = c.resolve<ISettingsRepository>('ISettingsRepository');
+      return new AgentExecutorProvider(factory, settingsRepo);
     },
   });
 

--- a/packages/core/src/infrastructure/services/agents/common/agent-executor-provider.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-executor-provider.service.ts
@@ -1,13 +1,19 @@
 import type { IAgentExecutorProvider } from '../../../../application/ports/output/agents/agent-executor-provider.interface.js';
 import type { IAgentExecutorFactory } from '../../../../application/ports/output/agents/agent-executor-factory.interface.js';
 import type { IAgentExecutor } from '../../../../application/ports/output/agents/agent-executor.interface.js';
-import { getSettings } from '../../settings.service.js';
+import type { ISettingsRepository } from '../../../../application/ports/output/repositories/settings.repository.interface.js';
 
 export class AgentExecutorProvider implements IAgentExecutorProvider {
-  constructor(private readonly factory: IAgentExecutorFactory) {}
+  constructor(
+    private readonly factory: IAgentExecutorFactory,
+    private readonly settingsRepository: ISettingsRepository
+  ) {}
 
-  getExecutor(): IAgentExecutor {
-    const settings = getSettings();
+  async getExecutor(): Promise<IAgentExecutor> {
+    const settings = await this.settingsRepository.load();
+    if (!settings) {
+      throw new Error('Settings not found. Please run initialization first.');
+    }
     return this.factory.createExecutor(settings.agent.type, settings.agent);
   }
 }

--- a/packages/core/src/infrastructure/services/agents/common/agent-runner.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-runner.service.ts
@@ -107,7 +107,7 @@ export class AgentRunnerService implements IAgentRunner {
 
     const settings = getSettings();
     const agentType = settings.agent.type;
-    const executor = this.executorProvider.getExecutor();
+    const executor = await this.executorProvider.getExecutor();
 
     const runId = crypto.randomUUID();
     const threadId = crypto.randomUUID();

--- a/packages/core/src/infrastructure/services/agents/common/structured-agent-caller.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/structured-agent-caller.service.ts
@@ -22,7 +22,7 @@ export class StructuredAgentCallerService implements IStructuredAgentCaller {
   ) {}
 
   async call<T>(prompt: string, schema: object, options?: StructuredCallOptions): Promise<T> {
-    const executor = this.executorProvider.getExecutor();
+    const executor = await this.executorProvider.getExecutor();
 
     if (executor.supportsFeature(AgentFeature.structuredOutput)) {
       return this.callWithNativeSchema<T>(executor, prompt, schema, options);

--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -176,7 +176,7 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
     executor = factory.createExecutor(args.agentType, settings.agent);
   } else {
     log('Creating executor from configured agent settings...');
-    executor = executorProvider.getExecutor();
+    executor = await executorProvider.getExecutor();
   }
 
   // Resolve merge node dependencies

--- a/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
+++ b/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
@@ -135,6 +135,17 @@ export function FeatureDrawerClient({ view: initialView }: FeatureDrawerClientPr
   const pathname = usePathname();
   const isOpen = pathname.startsWith('/feature/');
   const isOpenRef = useRef(isOpen);
+  const wasOpenRef = useRef(isOpen);
+
+  // When the drawer re-opens, force a server refresh so the view is always fresh.
+  // SSE skips router.refresh() while the drawer is closed, so data can go stale.
+  useEffect(() => {
+    if (isOpen && !wasOpenRef.current) {
+      router.refresh();
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen, router]);
+
   isOpenRef.current = isOpen;
 
   const onClose = useCallback(() => {

--- a/src/presentation/web/components/features/control-center/use-control-center-state.ts
+++ b/src/presentation/web/components/features/control-center/use-control-center-state.ts
@@ -16,14 +16,20 @@ import { deleteFeature } from '@/app/actions/delete-feature';
 import { addRepository } from '@/app/actions/add-repository';
 import { deleteRepository } from '@/app/actions/delete-repository';
 import { getFeatureMetadata } from '@/app/actions/get-feature-metadata';
+import { fetchGraphData } from '@/app/actions/get-graph-data';
 import { useAgentEventsContext } from '@/hooks/agent-events-provider';
 import { useSoundAction } from '@/hooks/use-sound-action';
+import { createLogger } from '@/lib/logger';
+
 import {
   mapEventTypeToState,
   resolveSseEventUpdates,
 } from '@/components/common/feature-node/derive-feature-state';
 import { useGraphState, type GraphCallbacks } from '@/hooks/use-graph-state';
 import type { FeatureEntry } from '@/lib/derive-graph';
+
+const log = createLogger('[Polling]');
+const POLL_INTERVAL_MS = 3_000;
 
 export interface ControlCenterState {
   nodes: CanvasNodeType[];
@@ -214,6 +220,25 @@ export function useControlCenterState(
         });
     }
   }, [events, updateFeature]);
+
+  // --- Polling fallback: catch any SSE events that were missed ---
+  useEffect(() => {
+    log.debug(`polling enabled (${POLL_INTERVAL_MS}ms interval)`);
+
+    const timer = setInterval(async () => {
+      try {
+        const { nodes: freshNodes, edges: freshEdges } = await fetchGraphData();
+        reconcile(freshNodes, freshEdges);
+      } catch {
+        log.warn('poll fetch failed — will retry next interval');
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      log.debug('polling disabled');
+      clearInterval(timer);
+    };
+  }, [reconcile]);
 
   // onNodesChange is a no-op: nodes are derived from domain Maps.
   // Since nodesDraggable=false and elementsSelectable=false, only React Flow's

--- a/src/presentation/web/hooks/use-agent-events.ts
+++ b/src/presentation/web/hooks/use-agent-events.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { NotificationEvent } from '@shepai/core/domain/generated/output';
+import { createLogger } from '@/lib/logger';
 
 export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
 
@@ -15,6 +16,7 @@ export interface UseAgentEventsResult {
   connectionStatus: ConnectionStatus;
 }
 
+const log = createLogger('[SSE]');
 const SW_PATH = '/agent-events-sw.js';
 const MAX_EVENTS = 500;
 const PRUNE_KEEP = 250;
@@ -40,8 +42,7 @@ export function useAgentEvents(options?: UseAgentEventsOptions): UseAgentEventsR
 
     if (msg.type === 'notification') {
       const parsed = msg.data as NotificationEvent;
-      // eslint-disable-next-line no-console
-      console.log('[SSE] event received:', parsed.eventType, parsed);
+      log.debug('event received:', parsed.eventType, parsed);
       setEvents((prev) => {
         const next = [...prev, parsed];
         return next.length > MAX_EVENTS ? next.slice(-PRUNE_KEEP) : next;

--- a/src/presentation/web/hooks/use-deploy-action.ts
+++ b/src/presentation/web/hooks/use-deploy-action.ts
@@ -1,7 +1,7 @@
 'use client';
-/* eslint-disable no-console */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { createLogger } from '@/lib/logger';
 import type { DeploymentState } from '@shepai/core/domain/generated/output';
 import { deployFeature } from '@/app/actions/deploy-feature';
 import { deployRepository } from '@/app/actions/deploy-repository';
@@ -25,15 +25,7 @@ export interface DeployActionState {
   url: string | null;
 }
 
-const PREFIX = '[useDeployAction]';
-const isDebug = !!process.env.NEXT_PUBLIC_DEBUG;
-const noop = () => undefined;
-const log = {
-  info: isDebug ? (...args: unknown[]) => console.info(PREFIX, ...args) : noop,
-  debug: isDebug ? (...args: unknown[]) => console.debug(PREFIX, ...args) : noop,
-  warn: (...args: unknown[]) => console.warn(PREFIX, ...args),
-  error: (...args: unknown[]) => console.error(PREFIX, ...args),
-};
+const log = createLogger('[useDeployAction]');
 
 const ERROR_CLEAR_DELAY = 5000;
 const POLL_INTERVAL = 3000;

--- a/tests/integration/infrastructure/services/agents/agent-infrastructure.test.ts
+++ b/tests/integration/infrastructure/services/agents/agent-infrastructure.test.ts
@@ -29,6 +29,7 @@ import type { IAgentExecutorFactory } from '@/application/ports/output/agents/ag
 import type { IAgentExecutorProvider } from '@/application/ports/output/agents/agent-executor-provider.interface.js';
 import type { IAgentRegistry } from '@/application/ports/output/agents/agent-registry.interface.js';
 import type { IAgentRunner } from '@/application/ports/output/agents/agent-runner.interface.js';
+import type { ISettingsRepository } from '@/application/ports/output/repositories/settings.repository.interface.js';
 import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import { AgentExecutorProvider } from '@/infrastructure/services/agents/common/agent-executor-provider.service.js';
 
@@ -63,10 +64,21 @@ describe('Agent Infrastructure Integration', () => {
       useFactory: () => createCheckpointer(':memory:'),
     });
 
+    container.register<ISettingsRepository>('ISettingsRepository', {
+      useValue: {
+        load: async () => ({ agent: { type: 'claude-code', authMethod: 'session' } }),
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        initialize: async () => {},
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        update: async () => {},
+      } as unknown as ISettingsRepository,
+    });
+
     container.register<IAgentExecutorProvider>('IAgentExecutorProvider', {
       useFactory: (c) => {
         const factory = c.resolve<IAgentExecutorFactory>('IAgentExecutorFactory');
-        return new AgentExecutorProvider(factory);
+        const settingsRepo = c.resolve<ISettingsRepository>('ISettingsRepository');
+        return new AgentExecutorProvider(factory, settingsRepo);
       },
     });
 

--- a/tests/unit/infrastructure/services/agents/agent-executor-provider.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-executor-provider.test.ts
@@ -3,19 +3,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AgentExecutorProvider } from '@/infrastructure/services/agents/common/agent-executor-provider.service.js';
 import type { IAgentExecutorFactory } from '@/application/ports/output/agents/agent-executor-factory.interface.js';
 import type { IAgentExecutor } from '@/application/ports/output/agents/agent-executor.interface.js';
-
-const { mockGetSettings } = vi.hoisted(() => ({
-  mockGetSettings: vi.fn(),
-}));
-
-vi.mock('@/infrastructure/services/settings.service.js', () => ({
-  getSettings: mockGetSettings,
-}));
+import type { ISettingsRepository } from '@/application/ports/output/repositories/settings.repository.interface.js';
 
 describe('AgentExecutorProvider', () => {
   let provider: AgentExecutorProvider;
   let mockFactory: IAgentExecutorFactory;
   let mockExecutor: IAgentExecutor;
+  let mockSettingsRepo: ISettingsRepository;
+
+  const defaultSettings = {
+    agent: { type: 'claude-code' as const, authMethod: 'session' as const },
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,34 +28,36 @@ describe('AgentExecutorProvider', () => {
       getSupportedAgents: vi.fn(),
       getCliInfo: vi.fn().mockReturnValue([]),
     };
-    mockGetSettings.mockReturnValue({
-      agent: { type: 'claude-code', authMethod: 'session' },
-    });
-    provider = new AgentExecutorProvider(mockFactory);
+    mockSettingsRepo = {
+      load: vi.fn().mockResolvedValue(defaultSettings),
+      initialize: vi.fn(),
+      update: vi.fn(),
+    };
+    provider = new AgentExecutorProvider(mockFactory, mockSettingsRepo);
   });
 
-  it('should call getSettings and pass agent.type and agent config to factory', () => {
-    provider.getExecutor();
+  it('should load settings from repository and pass agent config to factory', async () => {
+    await provider.getExecutor();
 
-    expect(mockGetSettings).toHaveBeenCalledOnce();
+    expect(mockSettingsRepo.load).toHaveBeenCalledOnce();
     expect(mockFactory.createExecutor).toHaveBeenCalledWith('claude-code', {
       type: 'claude-code',
       authMethod: 'session',
     });
   });
 
-  it('should return the executor from the factory', () => {
-    const result = provider.getExecutor();
+  it('should return the executor from the factory', async () => {
+    const result = await provider.getExecutor();
 
     expect(result).toBe(mockExecutor);
   });
 
-  it('should use the configured agent type, not a hardcoded default', () => {
-    mockGetSettings.mockReturnValue({
+  it('should use the configured agent type, not a hardcoded default', async () => {
+    vi.mocked(mockSettingsRepo.load).mockResolvedValue({
       agent: { type: 'cursor', authMethod: 'token', token: 'abc' },
-    });
+    } as any);
 
-    provider.getExecutor();
+    await provider.getExecutor();
 
     expect(mockFactory.createExecutor).toHaveBeenCalledWith('cursor', {
       type: 'cursor',
@@ -66,13 +66,27 @@ describe('AgentExecutorProvider', () => {
     });
   });
 
-  it('should throw if settings are not initialized', () => {
-    mockGetSettings.mockImplementation(() => {
-      throw new Error('Settings not initialized. Call initializeSettings() during CLI bootstrap.');
-    });
+  it('should throw if settings are not found', async () => {
+    vi.mocked(mockSettingsRepo.load).mockResolvedValue(null);
 
-    expect(() => provider.getExecutor()).toThrow(
-      'Settings not initialized. Call initializeSettings() during CLI bootstrap.'
+    await expect(provider.getExecutor()).rejects.toThrow(
+      'Settings not found. Please run initialization first.'
     );
+  });
+
+  it('should always read fresh settings from DB on each call', async () => {
+    await provider.getExecutor();
+
+    vi.mocked(mockSettingsRepo.load).mockResolvedValue({
+      agent: { type: 'cursor', authMethod: 'token' },
+    } as any);
+
+    await provider.getExecutor();
+
+    expect(mockSettingsRepo.load).toHaveBeenCalledTimes(2);
+    expect(mockFactory.createExecutor).toHaveBeenLastCalledWith('cursor', {
+      type: 'cursor',
+      authMethod: 'token',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Polling fallback**: 3s interval calls `fetchGraphData()` → `reconcile()` to catch missed SSE events without full page refresh
- **Fresh settings from DB**: `AgentExecutorProvider.getExecutor()` now reads from `ISettingsRepository` (DB) instead of stale in-memory `globalThis` singleton — agent type changes via CLI are picked up immediately
- **Stale drawer fix**: `router.refresh()` triggered when drawer re-opens to prevent Next.js router cache from showing stale PRD view after approval

## Test plan

- [x] `pnpm validate` passes (lint, format, typecheck, tsp)
- [x] `pnpm test:unit` — 257 files, 3105 tests all green
- [x] `pnpm build` — clean
- [ ] Manual: start `shep ui`, create feature, verify canvas updates every 3s via polling
- [ ] Manual: change agent via `shep settings agent` in separate terminal, create feature — should use new agent
- [ ] Manual: approve PRD, close drawer, click feature node — should show progress view not PRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)