### PR TITLE
fix(domain): add post-bootstrap schema verification to repair missing tables

### DIFF
--- a/packages/core/src/infrastructure/persistence/sqlite/sqlite-migration-storage.ts
+++ b/packages/core/src/infrastructure/persistence/sqlite/sqlite-migration-storage.ts
@@ -38,6 +38,20 @@ export class SQLiteMigrationStorage implements UmzugStorage<Database.Database> {
   }
 
   /**
+   * Mapping of legacy migration names to the tables they create.
+   * Used by verifyBootstrappedMigrations to detect migrations that were
+   * marked as executed by the bootstrap seeder but never actually ran.
+   */
+  private static readonly MIGRATION_TABLE_MAP: Record<string, string> = {
+    '001-create-settings-table': 'settings',
+    '003-create-agent-runs': 'agent_runs',
+    '004-create-features': 'features',
+    '008-add-approval-gates-and-phase-timings': 'phase_timings',
+    '015-create-repositories-and-backfill': 'repositories',
+    '033-create-pr-sync-lock': 'pr_sync_lock',
+  };
+
+  /**
    * Returns the names of all executed migrations, sorted lexicographically.
    */
   async executed(_meta: Pick<MigrationParams<Database.Database>, 'context'>): Promise<string[]> {
@@ -116,5 +130,36 @@ export class SQLiteMigrationStorage implements UmzugStorage<Database.Database> {
     });
 
     seedAll();
+
+    // After seeding, verify that expected schema artifacts actually exist.
+    // If a migration was inserted into the legacy list after the DB was already
+    // at a higher user_version, its DDL never ran but the seeder marked it done.
+    const seededCount = Math.min(userVersion, legacyMigrationNames.length);
+    const seededNames = legacyMigrationNames.slice(0, seededCount);
+    this.verifyBootstrappedMigrations(seededNames);
+  }
+
+  /**
+   * Checks that each bootstrapped migration's expected table actually exists.
+   * Only checks migrations that were seeded (present in seededNames).
+   * If a table is missing, removes the migration record from umzug_migrations
+   * so that umzug will re-run it on the next up() call.
+   */
+  private verifyBootstrappedMigrations(seededNames: string[]): void {
+    const seededSet = new Set(seededNames);
+    const tableCheck = this.db.prepare(
+      "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table' AND name=?"
+    );
+
+    for (const [migrationName, tableName] of Object.entries(
+      SQLiteMigrationStorage.MIGRATION_TABLE_MAP
+    )) {
+      if (!seededSet.has(migrationName)) continue;
+
+      const result = tableCheck.get(tableName) as { count: number };
+      if (result.count === 0) {
+        this.db.prepare('DELETE FROM umzug_migrations WHERE name = ?').run(migrationName);
+      }
+    }
   }
 }

--- a/tests/integration/infrastructure/persistence/sqlite/migrations.test.ts
+++ b/tests/integration/infrastructure/persistence/sqlite/migrations.test.ts
@@ -926,5 +926,33 @@ describe('SQLite Migrations', () => {
       expect(getSchemaVersion(db)).toBe(LATEST_SCHEMA_VERSION);
       expect(getAppliedMigrations(db)).toHaveLength(34);
     });
+
+    it('should repair missing pr_sync_lock table after bootstrap gap', async () => {
+      // Simulate the exact production scenario:
+      // 1. DB was at user_version=34 with all tables except pr_sync_lock
+      //    (migration 033 was added after the DB was already at version 34)
+      // 2. umzug transition: bootstrap seeds all 34 as "done"
+      // 3. Verification detects pr_sync_lock is missing, unlogs 033
+      // 4. umzug.up() re-runs migration 033, creating the table
+
+      // Step 1: Run all migrations to get the full schema
+      await runSQLiteMigrations(db);
+
+      // Step 2: Drop pr_sync_lock and umzug_migrations to simulate the gap
+      db.exec('DROP TABLE pr_sync_lock');
+      db.exec('DROP TABLE umzug_migrations');
+      // user_version stays at 34 (simulating the pre-umzug state)
+
+      // Step 3 & 4: Re-run migrations — should bootstrap, verify, and repair
+      await runSQLiteMigrations(db);
+
+      // pr_sync_lock should now exist
+      expect(tableExists(db, 'pr_sync_lock')).toBe(true);
+      // All 34 migrations should be tracked
+      expect(getAppliedMigrations(db)).toHaveLength(34);
+      // user_version may be 33 (set by re-run of 033) since 034 was already
+      // tracked and didn't re-run. With umzug, user_version is a legacy artifact.
+      expect(getSchemaVersion(db)).toBeGreaterThanOrEqual(33);
+    });
   });
 });

--- a/tests/integration/infrastructure/persistence/sqlite/sqlite-migration-storage.test.ts
+++ b/tests/integration/infrastructure/persistence/sqlite/sqlite-migration-storage.test.ts
@@ -161,6 +161,10 @@ describe('SQLiteMigrationStorage', () => {
   describe('bootstrap seeder', () => {
     it('should seed records when user_version > 0 and table is empty', () => {
       // Simulate an existing database with user_version = 5
+      // Create the tables that migrations 001/003/004 would have created
+      db.exec('CREATE TABLE settings (id TEXT PRIMARY KEY)');
+      db.exec('CREATE TABLE agent_runs (id TEXT PRIMARY KEY)');
+      db.exec('CREATE TABLE features (id TEXT PRIMARY KEY)');
       db.pragma('user_version = 5');
 
       // Create a new storage with legacy names — bootstrap should detect and seed
@@ -221,6 +225,9 @@ describe('SQLiteMigrationStorage', () => {
 
     it('should seed correct number of records matching user_version', () => {
       // Simulate database at version 3 (out of 5 available)
+      // Create tables that migrations 001/003 would have created
+      db.exec('CREATE TABLE settings (id TEXT PRIMARY KEY)');
+      db.exec('CREATE TABLE agent_runs (id TEXT PRIMARY KEY)');
       db.pragma('user_version = 3');
 
       new SQLiteMigrationStorage(db, SAMPLE_LEGACY_NAMES);
@@ -250,6 +257,9 @@ describe('SQLiteMigrationStorage', () => {
     });
 
     it('should be idempotent — calling constructor twice does not duplicate records', () => {
+      // Create tables that migrations 001/003 would have created
+      db.exec('CREATE TABLE settings (id TEXT PRIMARY KEY)');
+      db.exec('CREATE TABLE agent_runs (id TEXT PRIMARY KEY)');
       db.pragma('user_version = 3');
 
       new SQLiteMigrationStorage(db, SAMPLE_LEGACY_NAMES);
@@ -272,6 +282,163 @@ describe('SQLiteMigrationStorage', () => {
         count: number;
       };
       expect(count.count).toBe(0);
+    });
+  });
+
+  describe('bootstrap schema verification', () => {
+    /**
+     * Full list of legacy migration names matching production (001–034).
+     * Needed so the bootstrap seeder can seed all 34 records.
+     */
+    const ALL_LEGACY_NAMES = [
+      '001-create-settings-table',
+      '002-add-agent-config',
+      '003-create-agent-runs',
+      '004-create-features',
+      '005-add-feature-refs-to-agent-runs',
+      '006-add-approval-workflow',
+      '007-add-spec-path',
+      '008-add-approval-gates-and-phase-timings',
+      '009-add-notification-preferences',
+      '010-add-workflow-flags-and-pr-tracking',
+      '011-add-worktree-path',
+      '012-add-push-column',
+      '013-add-user-query',
+      '014-add-approval-wait-timing',
+      '015-create-repositories-and-backfill',
+      '016-add-repository-soft-delete',
+      '017-fix-repository-names',
+      '018-add-onboarding-and-approval-defaults',
+      '019-add-ci-fix-tracking',
+      '020-add-parent-id-and-backfill-ci-fix',
+      '021-backfill-ci-fix-columns',
+      '022-add-pr-notification-filters',
+      '023-backfill-orphaned-repositories',
+      '024-add-feature-flags-and-ci-workflow',
+      '025-add-model-default',
+      '026-add-model-id-to-agent-runs',
+      '027-add-fast-column',
+      '028-add-attachments',
+      '029-add-feature-soft-delete',
+      '030-add-evidence-workflow-settings',
+      '031-add-pr-mergeable',
+      '032-update-env-deploy-default',
+      '033-create-pr-sync-lock',
+      '034-add-merge-review-notifications',
+    ];
+
+    it('should unlog migration whose expected table is missing after bootstrap', () => {
+      // Simulate a DB that had all tables EXCEPT pr_sync_lock created,
+      // but user_version was already set to 34.
+      // Create the core tables that would exist in a real DB at version 34:
+      db.exec(`
+        CREATE TABLE settings (id TEXT PRIMARY KEY);
+        CREATE TABLE agent_runs (id TEXT PRIMARY KEY);
+        CREATE TABLE features (id TEXT PRIMARY KEY);
+        CREATE TABLE phase_timings (id TEXT PRIMARY KEY);
+        CREATE TABLE repositories (id TEXT PRIMARY KEY);
+      `);
+      // Deliberately omit pr_sync_lock table
+      db.pragma('user_version = 34');
+
+      // Construct storage — bootstrap seeds all 34 records,
+      // then verification should detect missing pr_sync_lock and unlog 033
+      new SQLiteMigrationStorage(db, ALL_LEGACY_NAMES);
+
+      const applied = db.prepare('SELECT name FROM umzug_migrations ORDER BY name').all() as {
+        name: string;
+      }[];
+      const appliedNames = applied.map((r) => r.name);
+
+      // Migration 033 should have been removed because pr_sync_lock table is missing
+      expect(appliedNames).not.toContain('033-create-pr-sync-lock');
+      // Other migrations should still be seeded
+      expect(appliedNames).toContain('001-create-settings-table');
+      expect(appliedNames).toContain('004-create-features');
+      expect(appliedNames).toContain('034-add-merge-review-notifications');
+      expect(applied).toHaveLength(33);
+    });
+
+    it('should not unlog migration when expected table exists', () => {
+      // Create ALL tables including pr_sync_lock
+      db.exec(`
+        CREATE TABLE settings (id TEXT PRIMARY KEY);
+        CREATE TABLE agent_runs (id TEXT PRIMARY KEY);
+        CREATE TABLE features (id TEXT PRIMARY KEY);
+        CREATE TABLE phase_timings (id TEXT PRIMARY KEY);
+        CREATE TABLE repositories (id TEXT PRIMARY KEY);
+        CREATE TABLE pr_sync_lock (id INTEGER PRIMARY KEY);
+      `);
+      db.pragma('user_version = 34');
+
+      new SQLiteMigrationStorage(db, ALL_LEGACY_NAMES);
+
+      const applied = db.prepare('SELECT name FROM umzug_migrations ORDER BY name').all() as {
+        name: string;
+      }[];
+      const appliedNames = applied.map((r) => r.name);
+
+      // All 34 should remain seeded
+      expect(appliedNames).toContain('033-create-pr-sync-lock');
+      expect(applied).toHaveLength(34);
+    });
+
+    it('should unlog multiple migrations when multiple tables are missing', () => {
+      // Create only settings and agent_runs — missing features, phase_timings,
+      // repositories, and pr_sync_lock
+      db.exec(`
+        CREATE TABLE settings (id TEXT PRIMARY KEY);
+        CREATE TABLE agent_runs (id TEXT PRIMARY KEY);
+      `);
+      db.pragma('user_version = 34');
+
+      new SQLiteMigrationStorage(db, ALL_LEGACY_NAMES);
+
+      const applied = db.prepare('SELECT name FROM umzug_migrations ORDER BY name').all() as {
+        name: string;
+      }[];
+      const appliedNames = applied.map((r) => r.name);
+
+      // These migrations' tables are missing, so they should be unlogged
+      expect(appliedNames).not.toContain('004-create-features');
+      expect(appliedNames).not.toContain('008-add-approval-gates-and-phase-timings');
+      expect(appliedNames).not.toContain('015-create-repositories-and-backfill');
+      expect(appliedNames).not.toContain('033-create-pr-sync-lock');
+      // These tables exist, so their migrations remain
+      expect(appliedNames).toContain('001-create-settings-table');
+      expect(appliedNames).toContain('003-create-agent-runs');
+      expect(applied).toHaveLength(30);
+    });
+
+    it('should not run verification when bootstrap did not seed (fresh DB)', () => {
+      // Fresh DB with user_version = 0 — bootstrap doesn't seed, verification shouldn't run
+      new SQLiteMigrationStorage(db, ALL_LEGACY_NAMES);
+
+      const count = db.prepare('SELECT COUNT(*) as count FROM umzug_migrations').get() as {
+        count: number;
+      };
+      expect(count.count).toBe(0);
+    });
+
+    it('should not run verification when bootstrap skipped (table already has records)', async () => {
+      // Pre-populate umzug_migrations with one record
+      db.exec(`
+        CREATE TABLE settings (id TEXT PRIMARY KEY);
+      `);
+      storage = new SQLiteMigrationStorage(db);
+      await storage.logMigration({ name: '001-create-settings-table', context: db });
+
+      db.pragma('user_version = 34');
+
+      // Construct with legacy names — bootstrap should skip (table not empty),
+      // and verification should NOT run either
+      new SQLiteMigrationStorage(db, ALL_LEGACY_NAMES);
+
+      const count = db.prepare('SELECT COUNT(*) as count FROM umzug_migrations').get() as {
+        count: number;
+      };
+      // Should still have just the one record we manually logged
+      expect(count.count).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes `[PrSyncWatcher] Poll failed: no such table: pr_sync_lock` error on server startup
- The umzug bootstrap seeder was marking all migrations as executed based on `PRAGMA user_version` without verifying their schema artifacts actually existed
- Adds `verifyBootstrappedMigrations()` to `SQLiteMigrationStorage` that checks table-creating migrations against `sqlite_master` and unlogs any whose tables are missing, so umzug re-runs them

## Test plan

- [x] 5 new unit tests for bootstrap schema verification (missing table, existing table, multiple missing, fresh DB skip, already-tracked skip)
- [x] 1 new end-to-end integration test simulating the exact production scenario (drop `pr_sync_lock` + `umzug_migrations`, re-run migrations, verify table recreated)
- [x] All 106 SQLite persistence tests pass
- [x] TypeScript typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)