### PR TITLE
fix(web): fix deep tree layout and align sidebar status with canvas nodes

### DIFF
--- a/src/presentation/web/components/common/feature-list-item/feature-list-item.stories.tsx
+++ b/src/presentation/web/components/common/feature-list-item/feature-list-item.stories.tsx
@@ -52,6 +52,24 @@ export const Done: Story = {
   },
 };
 
+export const Blocked: Story = {
+  args: {
+    name: 'Dependency Resolver',
+    status: 'blocked',
+    agentType: 'claude-code',
+    modelId: 'claude-sonnet-4-6',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    name: 'Broken Pipeline',
+    status: 'error',
+    agentType: 'cursor',
+    modelId: 'claude-opus-4-6',
+  },
+};
+
 export const WithClickHandler: Story = {
   args: {
     name: 'API Gateway',

--- a/src/presentation/web/components/common/feature-status-badges/feature-status-badges.stories.tsx
+++ b/src/presentation/web/components/common/feature-status-badges/feature-status-badges.stories.tsx
@@ -25,36 +25,36 @@ type Story = StoryObj<typeof meta>;
 
 export const AllStatuses: Story = {
   args: {
-    counts: { 'action-needed': 2, 'in-progress': 3, done: 5 },
+    counts: { 'action-needed': 2, 'in-progress': 3, blocked: 1, error: 1, done: 5 },
   },
 };
 
 export const ActionNeededOnly: Story = {
   args: {
-    counts: { 'action-needed': 4, 'in-progress': 0, done: 0 },
+    counts: { 'action-needed': 4, 'in-progress': 0, blocked: 0, error: 0, done: 0 },
   },
 };
 
 export const InProgressOnly: Story = {
   args: {
-    counts: { 'action-needed': 0, 'in-progress': 2, done: 0 },
+    counts: { 'action-needed': 0, 'in-progress': 2, blocked: 0, error: 0, done: 0 },
   },
 };
 
 export const DoneOnly: Story = {
   args: {
-    counts: { 'action-needed': 0, 'in-progress': 0, done: 7 },
+    counts: { 'action-needed': 0, 'in-progress': 0, blocked: 0, error: 0, done: 7 },
   },
 };
 
 export const LargeCounts: Story = {
   args: {
-    counts: { 'action-needed': 12, 'in-progress': 99, done: 150 },
+    counts: { 'action-needed': 12, 'in-progress': 99, blocked: 5, error: 3, done: 150 },
   },
 };
 
 export const Empty: Story = {
   args: {
-    counts: { 'action-needed': 0, 'in-progress': 0, done: 0 },
+    counts: { 'action-needed': 0, 'in-progress': 0, blocked: 0, error: 0, done: 0 },
   },
 };

--- a/src/presentation/web/components/common/feature-status-config.ts
+++ b/src/presentation/web/components/common/feature-status-config.ts
@@ -1,7 +1,7 @@
-import { CircleAlert, Loader2, CircleCheck } from 'lucide-react';
+import { CircleAlert, Loader2, CircleCheck, Ban, CircleX } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
-export type FeatureStatus = 'action-needed' | 'in-progress' | 'done';
+export type FeatureStatus = 'action-needed' | 'in-progress' | 'blocked' | 'error' | 'done';
 
 export interface FeatureStatusConfig {
   icon: LucideIcon;
@@ -23,6 +23,18 @@ export const featureStatusConfig: Record<FeatureStatus, FeatureStatusConfig> = {
     bgClass: 'bg-blue-500/10',
     label: 'In Progress',
   },
+  blocked: {
+    icon: Ban,
+    iconClass: 'text-gray-400',
+    bgClass: 'bg-gray-400/10',
+    label: 'Blocked',
+  },
+  error: {
+    icon: CircleX,
+    iconClass: 'text-red-500',
+    bgClass: 'bg-red-500/10',
+    label: 'Error',
+  },
   done: {
     icon: CircleCheck,
     iconClass: 'text-emerald-500',
@@ -31,4 +43,10 @@ export const featureStatusConfig: Record<FeatureStatus, FeatureStatusConfig> = {
   },
 };
 
-export const featureStatusOrder: FeatureStatus[] = ['action-needed', 'in-progress', 'done'];
+export const featureStatusOrder: FeatureStatus[] = [
+  'action-needed',
+  'error',
+  'blocked',
+  'in-progress',
+  'done',
+];

--- a/src/presentation/web/hooks/sidebar-features-context.tsx
+++ b/src/presentation/web/hooks/sidebar-features-context.tsx
@@ -17,20 +17,20 @@ export interface SidebarFeatureItem {
 }
 
 // ---------------------------------------------------------------------------
-// Pure mapping: FeatureNodeState (6-state) → FeatureStatus (3-state) | null
+// Pure mapping: FeatureNodeState (6-state) → FeatureStatus (5-state) | null
 // ---------------------------------------------------------------------------
 
 const stateMapping: Record<FeatureNodeState, FeatureStatus | null> = {
   'action-required': 'action-needed',
   running: 'in-progress',
   done: 'done',
-  blocked: 'in-progress',
-  error: 'in-progress',
+  blocked: 'blocked',
+  error: 'error',
   creating: null,
 };
 
 /**
- * Maps a canvas FeatureNodeState to the sidebar's 3-state FeatureStatus.
+ * Maps a canvas FeatureNodeState to the sidebar's 5-state FeatureStatus.
  * Returns `null` for `creating` (optimistic UI) — these should be excluded from the sidebar.
  */
 export function mapNodeStateToSidebarStatus(state: FeatureNodeState): FeatureStatus | null {

--- a/src/presentation/web/lib/layout-with-dagre.ts
+++ b/src/presentation/web/lib/layout-with-dagre.ts
@@ -115,9 +115,16 @@ export function layoutWithDagre<N extends Node>(
     centerMap.set(node.id, { cx: dagreNode.x, cy: dagreNode.y, w: size.width, h: size.height });
   }
 
-  // Post-process: center each group of children around their parent's
-  // secondary-axis center so the edge fans out symmetrically.
-  // Build parent→children map from the edges.
+  // ── Proper tree layout for the secondary axis ──
+  // Dagre gives us correct primary-axis (rank/X) positions but its secondary-
+  // axis (Y) positioning doesn't respect our tree structure well. Replace it
+  // with a bottom-up tree layout:
+  //   1. Compute subtree heights (leaves → roots)
+  //   2. Position children centered on parent (roots → leaves)
+  // This guarantees: no overlaps, parents centered on children, and straight
+  // lines for 1-to-1 connections at every depth.
+
+  // Build parent→children map from edges
   const childrenOf = new Map<string, string[]>();
   for (const edge of edges) {
     if (!centerMap.has(edge.source) || !centerMap.has(edge.target)) continue;
@@ -125,68 +132,82 @@ export function layoutWithDagre<N extends Node>(
     childrenOf.get(edge.source)!.push(edge.target);
   }
 
-  for (const [parentId, childIds] of childrenOf) {
-    if (childIds.length <= 1) continue;
-
-    const parent = centerMap.get(parentId)!;
-    const parentCenter = isHorizontal ? parent.cy : parent.cx;
-
-    // Sort children by their current secondary-axis position
-    const sorted = childIds
-      .filter((id) => centerMap.has(id))
-      .sort((a, b) => {
-        const pa = centerMap.get(a)!;
-        const pb = centerMap.get(b)!;
-        return isHorizontal ? pa.cy - pb.cy : pa.cx - pb.cx;
-      });
-
-    // Compute the current center of the children group
-    const first = centerMap.get(sorted[0])!;
-    const last = centerMap.get(sorted[sorted.length - 1])!;
-    const groupCenter = isHorizontal ? (first.cy + last.cy) / 2 : (first.cx + last.cx) / 2;
-
-    // Shift all children so the group center aligns with the parent center
-    const shift = parentCenter - groupCenter;
-    if (Math.abs(shift) > 1) {
-      for (const childId of sorted) {
-        const c = centerMap.get(childId)!;
-        if (isHorizontal) {
-          c.cy += shift;
-        } else {
-          c.cx += shift;
-        }
-      }
-    }
-  }
-
-  // Enforce input-order within each sibling group so that the caller's
-  // sort (e.g. by createdAt) is respected on the secondary axis.
+  // Sort children by input order (preserves caller's ordering, e.g. createdAt)
   const inputIndex = new Map<string, number>();
   for (let i = 0; i < graphNodes.length; i++) {
     inputIndex.set(graphNodes[i].id, i);
   }
+  for (const [, kids] of childrenOf) {
+    kids.sort((a, b) => (inputIndex.get(a) ?? 0) - (inputIndex.get(b) ?? 0));
+  }
 
-  for (const [, childIds] of childrenOf) {
-    const valid = childIds.filter((id) => centerMap.has(id));
-    if (valid.length <= 1) continue;
+  // Find tree roots (nodes that are parents but not children)
+  const childSet = new Set<string>();
+  for (const ids of childrenOf.values()) {
+    for (const id of ids) childSet.add(id);
+  }
+  // Include leaf nodes that have no children and are not in childrenOf keys
+  const allConnected = new Set(centerMap.keys());
+  const roots = [...allConnected].filter((id) => !childSet.has(id));
 
-    // Collect current secondary-axis positions, sorted ascending
-    const positions = valid
-      .map((id) => (isHorizontal ? centerMap.get(id)!.cy : centerMap.get(id)!.cx))
-      .sort((a, b) => a - b);
-
-    // Sort children by input index (preserves caller's ordering, e.g. createdAt)
-    const byInput = [...valid].sort((a, b) => (inputIndex.get(a) ?? 0) - (inputIndex.get(b) ?? 0));
-
-    // Assign sorted positions in input order
-    for (let i = 0; i < byInput.length; i++) {
-      const c = centerMap.get(byInput[i])!;
-      if (isHorizontal) {
-        c.cy = positions[i];
-      } else {
-        c.cx = positions[i];
-      }
+  // Bottom-up: compute the total secondary-axis span each subtree needs
+  const subtreeSpan = new Map<string, number>();
+  function computeSpan(nodeId: string): number {
+    if (subtreeSpan.has(nodeId)) return subtreeSpan.get(nodeId)!;
+    const c = centerMap.get(nodeId)!;
+    const nodeSpan = isHorizontal ? c.h : c.w;
+    const kids = childrenOf.get(nodeId);
+    if (!kids || kids.length === 0) {
+      subtreeSpan.set(nodeId, nodeSpan);
+      return nodeSpan;
     }
+    let childrenTotalSpan = 0;
+    for (const kid of kids) {
+      childrenTotalSpan += computeSpan(kid);
+    }
+    childrenTotalSpan += (kids.length - 1) * nodesep;
+    const span = Math.max(nodeSpan, childrenTotalSpan);
+    subtreeSpan.set(nodeId, span);
+    return span;
+  }
+
+  for (const root of roots) computeSpan(root);
+
+  // Top-down: position each node on the secondary axis, centering parent
+  // on its children block. For 1-to-1 edges the child gets the same
+  // secondary-axis value as its parent (straight line).
+  function positionTree(nodeId: string, centerPos: number): void {
+    const c = centerMap.get(nodeId)!;
+    if (isHorizontal) {
+      c.cy = centerPos;
+    } else {
+      c.cx = centerPos;
+    }
+    const kids = childrenOf.get(nodeId);
+    if (!kids || kids.length === 0) return;
+
+    // Total span occupied by children
+    let childrenTotalSpan = 0;
+    for (const kid of kids) {
+      childrenTotalSpan += subtreeSpan.get(kid) ?? 0;
+    }
+    childrenTotalSpan += (kids.length - 1) * nodesep;
+
+    // Start from the top of the centered children block
+    let cursor = centerPos - childrenTotalSpan / 2;
+    for (const kid of kids) {
+      const kidSpan = subtreeSpan.get(kid) ?? 0;
+      positionTree(kid, cursor + kidSpan / 2);
+      cursor += kidSpan + nodesep;
+    }
+  }
+
+  // Position each root tree. Stack root trees vertically with nodesep gap.
+  let rootCursor = 0;
+  for (const root of roots) {
+    const span = subtreeSpan.get(root) ?? 0;
+    positionTree(root, rootCursor + span / 2);
+    rootCursor += span + nodesep;
   }
 
   // Build result array converting center-coords to React Flow top-left

--- a/tests/unit/presentation/web/common/feature-status-badges.test.tsx
+++ b/tests/unit/presentation/web/common/feature-status-badges.test.tsx
@@ -10,7 +10,9 @@ function renderWithSidebar(ui: React.ReactElement) {
 describe('FeatureStatusBadges', () => {
   it('renders badges for statuses with counts > 0', () => {
     renderWithSidebar(
-      <FeatureStatusBadges counts={{ 'action-needed': 2, 'in-progress': 3, done: 5 }} />
+      <FeatureStatusBadges
+        counts={{ 'action-needed': 2, 'in-progress': 3, blocked: 0, error: 0, done: 5 }}
+      />
     );
 
     expect(screen.getByTestId('feature-status-badges')).toBeInTheDocument();
@@ -21,7 +23,9 @@ describe('FeatureStatusBadges', () => {
 
   it('displays correct count numbers', () => {
     renderWithSidebar(
-      <FeatureStatusBadges counts={{ 'action-needed': 2, 'in-progress': 3, done: 5 }} />
+      <FeatureStatusBadges
+        counts={{ 'action-needed': 2, 'in-progress': 3, blocked: 0, error: 0, done: 5 }}
+      />
     );
 
     expect(screen.getByText('2')).toBeInTheDocument();
@@ -31,7 +35,9 @@ describe('FeatureStatusBadges', () => {
 
   it('hides statuses with zero count', () => {
     renderWithSidebar(
-      <FeatureStatusBadges counts={{ 'action-needed': 0, 'in-progress': 2, done: 0 }} />
+      <FeatureStatusBadges
+        counts={{ 'action-needed': 0, 'in-progress': 2, blocked: 0, error: 0, done: 0 }}
+      />
     );
 
     expect(screen.queryByTestId('feature-status-badge-action-needed')).not.toBeInTheDocument();
@@ -41,7 +47,9 @@ describe('FeatureStatusBadges', () => {
 
   it('renders nothing when all counts are zero', () => {
     const { container } = renderWithSidebar(
-      <FeatureStatusBadges counts={{ 'action-needed': 0, 'in-progress': 0, done: 0 }} />
+      <FeatureStatusBadges
+        counts={{ 'action-needed': 0, 'in-progress': 0, blocked: 0, error: 0, done: 0 }}
+      />
     );
 
     expect(screen.queryByTestId('feature-status-badges')).not.toBeInTheDocument();
@@ -51,7 +59,7 @@ describe('FeatureStatusBadges', () => {
   it('applies custom className', () => {
     renderWithSidebar(
       <FeatureStatusBadges
-        counts={{ 'action-needed': 1, 'in-progress': 0, done: 0 }}
+        counts={{ 'action-needed': 1, 'in-progress': 0, blocked: 0, error: 0, done: 0 }}
         className="custom-class"
       />
     );

--- a/tests/unit/presentation/web/hooks/sidebar-features-context.test.tsx
+++ b/tests/unit/presentation/web/hooks/sidebar-features-context.test.tsx
@@ -17,8 +17,8 @@ describe('mapNodeStateToSidebarStatus', () => {
     ['action-required', 'action-needed'],
     ['running', 'in-progress'],
     ['done', 'done'],
-    ['blocked', 'in-progress'],
-    ['error', 'in-progress'],
+    ['blocked', 'blocked'],
+    ['error', 'error'],
     ['creating', null],
   ])('maps %s → %s', (input, expected) => {
     expect(mapNodeStateToSidebarStatus(input)).toBe(expected);


### PR DESCRIPTION
## Summary
- **Layout fix**: Replace dagre secondary-axis post-processing with a proper bottom-up tree layout algorithm. Dagre only handles primary-axis (rank/depth) positioning; the new algorithm computes subtree spans bottom-up then positions nodes top-down, guaranteeing no overlaps, parents centered on children, and straight lines for 1-to-1 connections at arbitrary depth.
- **Sidebar status fix**: Expand `FeatureStatus` from 3 states (action-needed, in-progress, done) to 5 by adding `blocked` (gray Ban icon) and `error` (red CircleX icon). Previously both mapped to `in-progress`, causing sidebar indicators to not match canvas node badges.

## Test plan
- [x] All 119 affected tests pass (10 test files)
- [x] Visual verification: 18 blocked features show correct "BLOCKED" group in sidebar
- [x] Tree layout verified with 16 nodes across 7 layers — no overlaps, proper centering
- [ ] Storybook: new `Blocked` and `Error` stories for FeatureListItem render correctly
- [ ] Storybook: FeatureStatusBadges stories include blocked/error counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)