### PR TITLE
fix(web): read version from DI container instead of build-time env vars

### DIFF
--- a/src/presentation/web/app/api/version/route.ts
+++ b/src/presentation/web/app/api/version/route.ts
@@ -1,26 +1,42 @@
 import { NextResponse } from 'next/server';
 
+import { resolve } from '@/lib/server-container';
+import type { IVersionService } from '@shepai/core/application/ports/output/services/version-service.interface';
+
 /** Prevent Next.js from statically prerendering this route at build time. */
 export const dynamic = 'force-dynamic';
 
 /**
  * Returns runtime version info.
  *
- * NEXT_PUBLIC_* env vars are inlined at build time for client components,
- * so client-side code sees the version from when the bundle was built —
- * not the currently running CLI version.
- *
- * This API route reads the env vars at runtime on the server, ensuring
- * the client always gets the correct version.
+ * Reads the version from the DI container's VersionService — the same source
+ * used by `shep --version`. This avoids stale values from NEXT_PUBLIC_* env
+ * vars which Next.js inlines at build time.
  */
 export function GET(): NextResponse {
-  return NextResponse.json({
-    version: process.env.NEXT_PUBLIC_SHEP_VERSION ?? 'unknown',
-    packageName: process.env.NEXT_PUBLIC_SHEP_PACKAGE_NAME ?? '@shepai/cli',
-    description: process.env.NEXT_PUBLIC_SHEP_DESCRIPTION ?? 'Autonomous AI Native SDLC Platform',
-    branch: process.env.NEXT_PUBLIC_SHEP_BRANCH ?? '',
-    commitHash: process.env.NEXT_PUBLIC_SHEP_COMMIT ?? '',
-    instancePath: process.env.NEXT_PUBLIC_SHEP_INSTANCE_PATH ?? '',
-    isDev: process.env.NODE_ENV === 'development',
-  });
+  try {
+    const versionService = resolve<IVersionService>('IVersionService');
+    const { version, name, description } = versionService.getVersion();
+
+    return NextResponse.json({
+      version,
+      packageName: name,
+      description,
+      branch: process.env.NEXT_PUBLIC_SHEP_BRANCH ?? '',
+      commitHash: process.env.NEXT_PUBLIC_SHEP_COMMIT ?? '',
+      instancePath: process.env.NEXT_PUBLIC_SHEP_INSTANCE_PATH ?? '',
+      isDev: process.env.NODE_ENV === 'development',
+    });
+  } catch {
+    // DI container not available (e.g. during build) — fall back to env vars
+    return NextResponse.json({
+      version: process.env.NEXT_PUBLIC_SHEP_VERSION ?? 'unknown',
+      packageName: process.env.NEXT_PUBLIC_SHEP_PACKAGE_NAME ?? '@shepai/cli',
+      description: process.env.NEXT_PUBLIC_SHEP_DESCRIPTION ?? 'Autonomous AI Native SDLC Platform',
+      branch: process.env.NEXT_PUBLIC_SHEP_BRANCH ?? '',
+      commitHash: process.env.NEXT_PUBLIC_SHEP_COMMIT ?? '',
+      instancePath: process.env.NEXT_PUBLIC_SHEP_INSTANCE_PATH ?? '',
+      isDev: process.env.NODE_ENV === 'development',
+    });
+  }
 }

--- a/src/presentation/web/lib/version.ts
+++ b/src/presentation/web/lib/version.ts
@@ -2,15 +2,18 @@
  * Version Information Helpers
  *
  * Provides version and system info for the Web UI.
- * Reads from NEXT_PUBLIC_SHEP_* environment variables which are set by:
- * 1. The CLI (`shep ui`) via setVersionEnvVars() before starting Next.js
- * 2. next.config.ts dev fallback for standalone `pnpm dev:web` mode
+ * Reads the version from the DI container's VersionService — the same source
+ * used by `shep --version`. Falls back to NEXT_PUBLIC_* env vars if the
+ * container is unavailable.
  *
  * The VersionInfo shape mirrors src/domain/value-objects/version-info.ts
  * from the CLI domain layer.
  */
 
 import { arch, platform } from 'node:os';
+
+import { resolve } from '@/lib/server-container';
+import type { IVersionService } from '@shepai/core/application/ports/output/services/version-service.interface';
 
 /** Version information for the package (mirrors domain VersionInfo) */
 export interface VersionInfo {
@@ -29,17 +32,29 @@ export interface SystemInfo {
 }
 
 /**
- * Get version info from environment variables.
- * Falls back to defaults if not set.
+ * Get version info from the DI container's VersionService.
+ * Falls back to env vars if the container is unavailable.
  */
 export function getVersionInfo(): VersionInfo {
-  return {
-    version: process.env.NEXT_PUBLIC_SHEP_VERSION ?? 'unknown',
-    name: process.env.NEXT_PUBLIC_SHEP_PACKAGE_NAME ?? '@shepai/cli',
-    description: process.env.NEXT_PUBLIC_SHEP_DESCRIPTION ?? 'Autonomous AI Native SDLC Platform',
-    branch: process.env.NEXT_PUBLIC_SHEP_BRANCH ?? '',
-    commitHash: process.env.NEXT_PUBLIC_SHEP_COMMIT ?? '',
-  };
+  try {
+    const versionService = resolve<IVersionService>('IVersionService');
+    const { version, name, description } = versionService.getVersion();
+    return {
+      version,
+      name,
+      description,
+      branch: process.env.NEXT_PUBLIC_SHEP_BRANCH ?? '',
+      commitHash: process.env.NEXT_PUBLIC_SHEP_COMMIT ?? '',
+    };
+  } catch {
+    return {
+      version: process.env.NEXT_PUBLIC_SHEP_VERSION ?? 'unknown',
+      name: process.env.NEXT_PUBLIC_SHEP_PACKAGE_NAME ?? '@shepai/cli',
+      description: process.env.NEXT_PUBLIC_SHEP_DESCRIPTION ?? 'Autonomous AI Native SDLC Platform',
+      branch: process.env.NEXT_PUBLIC_SHEP_BRANCH ?? '',
+      commitHash: process.env.NEXT_PUBLIC_SHEP_COMMIT ?? '',
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Web UI was showing stale version (e.g. v1.106.3 instead of v1.106.4) because Next.js inlines `NEXT_PUBLIC_*` env var references at build time
- Now `/api/version` and `lib/version.ts` resolve `IVersionService` from the DI container — the same source `shep --version` uses — reading `package.json` at runtime
- Falls back to env vars if the DI container is unavailable (e.g. during build)

## Test plan

- [ ] Run `pnpm dev:cli ui` and verify the sidebar shows the correct version from `package.json`
- [ ] Run `pnpm dev:web` and verify the version page shows the correct version
- [ ] Verify `curl http://localhost:4050/api/version` returns the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)