### PR TITLE
fix(agents): skip gpg signing for auto-init worktree commits

### DIFF
--- a/packages/core/src/infrastructure/services/git/worktree.service.ts
+++ b/packages/core/src/infrastructure/services/git/worktree.service.ts
@@ -143,9 +143,11 @@ export class WorktreeService implements IWorktreeService {
       }
       await this.execFile('git', ['config', 'user.name', GIT_AUTO_INIT_USER], { cwd: repoPath });
       await this.execFile('git', ['config', 'user.email', GIT_AUTO_INIT_EMAIL], { cwd: repoPath });
-      await this.execFile('git', ['commit', '--allow-empty', '-m', 'Initial commit'], {
-        cwd: repoPath,
-      });
+      await this.execFile(
+        'git',
+        ['commit', '--allow-empty', '--no-gpg-sign', '-m', 'Initial commit'],
+        { cwd: repoPath }
+      );
     } catch (error) {
       throw this.parseGitError(error);
     }

--- a/tests/unit/infrastructure/services/git/worktree.service.test.ts
+++ b/tests/unit/infrastructure/services/git/worktree.service.test.ts
@@ -364,7 +364,7 @@ describe('WorktreeService', () => {
       });
       expect(mockExecFile).toHaveBeenCalledWith(
         'git',
-        ['commit', '--allow-empty', '-m', 'Initial commit'],
+        ['commit', '--allow-empty', '--no-gpg-sign', '-m', 'Initial commit'],
         { cwd: '/plain/dir' }
       );
     });
@@ -389,7 +389,7 @@ describe('WorktreeService', () => {
       });
       expect(mockExecFile).toHaveBeenCalledWith(
         'git',
-        ['commit', '--allow-empty', '-m', 'Initial commit'],
+        ['commit', '--allow-empty', '--no-gpg-sign', '-m', 'Initial commit'],
         { cwd: '/empty/repo' }
       );
     });


### PR DESCRIPTION
## Summary
- Users with `commit.gpgsign=true` in their global git config get a GPG signing failure when `shep feat new` creates the initial empty commit using the `shep-ai[bot]` identity, since the bot's secret key doesn't exist on the user's machine
- Adds `--no-gpg-sign` to the internal scaffolding commit in `WorktreeService.ensureGitRepository`
- Updates unit test assertions to match

## Test plan
- [x] Unit tests pass (`pnpm vitest run tests/unit/infrastructure/services/git/worktree.service.test.ts` — 30/30)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)