### PR TITLE
fix(agents): pass cwd to getFailureLogs to prevent ci watch failure in worktrees

### DIFF
--- a/packages/core/src/application/ports/output/services/git-pr-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/git-pr-service.interface.ts
@@ -319,11 +319,12 @@ export interface IGitPrService {
    * Output is truncated to the first `logMaxChars` characters (head truncation).
    * A notice is appended when truncation occurs.
    *
+   * @param cwd - Working directory (must be inside a git repo so gh can resolve the remote)
    * @param runId - GitHub Actions run ID (numeric string)
    * @param branch - Branch name (informational, used in truncation notice)
    * @param logMaxChars - Maximum characters to return (default 50_000)
    * @returns Truncated failure log output
    * @throws GitPrError with GH_NOT_FOUND or GIT_ERROR code on failure
    */
-  getFailureLogs(runId: string, branch: string, logMaxChars?: number): Promise<string>;
+  getFailureLogs(cwd: string, runId: string, branch: string, logMaxChars?: number): Promise<string>;
 }

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/ci-watch-fix-loop.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/ci-watch-fix-loop.ts
@@ -132,7 +132,7 @@ export async function runCiWatchFixLoop(
 
     // Fetch failure logs
     const runId = extractRunId(runUrl) ?? '';
-    const failureLogs = await gitPrService.getFailureLogs(runId, branch, logMaxChars);
+    const failureLogs = await gitPrService.getFailureLogs(cwd, runId, branch, logMaxChars);
     const startedAt = new Date().toISOString();
 
     log.info(`CI fix attempt ${ciFixAttempts + 1}/${maxAttempts} for run ${runId}`);

--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -530,10 +530,15 @@ export class GitPrService implements IGitPrService {
     }
   }
 
-  async getFailureLogs(runId: string, _branch: string, logMaxChars = 50_000): Promise<string> {
+  async getFailureLogs(
+    cwd: string,
+    runId: string,
+    _branch: string,
+    logMaxChars = 50_000
+  ): Promise<string> {
     try {
       const { stdout } = await this.execFile('gh', ['run', 'view', runId, '--log-failed'], {
-        cwd: undefined,
+        cwd,
       });
       return this.truncateLog(stdout, logMaxChars, runId);
     } catch (error) {

--- a/tests/integration/services/git/git-pr.service.getFailureLogs.test.ts
+++ b/tests/integration/services/git/git-pr.service.getFailureLogs.test.ts
@@ -56,14 +56,14 @@ describe('GitPrService.getFailureLogs (integration)', () => {
   });
 
   describe('gh command invocation', () => {
-    it('calls gh with run view <runId> --log-failed and no cwd', async () => {
+    it('calls gh with run view <runId> --log-failed and the given cwd', async () => {
       vi.mocked(mockExec).mockResolvedValue({ stdout: REALISTIC_TYPECHECK_FAILURE, stderr: '' });
 
-      await service.getFailureLogs('9876543210', 'feat/ci-watch-fix-loop');
+      await service.getFailureLogs('/tmp/test', '9876543210', 'feat/ci-watch-fix-loop');
 
       expect(mockExec).toHaveBeenCalledOnce();
       expect(mockExec).toHaveBeenCalledWith('gh', ['run', 'view', '9876543210', '--log-failed'], {
-        cwd: undefined,
+        cwd: '/tmp/test',
       });
     });
 
@@ -71,7 +71,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
       vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
       const runId = '1234567890987654321';
 
-      await service.getFailureLogs(runId, 'main');
+      await service.getFailureLogs('/tmp/test', runId, 'main');
 
       const callArgs = vi.mocked(mockExec).mock.calls[0];
       expect(callArgs[1]).toContain(runId);
@@ -86,7 +86,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
         stderr: '',
       });
 
-      const result = await service.getFailureLogs('9876543210', 'feat/branch');
+      const result = await service.getFailureLogs('/tmp/test', '9876543210', 'feat/branch');
 
       expect(result).toBe(REALISTIC_TYPECHECK_FAILURE);
       expect(result).not.toContain('[Log truncated');
@@ -98,7 +98,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
         stderr: '',
       });
 
-      const result = await service.getFailureLogs('1122334455', 'feat/branch');
+      const result = await service.getFailureLogs('/tmp/test', '1122334455', 'feat/branch');
 
       expect(result).toBe(REALISTIC_LINT_FAILURE);
       expect(result).not.toContain('[Log truncated');
@@ -107,7 +107,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
     it('returns empty string when gh exits with code 0 and no output', async () => {
       vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
 
-      const result = await service.getFailureLogs('5544332211', 'feat/no-failures');
+      const result = await service.getFailureLogs('/tmp/test', '5544332211', 'feat/no-failures');
 
       expect(result).toBe('');
     });
@@ -124,7 +124,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
 
       vi.mocked(mockExec).mockResolvedValue({ stdout: longLog, stderr: '' });
 
-      const result = await service.getFailureLogs('7788990011', 'feat/flaky-tests');
+      const result = await service.getFailureLogs('/tmp/test', '7788990011', 'feat/flaky-tests');
 
       expect(result.length).toBeGreaterThan(50_000); // includes the notice
       expect(result.startsWith(longLog.slice(0, 50_000))).toBe(true);
@@ -137,7 +137,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
       const log = 'X'.repeat(200);
       vi.mocked(mockExec).mockResolvedValue({ stdout: log, stderr: '' });
 
-      const result = await service.getFailureLogs('1234567890', 'feat/branch', 100);
+      const result = await service.getFailureLogs('/tmp/test', '1234567890', 'feat/branch', 100);
 
       expect(result).toBe(
         `${'X'.repeat(
@@ -150,7 +150,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
       const log = 'A'.repeat(50_000);
       vi.mocked(mockExec).mockResolvedValue({ stdout: log, stderr: '' });
 
-      const result = await service.getFailureLogs('9999999999', 'feat/exact');
+      const result = await service.getFailureLogs('/tmp/test', '9999999999', 'feat/exact');
 
       expect(result).toBe(log);
       expect(result).not.toContain('[Log truncated');
@@ -163,9 +163,13 @@ describe('GitPrService.getFailureLogs (integration)', () => {
       (notFoundError as NodeJS.ErrnoException).code = 'ENOENT';
       vi.mocked(mockExec).mockRejectedValue(notFoundError);
 
-      await expect(service.getFailureLogs('9876543210', 'feat/branch')).rejects.toThrow(GitPrError);
+      await expect(
+        service.getFailureLogs('/tmp/test', '9876543210', 'feat/branch')
+      ).rejects.toThrow(GitPrError);
 
-      await expect(service.getFailureLogs('9876543210', 'feat/branch')).rejects.toMatchObject({
+      await expect(
+        service.getFailureLogs('/tmp/test', '9876543210', 'feat/branch')
+      ).rejects.toMatchObject({
         code: GitPrErrorCode.GH_NOT_FOUND,
       });
     });
@@ -176,7 +180,9 @@ describe('GitPrService.getFailureLogs (integration)', () => {
       );
       vi.mocked(mockExec).mockRejectedValue(execError);
 
-      await expect(service.getFailureLogs('9876543210', 'feat/branch')).rejects.toMatchObject({
+      await expect(
+        service.getFailureLogs('/tmp/test', '9876543210', 'feat/branch')
+      ).rejects.toMatchObject({
         code: GitPrErrorCode.GIT_ERROR,
       });
     });
@@ -187,7 +193,7 @@ describe('GitPrService.getFailureLogs (integration)', () => {
 
       let thrown: GitPrError | undefined;
       try {
-        await service.getFailureLogs('12345', 'feat/branch');
+        await service.getFailureLogs('/tmp/test', '12345', 'feat/branch');
       } catch (e) {
         thrown = e as GitPrError;
       }

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.ci-watch.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/merge.node.ci-watch.test.ts
@@ -416,6 +416,7 @@ describe('createMergeNode — CI watch/fix loop', () => {
       await node(baseState({ push: true }));
 
       expect(deps.gitPrService.getFailureLogs).toHaveBeenCalledWith(
+        '/tmp/worktree',
         '99999',
         expect.any(String),
         expect.any(Number)
@@ -740,6 +741,7 @@ describe('createMergeNode — CI watch/fix loop', () => {
       await node(baseState({ push: true }));
 
       expect(deps.gitPrService.getFailureLogs).toHaveBeenCalledWith(
+        '/tmp/worktree',
         expect.any(String),
         expect.any(String),
         25_000

--- a/tests/unit/infrastructure/services/git/git-pr.service.getFailureLogs.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.getFailureLogs.test.ts
@@ -33,10 +33,10 @@ describe('GitPrService.getFailureLogs', () => {
     const shortLog = 'Error: some test failed\n  at test.ts:10:5\n';
     vi.mocked(mockExec).mockResolvedValue({ stdout: shortLog, stderr: '' });
 
-    const result = await service.getFailureLogs('12345', 'feat/my-branch', 50_000);
+    const result = await service.getFailureLogs('/tmp/test', '12345', 'feat/my-branch', 50_000);
 
     expect(mockExec).toHaveBeenCalledWith('gh', ['run', 'view', '12345', '--log-failed'], {
-      cwd: undefined,
+      cwd: '/tmp/test',
     });
     expect(result).toBe(shortLog);
   });
@@ -45,7 +45,7 @@ describe('GitPrService.getFailureLogs', () => {
     const longLog = 'A'.repeat(100);
     vi.mocked(mockExec).mockResolvedValue({ stdout: longLog, stderr: '' });
 
-    const result = await service.getFailureLogs('99999', 'feat/my-branch', 50);
+    const result = await service.getFailureLogs('/tmp/test', '99999', 'feat/my-branch', 50);
 
     expect(result).toBe(
       `${'A'.repeat(50)}\n[Log truncated at 50 chars — full log available via gh run view 99999]`
@@ -56,7 +56,7 @@ describe('GitPrService.getFailureLogs', () => {
     const shortLog = 'short log output';
     vi.mocked(mockExec).mockResolvedValue({ stdout: shortLog, stderr: '' });
 
-    const result = await service.getFailureLogs('11111', 'feat/branch');
+    const result = await service.getFailureLogs('/tmp/test', '11111', 'feat/branch');
 
     expect(result).toBe(shortLog);
   });
@@ -66,17 +66,23 @@ describe('GitPrService.getFailureLogs', () => {
     (execError as NodeJS.ErrnoException).code = 'ENOENT';
     vi.mocked(mockExec).mockRejectedValue(execError);
 
-    await expect(service.getFailureLogs('12345', 'feat/branch')).rejects.toThrow(GitPrError);
-    await expect(service.getFailureLogs('12345', 'feat/branch')).rejects.toMatchObject({
-      code: GitPrErrorCode.GH_NOT_FOUND,
-    });
+    await expect(service.getFailureLogs('/tmp/test', '12345', 'feat/branch')).rejects.toThrow(
+      GitPrError
+    );
+    await expect(service.getFailureLogs('/tmp/test', '12345', 'feat/branch')).rejects.toMatchObject(
+      {
+        code: GitPrErrorCode.GH_NOT_FOUND,
+      }
+    );
   });
 
   it('should throw GitPrError with GIT_ERROR on generic gh failure', async () => {
     vi.mocked(mockExec).mockRejectedValue(new Error('gh run view failed: run not found'));
 
-    await expect(service.getFailureLogs('12345', 'feat/branch')).rejects.toMatchObject({
-      code: GitPrErrorCode.GIT_ERROR,
-    });
+    await expect(service.getFailureLogs('/tmp/test', '12345', 'feat/branch')).rejects.toMatchObject(
+      {
+        code: GitPrErrorCode.GIT_ERROR,
+      }
+    );
   });
 });


### PR DESCRIPTION
## Summary

- `getFailureLogs` was passing `cwd: undefined` to `execFile`, causing `gh run view` to fail with `no git remotes found` when the process cwd pointed to a cleaned-up worktree
- Added `cwd` as the first parameter to `getFailureLogs` (interface + implementation), consistent with all other `GitPrService` methods
- Updated the CI watch/fix loop caller to forward `cwd` from its params

## Test plan

- [x] All 3686 unit tests pass
- [x] TypeScript compiles cleanly
- [x] Lint + format pass (verified via pre-commit hooks)
- [ ] Verify CI watch no longer fails with "no git remotes found" during worktree-based merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)