### PR TITLE
fix(agents): skip verification in spec-only phases to prevent timeouts

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
@@ -310,6 +310,8 @@ export function buildCommitPushBlock(opts: {
   push: boolean;
   files: string[];
   commitHint: string;
+  /** Skip build/test/lint verification (for spec-only phases that don't modify source code) */
+  skipVerification?: boolean;
 }): string {
   const fileList = opts.files.map((f) => `\`${f}\``).join(', ');
   const lines = [
@@ -320,7 +322,7 @@ export function buildCommitPushBlock(opts: {
     `2. Commit with a conventional commit message — e.g. \`${opts.commitHint}\``,
     `   - The message should accurately describe what changed`,
   ];
-  if (opts.push) {
+  if (opts.push && !opts.skipVerification) {
     lines.push(`3. Run local verification before pushing:`);
     lines.push(`   - \`pnpm build\` — must compile without errors`);
     lines.push(`   - \`pnpm test\` — all tests must pass`);
@@ -337,6 +339,10 @@ export function buildCommitPushBlock(opts: {
     lines.push(``);
     lines.push(`4. Push to remote: \`git push -u origin HEAD\``);
     lines.push(`   - Do NOT wait for or watch CI — just push and finish`);
+  } else if (opts.push && opts.skipVerification) {
+    lines.push(`3. Push to remote: \`git push -u origin HEAD\``);
+    lines.push(`   - Do NOT wait for or watch CI — just push and finish`);
+    lines.push(`   - Do NOT run build, test, or lint — this phase only modifies spec files`);
   }
   return lines.join('\n');
 }

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/analyze.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/analyze.prompt.ts
@@ -100,5 +100,6 @@ ${buildCommitPushBlock({
   push: state.push,
   files: [`${state.specDir}/spec.yaml`],
   commitHint: 'docs(specs): analyze repository and define spec',
+  skipVerification: true,
 })}`;
 }

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/plan.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/plan.prompt.ts
@@ -213,5 +213,6 @@ ${buildCommitPushBlock({
   push: state.push,
   files: [`${state.specDir}/plan.yaml`, `${state.specDir}/tasks.yaml`],
   commitHint: 'docs(specs): create implementation plan and task breakdown',
+  skipVerification: true,
 })}`;
 }

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/requirements.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/requirements.prompt.ts
@@ -188,5 +188,6 @@ ${buildCommitPushBlock({
   push: state.push,
   files: [`${state.specDir}/spec.yaml`],
   commitHint: 'docs(specs): define requirements and product questions',
+  skipVerification: true,
 })}`;
 }

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/research.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/research.prompt.ts
@@ -140,5 +140,6 @@ ${buildCommitPushBlock({
   push: state.push,
   files: [`${state.specDir}/research.yaml`],
   commitHint: 'docs(specs): research technical decisions and library choices',
+  skipVerification: true,
 })}`;
 }

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/node-helpers.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/node-helpers.test.ts
@@ -252,6 +252,32 @@ describe('buildCommitPushBlock', () => {
     });
     expect(result.toLowerCase()).toMatch(/proceed|commit.*anyway|push.*anyway/);
   });
+
+  it('should skip verification but still push when skipVerification=true and push=true', () => {
+    const result = buildCommitPushBlock({
+      push: true,
+      files: ['spec.yaml'],
+      commitHint: 'docs(specs): update spec',
+      skipVerification: true,
+    });
+    expect(result).not.toContain('pnpm build');
+    expect(result).not.toContain('pnpm test');
+    expect(result).not.toContain('pnpm lint');
+    expect(result).toContain('git push');
+  });
+
+  it('should not include push when skipVerification=true but push=false', () => {
+    const result = buildCommitPushBlock({
+      push: false,
+      files: ['spec.yaml'],
+      commitHint: 'docs(specs): update spec',
+      skipVerification: true,
+    });
+    expect(result).not.toContain('pnpm build');
+    expect(result).not.toContain('pnpm test');
+    expect(result).not.toContain('pnpm lint');
+    expect(result).not.toContain('git push');
+  });
 });
 
 describe('isRejectionPayload', () => {


### PR DESCRIPTION
## Summary
- Spec-only phases (analyze, requirements, research, plan) were running `pnpm build` + `pnpm test` + `pnpm lint` before pushing, consuming most of the 300s agent timeout budget despite only writing YAML files
- Added `skipVerification` option to `buildCommitPushBlock()` — when enabled, the agent commits and pushes without running verification commands
- Enabled `skipVerification: true` for all four spec-only phases; implement and evidence phases are unchanged

## Test plan
- [x] Existing `buildCommitPushBlock` tests pass (32 tests)
- [x] New tests verify `skipVerification` skips build/test/lint but still includes push instructions
- [x] New tests verify `skipVerification` with `push=false` skips both verification and push
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)