### PR TITLE
fix(agents): skip git hooks in spec-only phases

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
@@ -323,7 +323,7 @@ export function buildCommitPushBlock(opts: {
     ``,
     `After completing all tasks above:`,
     `1. Stage the changed files: ${fileList} (use \`git add\` with the specific paths)`,
-    `2. Commit with a conventional commit message — e.g. \`${opts.commitHint}\``,
+    `2. Commit with a conventional commit message${opts.skipVerification ? ' using `--no-verify` to skip hooks' : ''} — e.g. \`git commit${opts.skipVerification ? ' --no-verify' : ''} -m "${opts.commitHint}"\``,
     `   - The message should accurately describe what changed`,
   ];
   if (opts.push && !opts.skipVerification) {

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/node-helpers.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/node-helpers.test.ts
@@ -278,6 +278,25 @@ describe('buildCommitPushBlock', () => {
     expect(result).not.toContain('pnpm lint');
     expect(result).not.toContain('git push');
   });
+
+  it('should include --no-verify in commit command when skipVerification=true', () => {
+    const result = buildCommitPushBlock({
+      push: true,
+      files: ['spec.yaml'],
+      commitHint: 'docs(specs): update spec',
+      skipVerification: true,
+    });
+    expect(result).toContain('--no-verify');
+  });
+
+  it('should NOT include --no-verify when skipVerification is false', () => {
+    const result = buildCommitPushBlock({
+      push: true,
+      files: ['spec.yaml'],
+      commitHint: 'docs(specs): update spec',
+    });
+    expect(result).not.toContain('--no-verify');
+  });
 });
 
 describe('isRejectionPayload', () => {


### PR DESCRIPTION
## Summary
- Spec-only phases (analyze, requirements, research, plan) were triggering pre-commit hooks (husky + lint-staged) that run `pnpm generate`, eslint, prettier, and typecheck — wasting agent timeout budget on YAML-only changes
- Added `--no-verify` flag to commit instructions when `skipVerification: true`, bypassing hooks entirely for these phases
- Added tests verifying `--no-verify` is present/absent based on the `skipVerification` flag

## Test plan
- [x] Existing `buildCommitPushBlock` tests pass (34/34)
- [ ] Verify spec-only phase agent runs no longer trigger pre-commit hooks
- [ ] Verify implementation phase still runs full verification + hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)