### PR TITLE
fix(agents): increase agent execution timeout from 300s to 600s

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
@@ -60,12 +60,16 @@ export function readSpecFile(specDir: string, filename: string): string {
 /**
  * Build executor options with cwd. Each node gets a clean agent context.
  */
-export function buildExecutorOptions(state: FeatureAgentState): AgentExecutionOptions {
+export function buildExecutorOptions(
+  state: FeatureAgentState,
+  overrides?: Partial<Pick<AgentExecutionOptions, 'timeout'>>
+): AgentExecutionOptions {
   return {
     cwd: state.worktreePath || state.repositoryPath,
     maxTurns: 5000,
-    timeout: 300_000, // 5 minutes per agent call — prevents infinite hangs
+    timeout: 600_000, // 10 minutes per agent call — prevents infinite hangs
     ...(state.model ? { model: state.model } : {}),
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
## Summary
- Increases agent execution timeout from 300s (5 min) to 600s (10 min)
- Merge and implement phases run `pnpm build` + `pnpm test` + `pnpm lint` which regularly exceeds the 5-minute limit
- Spec-only phases already skip verification (PR #341) so the longer default doesn't affect them
- Adds optional `overrides` parameter to `buildExecutorOptions()` for future per-phase customization

## Test plan
- [x] All 3831 unit tests pass
- [x] Build passes
- [x] No existing tests assert on the specific timeout value

🤖 Generated with [Claude Code](https://claude.com/claude-code)