### PR TITLE
feat(web): unified reject-approve button with file attachments

### DIFF
--- a/apis/json-schema/PrdRejectionPayload.yaml
+++ b/apis/json-schema/PrdRejectionPayload.yaml
@@ -13,6 +13,11 @@ properties:
     minimum: -2147483648
     maximum: 2147483647
     description: Iteration number (1-based, derived from PhaseTiming row count)
+  attachments:
+    type: array
+    items:
+      type: string
+    description: File attachment paths included with the rejection feedback
 required:
   - rejected
   - feedback

--- a/apis/json-schema/RejectionFeedbackEntry.yaml
+++ b/apis/json-schema/RejectionFeedbackEntry.yaml
@@ -17,6 +17,11 @@ properties:
     type: string
     format: date-time
     description: When the rejection occurred
+  attachments:
+    type: array
+    items:
+      type: string
+    description: File attachment paths included with the rejection feedback
 required:
   - iteration
   - message

--- a/packages/core/src/application/use-cases/agents/reject-agent-run.use-case.ts
+++ b/packages/core/src/application/use-cases/agents/reject-agent-run.use-case.ts
@@ -38,7 +38,8 @@ export class RejectAgentRunUseCase {
 
   async execute(
     id: string,
-    feedback: string
+    feedback: string,
+    attachments?: string[]
   ): Promise<{
     rejected: boolean;
     reason: string;
@@ -88,6 +89,7 @@ export class RejectAgentRunUseCase {
         message: feedback,
         phase: rejectedPhase,
         timestamp: new Date().toISOString(),
+        ...(attachments && attachments.length > 0 ? { attachments } : {}),
       };
 
       spec.rejectionFeedback = [...existingFeedback, newEntry];
@@ -128,6 +130,7 @@ export class RejectAgentRunUseCase {
       rejected: true,
       feedback,
       iteration,
+      ...(attachments && attachments.length > 0 ? { attachments } : {}),
     };
 
     // Derive worktree path with fallback — the mapper conditionally sets

--- a/packages/core/src/domain/generated/output.ts
+++ b/packages/core/src/domain/generated/output.ts
@@ -987,6 +987,10 @@ export type RejectionFeedbackEntry = {
    * When the rejection occurred
    */
   timestamp: any;
+  /**
+   * File attachment paths included with the rejection feedback
+   */
+  attachments?: string[];
 };
 
 /**
@@ -1902,6 +1906,10 @@ export type PrdRejectionPayload = {
    * Iteration number (1-based, derived from PhaseTiming row count)
    */
   iteration: number;
+  /**
+   * File attachment paths included with the rejection feedback
+   */
+  attachments?: string[];
 };
 
 /**

--- a/src/presentation/web/app/actions/reject-feature.ts
+++ b/src/presentation/web/app/actions/reject-feature.ts
@@ -6,7 +6,8 @@ import type { IFeatureRepository } from '@shepai/core/application/ports/output/r
 
 export async function rejectFeature(
   featureId: string,
-  feedback: string
+  feedback: string,
+  attachments?: string[]
 ): Promise<{
   rejected: boolean;
   iteration?: number;
@@ -34,7 +35,7 @@ export async function rejectFeature(
     }
 
     const rejectUseCase = resolve<RejectAgentRunUseCase>('RejectAgentRunUseCase');
-    const result = await rejectUseCase.execute(feature.agentRunId, feedback);
+    const result = await rejectUseCase.execute(feature.agentRunId, feedback, attachments);
 
     if (!result.rejected) {
       return { rejected: false, error: result.reason };

--- a/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
+++ b/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@shepai/core/domain/generated/output';
 import { approveFeature } from '@/app/actions/approve-feature';
 import { rejectFeature } from '@/app/actions/reject-feature';
+import type { RejectAttachment } from '@/components/common/drawer-action-bar';
 import { getFeatureArtifact } from '@/app/actions/get-feature-artifact';
 import { getResearchArtifact } from '@/app/actions/get-research-artifact';
 import { getMergeReviewData } from '@/app/actions/get-merge-review-data';
@@ -256,12 +257,18 @@ export function FeatureDrawerClient({ view: initialView }: FeatureDrawerClientPr
   // ── Approve / reject handlers ─────────────────────────────────────────
 
   const handleReject = useCallback(
-    async (feedback: string, label: string, onDone?: () => void) => {
+    async (
+      feedback: string,
+      label: string,
+      attachments: RejectAttachment[] = [],
+      onDone?: () => void
+    ) => {
       if (!featureNode?.featureId) return;
       isRejectingRef.current = true;
       setIsRejecting(true);
       try {
-        const result = await rejectFeature(featureNode.featureId, feedback);
+        const attachmentPaths = attachments.map((a) => a.path).filter(Boolean);
+        const result = await rejectFeature(featureNode.featureId, feedback, attachmentPaths);
         if (!result.rejected) {
           toast.error(result.error ?? `Failed to reject ${label.toLowerCase()}`);
           return;
@@ -285,15 +292,18 @@ export function FeatureDrawerClient({ view: initialView }: FeatureDrawerClientPr
   );
 
   const handlePrdReject = useCallback(
-    (feedback: string) => handleReject(feedback, 'Requirements', () => setPrdSelections({})),
+    (feedback: string, attachments: RejectAttachment[]) =>
+      handleReject(feedback, 'Requirements', attachments, () => setPrdSelections({})),
     [handleReject]
   );
   const handleTechReject = useCallback(
-    (feedback: string) => handleReject(feedback, 'Plan'),
+    (feedback: string, attachments: RejectAttachment[]) =>
+      handleReject(feedback, 'Plan', attachments),
     [handleReject]
   );
   const handleMergeReject = useCallback(
-    (feedback: string) => handleReject(feedback, 'Merge'),
+    (feedback: string, attachments: RejectAttachment[]) =>
+      handleReject(feedback, 'Merge', attachments),
     [handleReject]
   );
 

--- a/src/presentation/web/components/common/drawer-action-bar/drawer-action-bar-config.ts
+++ b/src/presentation/web/components/common/drawer-action-bar/drawer-action-bar-config.ts
@@ -1,15 +1,23 @@
 import type { ReactNode } from 'react';
 
+/** Attachment record for the reject form — mirrors FormAttachment from feature-create-drawer. */
+export interface RejectAttachment {
+  id: string;
+  name: string;
+  size: number;
+  mimeType: string;
+  path: string;
+  loading?: boolean;
+}
+
 export interface DrawerActionBarProps {
   /** Callback when user rejects with feedback (inline input or dialog) */
-  onReject?: (feedback: string) => void;
+  onReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   /** Callback when user approves */
   onApprove: () => void;
-  /** Label for the approve button */
+  /** Label for the approve button (used in both the split button and dropdown) */
   approveLabel: string;
-  /** Icon element for the approve button */
-  approveIcon?: ReactNode;
-  /** Placeholder for the inline revision input */
+  /** Placeholder for the inline revision textarea */
   revisionPlaceholder?: string;
   /** Whether an approval/processing operation is in flight */
   isProcessing?: boolean;

--- a/src/presentation/web/components/common/drawer-action-bar/drawer-action-bar.stories.tsx
+++ b/src/presentation/web/components/common/drawer-action-bar/drawer-action-bar.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
-import { Check } from 'lucide-react';
 import { DrawerActionBar } from './drawer-action-bar';
 
 const meta: Meta<typeof DrawerActionBar> = {
@@ -26,18 +25,10 @@ const meta: Meta<typeof DrawerActionBar> = {
 export default meta;
 type Story = StoryObj<typeof DrawerActionBar>;
 
-/** Default — approve button only. Plays "approve" sound on click. */
+/** Default — approve-only button (no reject input). */
 export const Default: Story = {};
 
-/** With approve icon. */
-export const WithIcon: Story = {
-  args: {
-    approveLabel: 'Approve PRD',
-    approveIcon: <Check className="mr-1.5 h-4 w-4" />,
-  },
-};
-
-/** With revision input — single line: chat input, send, approve. */
+/** Two-button bar: Reject + Approve with slide-expand animation on hover. */
 export const WithReject: Story = {
   args: {
     onReject: fn().mockName('onReject'),
@@ -67,7 +58,7 @@ export const Rejecting: Story = {
 export const WithRevisionInput: Story = {
   args: {
     onReject: fn().mockName('onReject'),
-    approveLabel: 'Approve',
+    approveLabel: 'Approve Plan',
     revisionPlaceholder: 'Ask AI to revise the plan...',
   },
 };

--- a/src/presentation/web/components/common/drawer-action-bar/drawer-action-bar.tsx
+++ b/src/presentation/web/components/common/drawer-action-bar/drawer-action-bar.tsx
@@ -1,17 +1,85 @@
 'use client';
 
-import { useState } from 'react';
-import { Send } from 'lucide-react';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { PaperclipIcon, Send, ChevronLeft, Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useSoundAction } from '@/hooks/use-sound-action';
-import type { DrawerActionBarProps } from './drawer-action-bar-config';
+import { AttachmentChip } from '@/components/common/attachment-chip';
+import { pickFiles } from '@/components/common/feature-create-drawer/pick-files';
+import type { DrawerActionBarProps, RejectAttachment } from './drawer-action-bar-config';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+const ALLOWED_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.svg',
+  '.bmp',
+  '.ico',
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.xls',
+  '.xlsx',
+  '.ppt',
+  '.pptx',
+  '.txt',
+  '.md',
+  '.csv',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.xml',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.swift',
+  '.kt',
+  '.html',
+  '.css',
+  '.scss',
+  '.less',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.fish',
+  '.toml',
+  '.ini',
+  '.cfg',
+  '.conf',
+  '.env',
+  '.zip',
+  '.tar',
+  '.gz',
+  '.log',
+]);
+
+function getExtension(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  return dot >= 0 ? filename.slice(dot).toLowerCase() : '';
+}
 
 export function DrawerActionBar({
   onReject,
   onApprove,
   approveLabel,
-  approveIcon,
   revisionPlaceholder,
   isProcessing = false,
   isRejecting = false,
@@ -25,51 +93,365 @@ export function DrawerActionBar({
   const approveSound = useSoundAction('approve');
   const disabled = isProcessing || isRejecting;
 
-  function handleRevisionSubmit(e: { preventDefault: () => void }) {
+  const [attachments, setAttachments] = useState<RejectAttachment[]>([]);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [hoverExpanded, setHoverExpanded] = useState(false);
+  const [ctrlHeld, setCtrlHeld] = useState(false);
+  const [shiftHeld, setShiftHeld] = useState(false);
+  const approveExpanded = hoverExpanded || (ctrlHeld && shiftHeld);
+  const rejectHighlighted = ctrlHeld && !shiftHeld;
+  const dragCounterRef = useRef(0);
+  const sessionIdRef = useRef(crypto.randomUUID());
+  const formRef = useRef<HTMLFormElement>(null);
+
+  // Track Ctrl/Meta + Shift keys for button state
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Control' || e.key === 'Meta') setCtrlHeld(true);
+      if (e.key === 'Shift') setShiftHeld(true);
+    }
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.key === 'Control' || e.key === 'Meta') setCtrlHeld(false);
+      if (e.key === 'Shift') setShiftHeld(false);
+    }
+    function onBlur() {
+      setCtrlHeld(false);
+      setShiftHeld(false);
+    }
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, []);
+
+  const handleFiles = useCallback(async (fileList: File[]) => {
+    setUploadError(null);
+
+    for (const file of fileList) {
+      if (file.size > MAX_FILE_SIZE) {
+        setUploadError(`"${file.name}" exceeds 10 MB limit`);
+        return;
+      }
+      const ext = getExtension(file.name);
+      if (ext && !ALLOWED_EXTENSIONS.has(ext)) {
+        setUploadError(`File type "${ext}" is not allowed`);
+        return;
+      }
+    }
+
+    for (const file of fileList) {
+      const tempId = crypto.randomUUID();
+
+      setAttachments((prev) => [
+        ...prev,
+        {
+          id: tempId,
+          name: file.name,
+          size: file.size,
+          mimeType: file.type || 'application/octet-stream',
+          path: '',
+          loading: true,
+        },
+      ]);
+
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+        formData.append('sessionId', sessionIdRef.current);
+
+        const res = await fetch('/api/attachments/upload', {
+          method: 'POST',
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Upload failed' }));
+          setAttachments((prev) => prev.filter((a) => a.id !== tempId));
+          setUploadError(body.error ?? 'Upload failed');
+          return;
+        }
+
+        const uploaded = await res.json();
+        setAttachments((prev) => {
+          const isDupe = prev.some((a) => a.id !== tempId && a.path === uploaded.path);
+          if (isDupe) return prev.filter((a) => a.id !== tempId);
+          return prev.map((a) =>
+            a.id === tempId ? { ...uploaded, id: tempId, loading: false } : a
+          );
+        });
+      } catch {
+        setAttachments((prev) => prev.filter((a) => a.id !== tempId));
+        setUploadError('Upload failed');
+      }
+    }
+  }, []);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current += 1;
+    if (dragCounterRef.current === 1) setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current -= 1;
+    if (dragCounterRef.current === 0) setIsDragOver(false);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      const files = Array.from(e.dataTransfer.files);
+      if (files.length > 0) handleFiles(files);
+    },
+    [handleFiles]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      const files: File[] = [];
+      for (const item of Array.from(items)) {
+        if (item.kind === 'file') {
+          const file = item.getAsFile();
+          if (file) files.push(file);
+        }
+      }
+      if (files.length > 0) {
+        e.preventDefault();
+        handleFiles(files);
+      }
+    },
+    [handleFiles]
+  );
+
+  const handleAddFiles = useCallback(async () => {
+    try {
+      const files = await pickFiles();
+      if (files) {
+        setAttachments((prev) => {
+          const existingPaths = new Set(prev.map((f) => f.path));
+          const unique = files
+            .filter((f) => !existingPaths.has(f.path))
+            .map(
+              (f): RejectAttachment => ({
+                id: crypto.randomUUID(),
+                name: f.name,
+                size: f.size,
+                mimeType: 'application/octet-stream',
+                path: f.path,
+              })
+            );
+          return unique.length > 0 ? [...prev, ...unique] : prev;
+        });
+      }
+    } catch {
+      // Native dialog failed — silently ignore
+    }
+  }, []);
+
+  const handleRemoveFile = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  const clearForm = useCallback(() => {
+    setChatInput('');
+    setAttachments([]);
+    setUploadError(null);
+  }, [setChatInput]);
+
+  function handleFormSubmit(e: { preventDefault: () => void }) {
     e.preventDefault();
     const text = chatInput.trim();
-    if (!text || !onReject) return;
-    onReject(text);
-    setChatInput('');
+
+    if (hoverExpanded || (ctrlHeld && shiftHeld)) {
+      // Approve mode (hovering arrow or Shift held)
+      approveSound.play();
+      onApprove();
+      clearForm();
+    } else {
+      // Reject mode — text required
+      if (!text || !onReject) return;
+      onReject(
+        text,
+        attachments.filter((a) => !a.loading)
+      );
+      clearForm();
+    }
   }
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      // Ctrl+Shift+Enter = approve, Ctrl+Enter = reject
+      formRef.current?.requestSubmit();
+    }
+  }, []);
+
+  const modKey =
+    typeof navigator !== 'undefined' && /Mac/i.test(navigator.userAgent) ? '⌘' : 'Ctrl';
 
   return (
     <div className="border-border shrink-0 border-t">
       {children}
       {onReject ? (
-        <form onSubmit={handleRevisionSubmit} className="flex items-center gap-2 p-4">
-          <Input
-            type="text"
-            placeholder={revisionPlaceholder ?? 'Ask AI to revise...'}
-            aria-label={revisionPlaceholder ?? 'Ask AI to revise...'}
-            disabled={disabled}
-            value={chatInput}
-            onChange={(e) => setChatInput(e.target.value)}
-            className="flex-1"
-            data-testid="drawer-chat-input"
-          />
-          <Button
-            type="submit"
-            variant="secondary"
-            size="icon"
-            aria-label="Send"
-            disabled={disabled}
-            data-testid="drawer-chat-send"
-          >
-            <Send />
-          </Button>
-          <Button
-            type="button"
-            disabled={disabled}
-            onClick={() => {
-              approveSound.play();
-              onApprove();
-            }}
-          >
-            {approveIcon}
-            {approveLabel}
-          </Button>
-        </form>
+        <TooltipProvider delayDuration={400}>
+          <form ref={formRef} onSubmit={handleFormSubmit} className="p-3">
+            <div
+              role="region"
+              aria-label="File drop zone"
+              data-drag-over={isDragOver ? 'true' : 'false'}
+              onDragEnter={handleDragEnter}
+              onDragLeave={handleDragLeave}
+              onDragOver={handleDragOver}
+              onDrop={handleDrop}
+              className={cn(
+                'rounded-md border-2 border-transparent transition-colors',
+                isDragOver && 'border-primary/50 bg-primary/5'
+              )}
+            >
+              <div className="border-input focus-within:ring-ring/50 focus-within:border-ring flex flex-col overflow-hidden rounded-md border shadow-xs transition-[color,box-shadow] focus-within:ring-[3px]">
+                <Textarea
+                  placeholder={revisionPlaceholder ?? 'Ask AI to revise...'}
+                  aria-label={revisionPlaceholder ?? 'Ask AI to revise...'}
+                  disabled={disabled}
+                  value={chatInput}
+                  onChange={(e) => setChatInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  onPaste={handlePaste}
+                  rows={3}
+                  className="min-h-0 flex-1 resize-none rounded-none border-0 shadow-none focus-visible:ring-0"
+                  data-testid="drawer-chat-input"
+                />
+                {attachments.length > 0 && (
+                  <div className="flex flex-wrap items-center gap-1.5 px-3 py-2">
+                    {attachments.map((file) => (
+                      <AttachmentChip
+                        key={file.id}
+                        name={file.name}
+                        size={file.size}
+                        mimeType={file.mimeType}
+                        path={file.path}
+                        onRemove={() => handleRemoveFile(file.id)}
+                        disabled={disabled}
+                        loading={file.loading}
+                      />
+                    ))}
+                  </div>
+                )}
+                {uploadError ? (
+                  <p className="text-destructive px-3 pb-2 text-xs">{uploadError}</p>
+                ) : null}
+                <div className="border-input flex items-center gap-2 border-t px-3 py-1.5">
+                  <span className="text-muted-foreground flex-1 truncate text-[11px]">
+                    <kbd className="bg-muted rounded px-1 py-0.5 font-mono text-[10px]">
+                      {modKey}+Enter
+                    </kbd>{' '}
+                    reject
+                    <span className="mx-1 opacity-40">|</span>
+                    <kbd className="bg-muted rounded px-1 py-0.5 font-mono text-[10px]">
+                      {modKey}+Shift+Enter
+                    </kbd>{' '}
+                    approve
+                  </span>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={handleAddFiles}
+                        disabled={disabled}
+                        aria-label="Attach files"
+                        className="text-muted-foreground hover:text-foreground cursor-pointer rounded p-1 transition-colors"
+                      >
+                        <PaperclipIcon className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">Attach files</TooltipContent>
+                  </Tooltip>
+
+                  {/* Single action button: Reject by default, Approve on hover of arrow / CTRL */}
+                  <div onMouseLeave={() => setHoverExpanded(false)}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="submit"
+                          disabled={disabled}
+                          data-testid="drawer-action-submit"
+                          className={cn(
+                            'relative flex h-8 min-w-[10rem] cursor-pointer items-center overflow-hidden rounded-md border pr-10 pl-4 text-sm font-medium whitespace-nowrap transition-colors',
+                            'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+                            approveExpanded
+                              ? 'border-blue-400/60 text-white'
+                              : rejectHighlighted
+                                ? 'border-primary bg-muted ring-primary/30 shadow-sm ring-1'
+                                : 'border-border bg-muted/50 hover:bg-muted shadow-sm'
+                          )}
+                        >
+                          {/* Blue fill — slides in from right */}
+                          <div
+                            className="pointer-events-none absolute inset-0 bg-blue-500/85 transition-transform duration-300 ease-in-out"
+                            style={{
+                              transform: approveExpanded ? 'translateX(0)' : 'translateX(100%)',
+                            }}
+                          />
+                          {/* Reject content */}
+                          <span
+                            className={cn(
+                              'absolute inset-0 z-10 flex items-center justify-center gap-1.5 pr-8 transition-opacity duration-300',
+                              approveExpanded ? 'opacity-0' : 'opacity-100'
+                            )}
+                          >
+                            <Send className="h-3.5 w-3.5 shrink-0" />
+                            Reject
+                          </span>
+                          {/* Approve content — overlaid, centered */}
+                          <span
+                            className={cn(
+                              'absolute inset-0 z-10 flex items-center justify-center gap-1.5 text-white transition-opacity duration-300',
+                              approveExpanded ? 'opacity-100' : 'opacity-0'
+                            )}
+                          >
+                            <Check className="h-3.5 w-3.5 shrink-0" />
+                            {approveLabel}
+                          </span>
+                          {/* Arrow indicator — hover trigger */}
+                          <span
+                            className={cn(
+                              'border-input/60 absolute inset-y-0 right-0 z-20 flex w-8 cursor-pointer items-center justify-center rounded-r-[5px] border-l bg-blue-500/85 transition-opacity duration-300',
+                              approveExpanded && 'pointer-events-none opacity-0'
+                            )}
+                            onMouseEnter={() => setHoverExpanded(true)}
+                          >
+                            <ChevronLeft className="h-3.5 w-3.5 text-white" />
+                          </span>
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        {approveExpanded ? 'Approve' : 'Send revision feedback'}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </form>
+        </TooltipProvider>
       ) : (
         <div className="flex items-center gap-2 px-4 pb-4">
           <Button
@@ -81,7 +463,6 @@ export function DrawerActionBar({
               onApprove();
             }}
           >
-            {approveIcon}
             {approveLabel}
           </Button>
         </div>

--- a/src/presentation/web/components/common/drawer-action-bar/index.ts
+++ b/src/presentation/web/components/common/drawer-action-bar/index.ts
@@ -1,2 +1,2 @@
 export { DrawerActionBar } from './drawer-action-bar';
-export type { DrawerActionBarProps } from './drawer-action-bar-config';
+export type { DrawerActionBarProps, RejectAttachment } from './drawer-action-bar-config';

--- a/src/presentation/web/components/common/feature-drawer-tabs/feature-drawer-tabs.tsx
+++ b/src/presentation/web/components/common/feature-drawer-tabs/feature-drawer-tabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Loader2, Check } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { getFeaturePhaseTimings } from '@/app/actions/get-feature-phase-timings';
 import type {
@@ -20,6 +20,7 @@ import { TechDecisionsContent } from '@/components/common/tech-decisions-review'
 import { ProductDecisionsSummary } from '@/components/common/product-decisions-summary';
 import { MergeReview } from '@/components/common/merge-review';
 import { DrawerActionBar } from '@/components/common/drawer-action-bar';
+import type { RejectAttachment } from '@/components/common/drawer-action-bar';
 import { OverviewTab } from './overview-tab';
 import { ActivityTab } from './activity-tab';
 import { LogTab } from './log-tab';
@@ -86,13 +87,13 @@ export interface FeatureDrawerTabsProps {
   prdSelections?: Record<string, string>;
   onPrdSelect?: (questionId: string, optionId: string) => void;
   onPrdApprove?: (actionId: string) => void;
-  onPrdReject?: (feedback: string) => void;
+  onPrdReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   isPrdLoading?: boolean;
 
   // Tech decisions
   techData?: TechDecisionsReviewData | null;
   onTechApprove?: () => void;
-  onTechReject?: (feedback: string) => void;
+  onTechReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   isTechLoading?: boolean;
 
   // Product decisions
@@ -101,7 +102,7 @@ export interface FeatureDrawerTabsProps {
   // Merge review
   mergeData?: MergeReviewData | null;
   onMergeApprove?: () => void;
-  onMergeReject?: (feedback: string) => void;
+  onMergeReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   isMergeLoading?: boolean;
 
   // Shared
@@ -371,7 +372,7 @@ function DrawerActionBarForTech({
   onChatInputChange,
 }: {
   onApprove: () => void;
-  onReject?: (feedback: string) => void;
+  onReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   isProcessing?: boolean;
   isRejecting?: boolean;
   chatInput?: string;
@@ -382,7 +383,6 @@ function DrawerActionBarForTech({
       onReject={onReject}
       onApprove={onApprove}
       approveLabel="Approve Plan"
-      approveIcon={<Check className="mr-1.5 h-4 w-4" />}
       revisionPlaceholder="Ask AI to revise the plan..."
       isProcessing={isProcessing}
       isRejecting={isRejecting}

--- a/src/presentation/web/components/common/merge-review/merge-review-config.ts
+++ b/src/presentation/web/components/common/merge-review/merge-review-config.ts
@@ -1,4 +1,5 @@
 import type { PrStatus, CiStatus } from '@shepai/core/domain/generated/output';
+import type { RejectAttachment } from '@/components/common/drawer-action-bar';
 
 /** Diff summary statistics for the PR */
 export interface MergeReviewDiffSummary {
@@ -53,7 +54,7 @@ export interface MergeReviewProps {
   /** Approve merge callback */
   onApprove: () => void;
   /** Reject merge callback — opens feedback dialog when provided; also used for inline text rejection */
-  onReject?: (feedback: string) => void;
+  onReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   /** Controls disabled state during approval */
   isProcessing?: boolean;
   /** Whether a reject operation is in flight */

--- a/src/presentation/web/components/common/merge-review/merge-review.tsx
+++ b/src/presentation/web/components/common/merge-review/merge-review.tsx
@@ -2,8 +2,6 @@
 
 import {
   ExternalLink,
-  GitMerge,
-  Loader2,
   AlertTriangle,
   FileDiff,
   GitCommitHorizontal,
@@ -180,13 +178,6 @@ export function MergeReview({
         onReject={onReject}
         onApprove={onApprove}
         approveLabel="Approve Merge"
-        approveIcon={
-          isProcessing ? (
-            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-          ) : (
-            <GitMerge className="mr-1.5 h-4 w-4" />
-          )
-        }
         revisionPlaceholder="Ask AI to revise before merging..."
         isProcessing={isProcessing}
         isRejecting={isRejecting}

--- a/src/presentation/web/components/common/prd-questionnaire/prd-questionnaire-config.ts
+++ b/src/presentation/web/components/common/prd-questionnaire/prd-questionnaire-config.ts
@@ -4,6 +4,7 @@ import type {
   PrdFinalAction,
   PrdQuestionnaireData,
 } from '@shepai/core/domain/generated/output';
+import type { RejectAttachment } from '@/components/common/drawer-action-bar';
 
 export type { PrdOption, PrdQuestion, PrdFinalAction, PrdQuestionnaireData };
 
@@ -17,7 +18,7 @@ export interface PrdQuestionnaireProps {
   /** Finalize requirements callback */
   onApprove: (actionId: string) => void;
   /** Reject requirements callback — opens feedback dialog when provided; also used for inline text rejection */
-  onReject?: (feedback: string) => void;
+  onReject?: (feedback: string, attachments: RejectAttachment[]) => void;
   /** Controls disabled/animated state during refinement */
   isProcessing?: boolean;
   /** Whether a reject operation is in flight */

--- a/src/presentation/web/components/common/prd-questionnaire/prd-questionnaire.tsx
+++ b/src/presentation/web/components/common/prd-questionnaire/prd-questionnaire.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -169,7 +169,6 @@ export function PrdQuestionnaire({
         onReject={onReject}
         onApprove={() => onApprove(finalAction.id)}
         approveLabel={finalAction.label}
-        approveIcon={<Check className="mr-1.5 h-4 w-4" />}
         revisionPlaceholder="Ask AI to refine requirements..."
         isProcessing={isProcessing}
         isRejecting={isRejecting}

--- a/src/presentation/web/components/common/tech-decisions-review/tech-decisions-review.tsx
+++ b/src/presentation/web/components/common/tech-decisions-review/tech-decisions-review.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import type { Components } from 'react-markdown';
 import Markdown from 'react-markdown';
-import { Check, ChevronRight, GitCompareArrows, Layers } from 'lucide-react';
+import { ChevronRight, GitCompareArrows, Layers } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { DrawerActionBar } from '@/components/common/drawer-action-bar';
 import { useSoundAction } from '@/hooks/use-sound-action';
@@ -180,7 +180,6 @@ export function TechDecisionsReview({
         onReject={onReject}
         onApprove={onApprove}
         approveLabel="Approve Plan"
-        approveIcon={<Check className="mr-1.5 h-4 w-4" />}
         revisionPlaceholder="Ask AI to revise the plan..."
         isProcessing={isProcessing}
         isRejecting={isRejecting}

--- a/tests/unit/presentation/web/actions/reject-feature.test.ts
+++ b/tests/unit/presentation/web/actions/reject-feature.test.ts
@@ -71,7 +71,7 @@ describe('rejectFeature server action', () => {
     const result = await rejectFeature('feat-1', 'needs changes');
 
     expect(result).toEqual({ rejected: false, error: 'Not waiting for approval' });
-    expect(mockExecute).toHaveBeenCalledWith('run-1', 'needs changes');
+    expect(mockExecute).toHaveBeenCalledWith('run-1', 'needs changes', undefined);
   });
 
   it('returns success with iteration info on successful rejection', async () => {

--- a/tests/unit/presentation/web/components/common/drawer-action-bar/drawer-action-bar.test.tsx
+++ b/tests/unit/presentation/web/components/common/drawer-action-bar/drawer-action-bar.test.tsx
@@ -16,12 +16,12 @@ vi.mock('@/hooks/use-sound-action', () => ({
   }),
 }));
 
-describe('DrawerActionBar — sound effects', () => {
+describe('DrawerActionBar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('plays approve sound when approve button is clicked', async () => {
+  it('plays approve sound when approve button is clicked (no onReject)', async () => {
     const user = userEvent.setup();
     const onApprove = vi.fn();
     render(<DrawerActionBar onApprove={onApprove} approveLabel="Approve" />);
@@ -32,16 +32,16 @@ describe('DrawerActionBar — sound effects', () => {
     expect(onApprove).toHaveBeenCalledOnce();
   });
 
-  it('calls onReject when revision is submitted via chat input', async () => {
+  it('calls onReject when revision is submitted via submit button', async () => {
     const user = userEvent.setup();
     const onReject = vi.fn();
     render(<DrawerActionBar onApprove={vi.fn()} approveLabel="Approve" onReject={onReject} />);
 
     const input = screen.getByRole('textbox');
     await user.type(input, 'please revise this');
-    await user.click(screen.getByRole('button', { name: /send/i }));
+    await user.click(screen.getByTestId('drawer-action-submit'));
 
-    expect(onReject).toHaveBeenCalledWith('please revise this');
+    expect(onReject).toHaveBeenCalledWith('please revise this', []);
   });
 
   it('disables all controls when isProcessing is true', () => {
@@ -55,8 +55,8 @@ describe('DrawerActionBar — sound effects', () => {
     );
 
     expect(screen.getByRole('textbox')).toBeDisabled();
-    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /approve/i })).toBeDisabled();
+    expect(screen.getByTestId('drawer-action-submit')).toBeDisabled();
+    // Single button — approve is now part of drawer-action-submit
     expect(mockApprovePlay).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/presentation/web/components/common/merge-review/merge-review.test.tsx
+++ b/tests/unit/presentation/web/components/common/merge-review/merge-review.test.tsx
@@ -208,7 +208,7 @@ describe('MergeReview', () => {
       fireEvent.change(input, { target: { value: '  fix the tests  ' } });
       fireEvent.submit(input.closest('form')!);
 
-      expect(onReject).toHaveBeenCalledWith('fix the tests');
+      expect(onReject).toHaveBeenCalledWith('fix the tests', []);
     });
 
     it('does not call onReject when input is empty', () => {
@@ -230,11 +230,14 @@ describe('MergeReview', () => {
   });
 
   describe('approve button', () => {
-    it('renders "Approve Merge" button that calls onApprove', () => {
+    it('renders "Approve Merge" button that calls onApprove when Ctrl+Shift is held', () => {
       const onApprove = vi.fn();
       render(<MergeReview {...baseProps} onApprove={onApprove} />);
 
-      const button = screen.getByRole('button', { name: /approve merge/i });
+      // Hold Ctrl+Shift to switch the single button into approve mode
+      fireEvent.keyDown(window, { key: 'Control' });
+      fireEvent.keyDown(window, { key: 'Shift' });
+      const button = screen.getByTestId('drawer-action-submit');
       fireEvent.click(button);
 
       expect(onApprove).toHaveBeenCalledTimes(1);
@@ -243,7 +246,7 @@ describe('MergeReview', () => {
     it('disables approve button when isProcessing is true', () => {
       render(<MergeReview {...baseProps} isProcessing />);
 
-      const button = screen.getByRole('button', { name: /approve merge/i });
+      const button = screen.getByTestId('drawer-action-submit');
       expect(button).toBeDisabled();
     });
   });

--- a/tests/unit/presentation/web/components/common/prd-questionnaire/prd-questionnaire.test.tsx
+++ b/tests/unit/presentation/web/components/common/prd-questionnaire/prd-questionnaire.test.tsx
@@ -167,10 +167,10 @@ describe('PrdQuestionnaire', () => {
       const input = screen.getByLabelText('Ask AI to refine requirements...');
       fireEvent.change(input, { target: { value: 'Make it simpler' } });
 
-      const sendButton = screen.getByRole('button', { name: /send/i });
+      const sendButton = screen.getByRole('button', { name: /reject/i });
       fireEvent.click(sendButton);
 
-      expect(onReject).toHaveBeenCalledWith('Make it simpler');
+      expect(onReject).toHaveBeenCalledWith('Make it simpler', []);
     });
 
     it('approve button calls onApprove with finalAction.id', () => {
@@ -230,7 +230,7 @@ describe('PrdQuestionnaire', () => {
       expect(prevButton).toBeDisabled();
 
       // Send button is disabled
-      const sendButton = screen.getByRole('button', { name: /send/i });
+      const sendButton = screen.getByRole('button', { name: /reject/i });
       expect(sendButton).toBeDisabled();
 
       // Chat input is disabled
@@ -314,9 +314,9 @@ describe('PrdQuestionnaire', () => {
 
       const input = screen.getByLabelText('Ask AI to refine requirements...');
       fireEvent.change(input, { target: { value: 'Needs more detail' } });
-      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+      fireEvent.click(screen.getByRole('button', { name: /reject/i }));
 
-      expect(onReject).toHaveBeenCalledWith('Needs more detail');
+      expect(onReject).toHaveBeenCalledWith('Needs more detail', []);
     });
 
     it('approve button is disabled when isRejecting is true', () => {

--- a/tests/unit/presentation/web/components/common/tech-decisions-review/tech-decisions-review.test.tsx
+++ b/tests/unit/presentation/web/components/common/tech-decisions-review/tech-decisions-review.test.tsx
@@ -85,9 +85,9 @@ describe('TechDecisionsReview', () => {
 
       const input = screen.getByLabelText('Ask AI to revise the plan...');
       fireEvent.change(input, { target: { value: 'Reconsider the database' } });
-      fireEvent.click(screen.getByRole('button', { name: /send/i }));
+      fireEvent.click(screen.getByRole('button', { name: /reject/i }));
 
-      expect(onReject).toHaveBeenCalledWith('Reconsider the database');
+      expect(onReject).toHaveBeenCalledWith('Reconsider the database', []);
     });
 
     it('approve button is disabled when isRejecting is true', () => {
@@ -115,10 +115,10 @@ describe('TechDecisionsReview', () => {
       const input = screen.getByLabelText('Ask AI to revise the plan...');
       fireEvent.change(input, { target: { value: 'Add caching layer' } });
 
-      const sendButton = screen.getByRole('button', { name: /send/i });
+      const sendButton = screen.getByRole('button', { name: /reject/i });
       fireEvent.click(sendButton);
 
-      expect(onReject).toHaveBeenCalledWith('Add caching layer');
+      expect(onReject).toHaveBeenCalledWith('Add caching layer', []);
     });
   });
 
@@ -134,7 +134,7 @@ describe('TechDecisionsReview', () => {
       render(<TechDecisionsReview {...defaultProps} onReject={onReject} isProcessing />);
 
       expect(screen.getByLabelText('Ask AI to revise the plan...')).toBeDisabled();
-      expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /reject/i })).toBeDisabled();
     });
   });
 });

--- a/tsp/agents/prd-approval.tsp
+++ b/tsp/agents/prd-approval.tsp
@@ -34,6 +34,9 @@ model PrdRejectionPayload {
 
   @doc("Iteration number (1-based, derived from PhaseTiming row count)")
   iteration: int32;
+
+  @doc("File attachment paths included with the rejection feedback")
+  attachments?: string[];
 }
 
 @doc("A single question with its options as presented in the review TUI")

--- a/tsp/domain/value-objects/spec-metadata.tsp
+++ b/tsp/domain/value-objects/spec-metadata.tsp
@@ -108,6 +108,9 @@ model RejectionFeedbackEntry {
 
   @doc("When the rejection occurred")
   timestamp: utcDateTime;
+
+  @doc("File attachment paths included with the rejection feedback")
+  attachments?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Redesigned DrawerActionBar** into a single unified button with a smooth hover-triggered approve transition (blue slide-in animation via chevron hover zone)
- **Added keyboard shortcuts**: `Ctrl+Enter` for reject, `Ctrl+Shift+Enter` for approve, with platform-aware hints (Ctrl vs ⌘)
- **Added file attachment support** to rejection feedback across all review components (PRD questionnaire, merge review, tech decisions)
- **Visual feedback**: Ctrl-only highlights the reject button, Ctrl+Shift triggers the approve transition
- **TypeSpec + domain changes**: Added `attachments` field to `PrdRejectionPayload` and `RejectionFeedbackEntry`

## Test plan

- [x] All 2440 unit tests pass (`pnpm vitest run --changed`)
- [ ] Visual verification in Storybook (`pnpm dev:storybook`)
- [ ] Test keyboard shortcuts: Ctrl+Enter sends reject, Ctrl+Shift+Enter approves
- [ ] Test hover: hovering chevron triggers approve animation
- [ ] Test file attachments: drag-drop, paste, and file picker work in rejection feedback
- [ ] Verify in production mode (`shep ui`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)