### PR TITLE
fix(web): track pr status in sse cache for merge detection

### DIFF
--- a/src/presentation/web/app/api/agent-events/route.ts
+++ b/src/presentation/web/app/api/agent-events/route.ts
@@ -38,6 +38,7 @@ interface CachedFeatureState {
   lifecycle: string;
   completedPhases: Set<string>;
   featureName: string;
+  prStatus: string | undefined;
   prMergeable: boolean | undefined;
   prCiStatus: string | undefined;
 }
@@ -171,6 +172,7 @@ export function GET(request: Request): Response {
                   lifecycle: feature.lifecycle,
                   completedPhases,
                   featureName: feature.name,
+                  prStatus: feature.pr?.status,
                   prMergeable: feature.pr?.mergeable,
                   prCiStatus: feature.pr?.ciStatus,
                 });
@@ -231,10 +233,16 @@ export function GET(request: Request): Response {
                 }
               }
 
-              // Check for PR data changes (mergeable / CI status)
+              // Check for PR data changes (status / mergeable / CI status)
+              const curPrStatus = feature.pr?.status;
               const curMergeable = feature.pr?.mergeable;
               const curCiStatus = feature.pr?.ciStatus;
-              if (curMergeable !== prev.prMergeable || curCiStatus !== prev.prCiStatus) {
+              if (
+                curPrStatus !== prev.prStatus ||
+                curMergeable !== prev.prMergeable ||
+                curCiStatus !== prev.prCiStatus
+              ) {
+                prev.prStatus = curPrStatus;
                 prev.prMergeable = curMergeable;
                 prev.prCiStatus = curCiStatus;
                 const nodeName = LIFECYCLE_TO_NODE[feature.lifecycle as SdlcLifecycle] ?? 'merge';


### PR DESCRIPTION
## Summary
- The SSE route's `CachedFeatureState` tracked `prMergeable` and `prCiStatus` but **not `pr.status`** (Open/Merged/Closed)
- When `PrSyncWatcherService` updated a feature's PR status from Open to Merged in the DB, the SSE route never detected the change and never emitted an event to the UI
- Added `prStatus` to the cache interface, seed, and delta check so Open→Merged/Closed transitions are now propagated in real-time

## Test plan
- [ ] Start a feature, let it reach Review with an open PR
- [ ] Merge the PR on GitHub
- [ ] Verify the UI updates the PR badge from "Open" to "Merged" within ~30s (PrSyncWatcher poll) without needing a page refresh
- [ ] Verify server logs show `[SSE] emit: PhaseCompleted` with "PR status updated" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)