### PR TITLE
perf(agents): lazy-load heavy imports to reduce cli startup by ~300ms

### DIFF
--- a/packages/core/src/application/ports/output/agents/agent-registry.interface.ts
+++ b/packages/core/src/application/ports/output/agents/agent-registry.interface.ts
@@ -85,7 +85,7 @@ export interface IAgentRegistry {
    * @param name - The unique agent name (e.g., 'analyze-repository')
    * @returns The agent definition, or undefined if not registered
    */
-  get(name: string): AgentDefinitionWithFactory | undefined;
+  get(name: string): Promise<AgentDefinitionWithFactory | undefined>;
 
   /**
    * List all registered agent definitions.

--- a/packages/core/src/application/use-cases/agents/run-agent.use-case.ts
+++ b/packages/core/src/application/use-cases/agents/run-agent.use-case.ts
@@ -52,7 +52,7 @@ export class RunAgentUseCase {
    * @throws Error if the agent name is not registered
    */
   async execute(input: RunAgentInput): Promise<AgentRun> {
-    const definition = this.agentRegistry.get(input.agentName);
+    const definition = await this.agentRegistry.get(input.agentName);
     if (!definition) {
       const available = this.agentRegistry.list().map((a) => a.name);
       throw new Error(
@@ -71,7 +71,7 @@ export class RunAgentUseCase {
    * @throws Error if the agent name is not registered
    */
   async *executeStream(input: RunAgentInput): AsyncIterable<AgentRunEvent> {
-    const definition = this.agentRegistry.get(input.agentName);
+    const definition = await this.agentRegistry.get(input.agentName);
     if (!definition) {
       const available = this.agentRegistry.list().map((a) => a.name);
       throw new Error(

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -33,7 +33,6 @@ import { execFile } from 'node:child_process';
 import type { IVersionService } from '../../application/ports/output/services/version-service.interface.js';
 import { VersionService } from '../services/version.service.js';
 import type { IWebServerService } from '../../application/ports/output/services/web-server-service.interface.js';
-import { WebServerService } from '../services/web-server.service.js';
 import type { IWorktreeService } from '../../application/ports/output/services/worktree-service.interface.js';
 import { WorktreeService } from '../services/git/worktree.service.js';
 import type { IToolInstallerService } from '../../application/ports/output/services/tool-installer.service.js';
@@ -72,8 +71,6 @@ import { SpecInitializerService } from '../services/spec/spec-initializer.servic
 import { DesktopNotifier } from '../services/notifications/desktop-notifier.js';
 import { NotificationService } from '../services/notifications/notification.service.js';
 import { getNotificationBus } from '../services/notifications/notification-bus.js';
-import { createCheckpointer } from '../services/agents/common/checkpointer.js';
-import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import { spawn } from 'node:child_process';
 
 // Use cases
@@ -177,8 +174,28 @@ export async function initializeContainer(): Promise<typeof container> {
   // Register services (singletons via @injectable + token)
   container.registerSingleton<IAgentValidator>('IAgentValidator', AgentValidatorService);
   container.registerSingleton<IVersionService>('IVersionService', VersionService);
+  // IWebServerService is registered as a lazy proxy to avoid importing `next`
+  // (~80ms) for non-web commands. The actual service is loaded on first method call.
   container.register<IWebServerService>('IWebServerService', {
-    useFactory: () => new WebServerService(),
+    useFactory: () => {
+      let instance: IWebServerService | null = null;
+      const getInstance = async (): Promise<IWebServerService> => {
+        if (!instance) {
+          const { WebServerService } = await import('../services/web-server.service.js');
+          instance = new WebServerService();
+        }
+        return instance;
+      };
+      return new Proxy({} as IWebServerService, {
+        get: (_target, prop) => {
+          return async (...args: unknown[]) => {
+            const svc = await getInstance();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (svc as any)[prop](...args);
+          };
+        },
+      });
+    },
   });
   container.registerSingleton<IWorktreeService>('IWorktreeService', WorktreeService);
   container.registerSingleton<IToolInstallerService>(
@@ -247,17 +264,14 @@ export async function initializeContainer(): Promise<typeof container> {
     useFactory: () => new AgentRegistryService(),
   });
 
-  container.register('Checkpointer', {
-    useFactory: () => createCheckpointer(':memory:'),
-  });
-
   container.register<IAgentRunner>('IAgentRunner', {
     useFactory: (c) => {
       const registry = c.resolve<IAgentRegistry>('IAgentRegistry');
       const executorProvider = c.resolve<IAgentExecutorProvider>('IAgentExecutorProvider');
-      const checkpointer = c.resolve('Checkpointer') as BaseCheckpointSaver;
       const runRepository = c.resolve<IAgentRunRepository>('IAgentRunRepository');
-      return new AgentRunnerService(registry, executorProvider, checkpointer, runRepository);
+      // Checkpointer is lazy-loaded to avoid ~240ms startup cost from
+      // @langchain/langgraph-checkpoint-sqlite on every CLI invocation.
+      return new AgentRunnerService(registry, executorProvider, runRepository);
     },
   });
 

--- a/packages/core/src/infrastructure/services/agents/common/agent-registry.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-registry.service.ts
@@ -12,36 +12,82 @@ import type {
   IAgentRegistry,
   AgentDefinitionWithFactory,
 } from '@/application/ports/output/agents/agent-registry.interface.js';
-import { createAnalyzeRepositoryGraph } from '../analyze-repo/analyze-repository-graph.js';
-import { createFeatureAgentGraph } from '../feature-agent/feature-agent-graph.js';
+
+/**
+ * Lazy agent definition. The graphFactory is loaded on first access via
+ * dynamic import, avoiding the ~300ms @langchain/langgraph import at startup.
+ */
+interface LazyAgentDefinition {
+  name: string;
+  description: string;
+  importFn: () => Promise<Record<string, unknown>>;
+  factoryExport: string;
+  /** Cached placeholder definition for list() — avoids creating new objects each call */
+  placeholder?: AgentDefinitionWithFactory;
+}
 
 export class AgentRegistryService implements IAgentRegistry {
   private readonly agents = new Map<string, AgentDefinitionWithFactory>();
+  private readonly lazyAgents: LazyAgentDefinition[] = [];
 
   constructor() {
-    // Register built-in agents
-    this.register({
-      name: 'analyze-repository',
-      description: 'Analyze repository structure, dependencies, and architecture',
-      graphFactory: createAnalyzeRepositoryGraph,
-    });
+    // Register built-in agents as lazy definitions to avoid importing
+    // @langchain/langgraph (~300ms) at CLI startup.
+    this.lazyAgents.push(
+      {
+        name: 'analyze-repository',
+        description: 'Analyze repository structure, dependencies, and architecture',
+        importFn: () => import('../analyze-repo/analyze-repository-graph.js'),
+        factoryExport: 'createAnalyzeRepositoryGraph',
+      },
+      {
+        name: 'feature-agent',
+        description: 'Autonomous SDLC agent: analyze → requirements → research → plan → implement',
+        importFn: () => import('../feature-agent/feature-agent-graph.js'),
+        factoryExport: 'createFeatureAgentGraph',
+      }
+    );
+  }
 
-    this.register({
-      name: 'feature-agent',
-      description: 'Autonomous SDLC agent: analyze → requirements → research → plan → implement',
-      graphFactory: createFeatureAgentGraph,
-    });
+  private async resolveLazy(name: string): Promise<AgentDefinitionWithFactory | undefined> {
+    const lazy = this.lazyAgents.find((a) => a.name === name);
+    if (!lazy) return undefined;
+    const mod = await lazy.importFn();
+    const definition: AgentDefinitionWithFactory = {
+      name: lazy.name,
+      description: lazy.description,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      graphFactory: mod[lazy.factoryExport] as (...args: any[]) => any,
+    };
+    this.agents.set(name, definition);
+    return definition;
   }
 
   register(definition: AgentDefinitionWithFactory): void {
     this.agents.set(definition.name, definition);
   }
 
-  get(name: string): AgentDefinitionWithFactory | undefined {
-    return this.agents.get(name);
+  async get(name: string): Promise<AgentDefinitionWithFactory | undefined> {
+    const eager = this.agents.get(name);
+    if (eager) return eager;
+    return this.resolveLazy(name);
   }
 
   list(): AgentDefinitionWithFactory[] {
-    return Array.from(this.agents.values());
+    // Returns eagerly-registered + cached placeholder metadata for lazy agents.
+    const all = new Map(this.agents);
+    for (const lazy of this.lazyAgents) {
+      if (!all.has(lazy.name)) {
+        lazy.placeholder ??= {
+          name: lazy.name,
+          description: lazy.description,
+          graphFactory: () => {
+            throw new Error(`Agent '${lazy.name}' must be resolved via get() before use`);
+          },
+        };
+        all.set(lazy.name, lazy.placeholder);
+      }
+    }
+    return Array.from(all.values());
   }
 }

--- a/packages/core/src/infrastructure/services/agents/common/agent-runner.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-runner.service.ts
@@ -23,11 +23,24 @@ import { getSettings } from '@/infrastructure/services/settings.service.js';
 import { EventChannel } from '../streaming/event-channel.js';
 import { StreamingExecutorProxy } from '../streaming/streaming-executor-proxy.js';
 
+/**
+ * Lazy-loads the checkpointer to avoid ~240ms startup cost from
+ * @langchain/langgraph-checkpoint-sqlite on every CLI invocation.
+ * The import only happens when an agent is actually run.
+ */
+let _checkpointer: BaseCheckpointSaver | null = null;
+async function getCheckpointer(): Promise<BaseCheckpointSaver> {
+  if (!_checkpointer) {
+    const { createCheckpointer } = await import('./checkpointer.js');
+    _checkpointer = createCheckpointer(':memory:');
+  }
+  return _checkpointer;
+}
+
 export class AgentRunnerService implements IAgentRunner {
   constructor(
     private readonly registry: IAgentRegistry,
     private readonly executorProvider: IAgentExecutorProvider,
-    private readonly checkpointer: BaseCheckpointSaver,
     private readonly runRepository: IAgentRunRepository
   ) {}
 
@@ -35,7 +48,8 @@ export class AgentRunnerService implements IAgentRunner {
     const { definition, executor, runId, threadId } = await this.setupRun(agentName, prompt);
 
     try {
-      const compiledGraph = definition.graphFactory(executor, this.checkpointer);
+      const checkpointer = await getCheckpointer();
+      const compiledGraph = definition.graphFactory(executor, checkpointer);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (compiledGraph as any).invoke(
         { repositoryPath: options?.repositoryPath ?? process.cwd() },
@@ -62,7 +76,8 @@ export class AgentRunnerService implements IAgentRunner {
     const proxy = new StreamingExecutorProxy(executor, channel);
 
     // Compile graph with proxy (graph doesn't know about streaming)
-    const compiledGraph = definition.graphFactory(proxy, this.checkpointer);
+    const checkpointer = await getCheckpointer();
+    const compiledGraph = definition.graphFactory(proxy, checkpointer);
 
     // Start graph invocation in background
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -95,7 +110,7 @@ export class AgentRunnerService implements IAgentRunner {
   }
 
   private async setupRun(agentName: string, prompt: string) {
-    const definition = this.registry.get(agentName);
+    const definition = await this.registry.get(agentName);
     if (!definition) {
       throw new Error(
         `Agent '${agentName}' not found. Available: ${this.registry

--- a/src/presentation/cli/index.ts
+++ b/src/presentation/cli/index.ts
@@ -61,7 +61,6 @@ import { initializeContainer, container } from '@/infrastructure/di/container.js
 import { InitializeSettingsUseCase } from '@/application/use-cases/settings/initialize-settings.use-case.js';
 import { initializeSettings } from '@/infrastructure/services/settings.service.js';
 import { CheckOnboardingStatusUseCase } from '@/application/use-cases/settings/check-onboarding-status.use-case.js';
-import { onboardingWizard } from '../tui/wizards/onboarding/onboarding.wizard.js';
 
 /**
  * Bootstrap function - initializes all dependencies before CLI starts.
@@ -97,6 +96,8 @@ async function bootstrap() {
       const onboardingCheck = new CheckOnboardingStatusUseCase();
       const { isComplete } = await onboardingCheck.execute();
       if (!isComplete) {
+        // Lazy-import to avoid ~460ms startup cost when onboarding is already complete
+        const { onboardingWizard } = await import('../tui/wizards/onboarding/onboarding.wizard.js');
         await onboardingWizard();
       }
     }

--- a/tests/integration/infrastructure/services/agents/agent-infrastructure.test.ts
+++ b/tests/integration/infrastructure/services/agents/agent-infrastructure.test.ts
@@ -20,7 +20,6 @@ import { SQLiteAgentRunRepository } from '@/infrastructure/repositories/agent-ru
 import { AgentExecutorFactory } from '@/infrastructure/services/agents/common/agent-executor-factory.service.js';
 import { AgentRegistryService } from '@/infrastructure/services/agents/common/agent-registry.service.js';
 import { AgentRunnerService } from '@/infrastructure/services/agents/common/agent-runner.service.js';
-import { createCheckpointer } from '@/infrastructure/services/agents/common/checkpointer.js';
 import { RunAgentUseCase } from '@/application/use-cases/agents/run-agent.use-case.js';
 
 // Port interfaces
@@ -30,7 +29,6 @@ import type { IAgentExecutorProvider } from '@/application/ports/output/agents/a
 import type { IAgentRegistry } from '@/application/ports/output/agents/agent-registry.interface.js';
 import type { IAgentRunner } from '@/application/ports/output/agents/agent-runner.interface.js';
 import type { ISettingsRepository } from '@/application/ports/output/repositories/settings.repository.interface.js';
-import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import { AgentExecutorProvider } from '@/infrastructure/services/agents/common/agent-executor-provider.service.js';
 
 import { runSQLiteMigrations } from '@/infrastructure/persistence/sqlite/migrations.js';
@@ -60,10 +58,6 @@ describe('Agent Infrastructure Integration', () => {
       useFactory: () => new AgentRegistryService(),
     });
 
-    container.register('Checkpointer', {
-      useFactory: () => createCheckpointer(':memory:'),
-    });
-
     container.register<ISettingsRepository>('ISettingsRepository', {
       useValue: {
         load: async () => ({ agent: { type: 'claude-code', authMethod: 'session' } }),
@@ -86,9 +80,8 @@ describe('Agent Infrastructure Integration', () => {
       useFactory: (c) => {
         const registry = c.resolve<IAgentRegistry>('IAgentRegistry');
         const executorProvider = c.resolve<IAgentExecutorProvider>('IAgentExecutorProvider');
-        const checkpointer = c.resolve('Checkpointer') as BaseCheckpointSaver;
         const runRepository = c.resolve<IAgentRunRepository>('IAgentRunRepository');
-        return new AgentRunnerService(registry, executorProvider, checkpointer, runRepository);
+        return new AgentRunnerService(registry, executorProvider, runRepository);
       },
     });
 
@@ -132,9 +125,9 @@ describe('Agent Infrastructure Integration', () => {
   });
 
   describe('Agent Registry', () => {
-    it('should have analyze-repository agent with graph factory', () => {
+    it('should have analyze-repository agent with graph factory', async () => {
       const registry = container.resolve<IAgentRegistry>('IAgentRegistry');
-      const definition = registry.get('analyze-repository');
+      const definition = await registry.get('analyze-repository');
 
       expect(definition).toBeDefined();
       expect(definition!.name).toBe('analyze-repository');
@@ -142,7 +135,7 @@ describe('Agent Infrastructure Integration', () => {
       expect(typeof definition!.graphFactory).toBe('function');
     });
 
-    it('should allow registering custom agents', () => {
+    it('should allow registering custom agents', async () => {
       const registry = container.resolve<IAgentRegistry>('IAgentRegistry');
       const before = registry.list().length;
 
@@ -153,7 +146,7 @@ describe('Agent Infrastructure Integration', () => {
       });
 
       expect(registry.list().length).toBe(before + 1);
-      expect(registry.get('test-agent')).toBeDefined();
+      expect(await registry.get('test-agent')).toBeDefined();
     });
   });
 

--- a/tests/unit/application/ports/agent-runtime.interface.test.ts
+++ b/tests/unit/application/ports/agent-runtime.interface.test.ts
@@ -104,7 +104,7 @@ describe('IAgentRegistry type contracts', () => {
     const mockRegistry: IAgentRegistry = {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       register: (_def) => {},
-      get: (_name) => undefined,
+      get: async (_name) => undefined,
       list: () => [],
     };
     expect(mockRegistry.register).toBeDefined();
@@ -123,14 +123,14 @@ describe('IAgentRegistry type contracts', () => {
     expect(def.graphFactory).toBeDefined();
   });
 
-  it('should return undefined for unregistered agent names', () => {
+  it('should return undefined for unregistered agent names', async () => {
     const mockRegistry: IAgentRegistry = {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       register: () => {},
-      get: () => undefined,
+      get: async () => undefined,
       list: () => [],
     };
-    expect(mockRegistry.get('nonexistent')).toBeUndefined();
+    expect(await mockRegistry.get('nonexistent')).toBeUndefined();
   });
 
   it('should return registered agents from list', () => {
@@ -149,7 +149,7 @@ describe('IAgentRegistry type contracts', () => {
     const mockRegistry: IAgentRegistry = {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       register: () => {},
-      get: (name) => defs.find((d) => d.name === name),
+      get: async (name) => defs.find((d) => d.name === name),
       list: () => defs,
     };
     expect(mockRegistry.list()).toHaveLength(2);
@@ -157,7 +157,7 @@ describe('IAgentRegistry type contracts', () => {
     expect(mockRegistry.list()[1].name).toBe('gather-requirements');
   });
 
-  it('should retrieve a registered agent by name', () => {
+  it('should retrieve a registered agent by name', async () => {
     const def: AgentDefinitionWithFactory = {
       name: 'implement-feature',
       description: 'Implement a feature from a plan',
@@ -166,10 +166,10 @@ describe('IAgentRegistry type contracts', () => {
     const mockRegistry: IAgentRegistry = {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       register: () => {},
-      get: (name) => (name === 'implement-feature' ? def : undefined),
+      get: async (name) => (name === 'implement-feature' ? def : undefined),
       list: () => [def],
     };
-    const found = mockRegistry.get('implement-feature');
+    const found = await mockRegistry.get('implement-feature');
     expect(found).toBeDefined();
     expect(found?.name).toBe('implement-feature');
     expect(found?.graphFactory()).toEqual({ nodes: [] });

--- a/tests/unit/application/use-cases/agents/run-agent.use-case.test.ts
+++ b/tests/unit/application/use-cases/agents/run-agent.use-case.test.ts
@@ -64,8 +64,8 @@ describe('RunAgentUseCase', () => {
     mockRegistry = {
       register: vi.fn(),
       get: vi
-        .fn<(name: string) => AgentDefinitionWithFactory | undefined>()
-        .mockReturnValue(createMockDefinition('analyze-repository')),
+        .fn<(name: string) => Promise<AgentDefinitionWithFactory | undefined>>()
+        .mockResolvedValue(createMockDefinition('analyze-repository')),
       list: vi
         .fn<() => AgentDefinitionWithFactory[]>()
         .mockReturnValue([createMockDefinition('analyze-repository')]),
@@ -123,7 +123,7 @@ describe('RunAgentUseCase', () => {
 
   describe('agent not found', () => {
     it('should throw error when agent name is not found in registry', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
 
       await expect(
         useCase.execute({
@@ -136,7 +136,7 @@ describe('RunAgentUseCase', () => {
     });
 
     it('should include available agents in error message', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
       vi.mocked(mockRegistry.list).mockReturnValue([
         createMockDefinition('analyze-repository'),
         createMockDefinition('gather-requirements'),
@@ -151,7 +151,7 @@ describe('RunAgentUseCase', () => {
     });
 
     it('should handle empty agent list in error message', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
       vi.mocked(mockRegistry.list).mockReturnValue([]);
 
       await expect(
@@ -179,7 +179,7 @@ describe('RunAgentUseCase', () => {
     });
 
     it('should validate agent exists before streaming', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
 
       const streamFn = async () => {
         for await (const _event of useCase.executeStream({

--- a/tests/unit/infrastructure/services/agents/agent-registry.service.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-registry.service.test.ts
@@ -19,8 +19,8 @@ describe('AgentRegistryService', () => {
   });
 
   describe('constructor', () => {
-    it('should pre-register the analyze-repository agent', () => {
-      const agent = registry.get('analyze-repository');
+    it('should pre-register the analyze-repository agent', async () => {
+      const agent = await registry.get('analyze-repository');
 
       expect(agent).toBeDefined();
       expect(agent!.name).toBe('analyze-repository');
@@ -32,7 +32,7 @@ describe('AgentRegistryService', () => {
   });
 
   describe('register', () => {
-    it('should register a new agent definition', () => {
+    it('should register a new agent definition', async () => {
       const definition: AgentDefinitionWithFactory = {
         name: 'gather-requirements',
         description: 'Gather and refine user requirements',
@@ -41,11 +41,11 @@ describe('AgentRegistryService', () => {
 
       registry.register(definition);
 
-      const result = registry.get('gather-requirements');
+      const result = await registry.get('gather-requirements');
       expect(result).toBe(definition);
     });
 
-    it('should overwrite an existing agent with the same name', () => {
+    it('should overwrite an existing agent with the same name', async () => {
       const original: AgentDefinitionWithFactory = {
         name: 'test-agent',
         description: 'Original',
@@ -60,22 +60,22 @@ describe('AgentRegistryService', () => {
       registry.register(original);
       registry.register(updated);
 
-      const result = registry.get('test-agent');
+      const result = await registry.get('test-agent');
       expect(result).toBe(updated);
       expect(result!.description).toBe('Updated');
     });
   });
 
   describe('get', () => {
-    it('should return a registered agent by name', () => {
-      const agent = registry.get('analyze-repository');
+    it('should return a registered agent by name', async () => {
+      const agent = await registry.get('analyze-repository');
 
       expect(agent).toBeDefined();
       expect(agent!.name).toBe('analyze-repository');
     });
 
-    it('should return undefined for an unknown agent name', () => {
-      const agent = registry.get('non-existent-agent');
+    it('should return undefined for an unknown agent name', async () => {
+      const agent = await registry.get('non-existent-agent');
 
       expect(agent).toBeUndefined();
     });

--- a/tests/unit/infrastructure/services/agents/agent-runner.service.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-runner.service.test.ts
@@ -34,6 +34,12 @@ vi.mock('@/infrastructure/services/settings.service.js', () => ({
   }),
 }));
 
+// Mock the checkpointer module (lazy-loaded by agent-runner)
+const mockCheckpointer = {};
+vi.mock('@/infrastructure/services/agents/common/checkpointer.js', () => ({
+  createCheckpointer: vi.fn().mockReturnValue(mockCheckpointer),
+}));
+
 // UUID regex for non-deterministic ID assertions
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
@@ -41,7 +47,6 @@ describe('AgentRunnerService', () => {
   let runner: AgentRunnerService;
   let mockRegistry: IAgentRegistry;
   let mockExecutorProvider: IAgentExecutorProvider;
-  let mockCheckpointer: any;
   let mockRunRepository: IAgentRunRepository;
   let mockExecutor: IAgentExecutor;
   let mockCompiledGraph: any;
@@ -70,15 +75,13 @@ describe('AgentRunnerService', () => {
 
     mockRegistry = {
       register: vi.fn(),
-      get: vi.fn().mockReturnValue(mockDefinition),
+      get: vi.fn().mockResolvedValue(mockDefinition),
       list: vi.fn().mockReturnValue([mockDefinition]),
     };
 
     mockExecutorProvider = {
       getExecutor: vi.fn().mockReturnValue(mockExecutor),
     };
-
-    mockCheckpointer = {};
 
     const storedRuns = new Map<string, AgentRun>();
     mockRunRepository = {
@@ -104,12 +107,7 @@ describe('AgentRunnerService', () => {
       delete: vi.fn().mockResolvedValue(undefined),
     };
 
-    runner = new AgentRunnerService(
-      mockRegistry,
-      mockExecutorProvider,
-      mockCheckpointer,
-      mockRunRepository
-    );
+    runner = new AgentRunnerService(mockRegistry, mockExecutorProvider, mockRunRepository);
   });
 
   describe('runAgent', () => {
@@ -208,7 +206,7 @@ describe('AgentRunnerService', () => {
     });
 
     it('should throw error when agent is not found', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
 
       await expect(runner.runAgent('non-existent', 'Analyze')).rejects.toThrow(
         "Agent 'non-existent' not found"
@@ -216,7 +214,7 @@ describe('AgentRunnerService', () => {
     });
 
     it('should include available agents in not-found error message', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
 
       await expect(runner.runAgent('non-existent', 'Analyze')).rejects.toThrow(
         'analyze-repository'
@@ -393,7 +391,7 @@ describe('AgentRunnerService', () => {
     });
 
     it('should throw for unknown agent name', async () => {
-      vi.mocked(mockRegistry.get).mockReturnValue(undefined);
+      vi.mocked(mockRegistry.get).mockResolvedValue(undefined);
 
       const streamFn = async () => {
         for await (const _event of runner.runAgentStream('non-existent', 'Analyze')) {


### PR DESCRIPTION
## Summary

- Defer `@langchain/langgraph` (~300ms), `@langchain/langgraph-checkpoint-sqlite` (~240ms), `next` (~80ms), and onboarding wizard (~460ms) imports until actually needed
- Agent registry uses dynamic `import()` resolved on first `get()` call — `IAgentRegistry.get()` is now async
- Checkpointer lazy-loads on first agent run instead of at DI container init
- `WebServerService` uses a Proxy for lazy instantiation (only loaded when `shep ui` is run)
- Onboarding wizard imports inline (only when onboarding is incomplete)

**Results:** ~200-300ms faster per CLI invocation, ~21s faster across the e2e:cli suite (217s → 196s)

## Test plan

- [x] `pnpm build:cli` succeeds
- [x] `pnpm vitest run --changed` — 478 tests pass
- [x] `pnpm test:e2e:cli` — 82 tests pass
- [x] `pnpm test:e2e:web` — 6 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)