### PR TITLE
fix(agents): use --auto flag for gh pr merge to respect branch protection

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -272,9 +272,9 @@ export function buildMergeSquashPrompt(
 
 ## Instructions
 
-1. Merge the PR using squash merge: \`gh pr merge ${state.prNumber} --squash --delete-branch\`
-2. If merge conflicts are encountered, resolve them and retry
-3. If the merge fails, report the error clearly
+1. Merge the PR using squash merge with auto-merge: \`gh pr merge ${state.prNumber} --squash --delete-branch --auto\`
+   - The --auto flag queues the merge to execute automatically once all branch protection requirements (CI checks, reviews, etc.) are satisfied
+2. If the merge command fails, report the error clearly
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- `gh pr merge --squash` fails immediately when branch protection rules require checks/reviews to pass first
- Added `--auto` flag so GitHub queues the merge and executes it once all requirements are satisfied

## Test plan
- [ ] Trigger a merge on a repo with branch protection and verify it queues with `--auto` instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)