### PR TITLE
fix(web): move cmd+enter handler to form level for reliable submission

### DIFF
--- a/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
+++ b/src/presentation/web/components/common/feature-create-drawer/feature-create-drawer.tsx
@@ -363,7 +363,7 @@ export function FeatureCreateDrawer({
   );
 
   const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
+    (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
       if (!description.trim()) return;
       createSound.play();
@@ -465,7 +465,7 @@ export function FeatureCreateDrawer({
 
   const formRef = useRef<HTMLFormElement>(null);
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault();
       formRef.current?.requestSubmit();
@@ -537,6 +537,7 @@ export function FeatureCreateDrawer({
             ref={formRef}
             id="create-feature-form"
             onSubmit={handleSubmit}
+            onKeyDown={handleKeyDown}
             className="flex flex-col gap-4"
           >
             {/* Description + inline controls with drop zone */}
@@ -573,7 +574,6 @@ export function FeatureCreateDrawer({
                   placeholder="e.g. Add GitHub OAuth login with callback handling and token refresh..."
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
-                  onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
                   required
                   disabled={isSubmitting}


### PR DESCRIPTION
## Summary
- Moved the `Cmd+Enter` / `Ctrl+Enter` keyboard shortcut handler from the `<textarea>` to the `<form>` element
- Previously, the shortcut only worked when the textarea had focus — pressing it while focused on any other form element (toggles, model picker, combobox, etc.) did nothing and triggered the macOS system alert sound
- Also fixed a deprecated `React.FormEvent` type annotation

## Test plan
- [ ] Open the create feature drawer
- [ ] Type a description, then click on a toggle (e.g. Fast Mode) so focus leaves the textarea
- [ ] Press `Cmd+Enter` — feature should be created successfully
- [ ] Verify `Cmd+Enter` still works when the textarea has focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)