### PR TITLE
fix(agents): pass fast flag on reject/approve resume

### DIFF
--- a/packages/core/src/application/use-cases/agents/approve-agent-run.use-case.ts
+++ b/packages/core/src/application/use-cases/agents/approve-agent-run.use-case.ts
@@ -126,6 +126,7 @@ export class ApproveAgentRunUseCase {
         ...(payload ? { resumePayload: JSON.stringify(payload) } : {}),
         agentType: run.agentType,
         ...(run.modelId ? { model: run.modelId } : {}),
+        ...(feature?.fast ? { fast: true } : {}),
       }
     );
 

--- a/packages/core/src/application/use-cases/agents/reject-agent-run.use-case.ts
+++ b/packages/core/src/application/use-cases/agents/reject-agent-run.use-case.ts
@@ -152,6 +152,7 @@ export class RejectAgentRunUseCase {
         push: feature?.push ?? false,
         openPr: feature?.openPr ?? false,
         resumePayload: JSON.stringify(rejectionPayload),
+        ...(feature.fast ? { fast: true } : {}),
       }
     );
 

--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-worker.ts
@@ -377,8 +377,14 @@ export async function runWorker(args: WorkerArgs): Promise<void> {
     const interruptPayload = result.__interrupt__ as { value: unknown }[] | undefined;
     if (interruptPayload && interruptPayload.length > 0) {
       const now = new Date();
+      // Extract the node name from the interrupt payload so the rejection
+      // use case can tag feedback with the correct phase (e.g. "merge").
+      const interruptValue = interruptPayload[0]?.value as Record<string, unknown> | undefined;
+      const interruptNode =
+        typeof interruptValue?.node === 'string' ? interruptValue.node : undefined;
       await runRepository.updateStatus(args.runId, AgentRunStatus.waitingApproval, {
         updatedAt: now,
+        ...(interruptNode ? { result: `node:${interruptNode}` } : {}),
       });
       log('Run paused — waiting for human approval');
       return;

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/merge/merge.node.ts
@@ -105,6 +105,7 @@ export function createMergeNode(deps: MergeNodeDeps) {
       return {
         currentNode: 'merge',
         messages: [`[merge] Rejected — will re-execute`],
+        error: null,
         _approvalAction: null,
         _rejectionFeedback: null,
         _needsReexecution: true,

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/fast-implement.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/fast-implement.prompt.ts
@@ -109,6 +109,47 @@ function extractUserQuery(specDir: string): string {
 }
 
 /**
+ * Extract rejection feedback from spec.yaml for merge-phase rejections.
+ * Returns a formatted prompt section if feedback exists, empty string otherwise.
+ */
+function getRejectionFeedback(specDir: string): string {
+  try {
+    const specContent = readSpecFile(specDir, 'spec.yaml');
+    if (!specContent) return '';
+
+    const specData = yaml.load(specContent) as Record<string, unknown> | null;
+    const rejectionFeedback = specData?.rejectionFeedback as
+      | { iteration: number; message: string; phase?: string; timestamp: string }[]
+      | undefined;
+    if (rejectionFeedback && rejectionFeedback.length > 0) {
+      const mergeRejections = rejectionFeedback.filter((e) => e.phase === 'merge');
+      if (mergeRejections.length > 0) {
+        const latest = mergeRejections[mergeRejections.length - 1];
+        const older = mergeRejections.slice(0, -1);
+        const olderSection =
+          older.length > 0
+            ? `\n### Earlier feedback (for context only)\n${older.map((e) => `- Iteration ${e.iteration}: ${e.message}`).join('\n')}\n`
+            : '';
+        return `
+## CRITICAL — User Rejection Feedback (MUST ADDRESS)
+
+**YOUR PRIMARY TASK: The user rejected the previous result and gave this feedback. You MUST act on it:**
+
+> ${latest.message}
+
+(Iteration ${latest.iteration}, ${latest.timestamp})
+
+Do NOT just record this feedback — you must actually make the changes the user requested.
+${olderSection}`;
+      }
+    }
+  } catch {
+    // Continue without rejection feedback
+  }
+  return '';
+}
+
+/**
  * Build the fast-implement prompt from user query + codebase context.
  *
  * The prompt includes:
@@ -129,18 +170,21 @@ export function buildFastImplementPrompt(state: FeatureAgentState): string {
   const packageJson = readWorktreeFile(cwd, 'package.json');
   const dirListing = buildDirectoryListing(cwd);
 
+  // Check for rejection feedback from prior merge rejection
+  const rejectionSection = getRejectionFeedback(state.specDir);
+
   // Build sections conditionally
   const sections: string[] = [];
 
   sections.push(`You are a senior software engineer implementing a change directly from a user request.
-
+${rejectionSection}
 ## User Request
 
 ${userQuery}
 
 ## Implementation Instructions
 
-1. Implement the requested changes in the codebase
+1. ${rejectionSection ? 'Address the rejection feedback above by modifying the existing implementation' : 'Implement the requested changes in the codebase'}
 2. Write tests for your changes where appropriate
 3. Run the test suite and fix any failures
 4. Run the linter and fix any issues


### PR DESCRIPTION
## Summary

- **Root cause:** `RejectAgentRunUseCase` and `ApproveAgentRunUseCase` didn't pass the `fast` flag when spawning resume workers. Fast-mode features resumed with the standard graph (requiring `plan.yaml`/`tasks.yaml`), causing immediate failure.
- Pass `feature.fast` to the spawned worker in both reject and approve use cases
- Store the interrupt node name in `run.result` so rejection feedback gets tagged with the correct phase (e.g. `merge`)
- Clear stale `error` state in the merge node on rejection re-execution
- Inject rejection feedback from `spec.yaml` into the fast-implement prompt so the agent knows what changes the user requested

## Test plan

- [x] All 3862 unit tests pass
- [x] Build succeeds
- [x] Typecheck passes
- [ ] Reject a fast-mode feature at merge approval and verify it resumes with the fast graph (logs should show `fast-implement`, not `implement`)
- [ ] Verify rejection feedback appears in the fast-implement agent prompt
- [ ] Approve a fast-mode feature at merge and verify it resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)