### PR TITLE
fix: distinguish network timeouts from agent execution timeouts

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/node-helpers.ts
@@ -67,7 +67,7 @@ export function buildExecutorOptions(
   return {
     cwd: state.worktreePath || state.repositoryPath,
     maxTurns: 5000,
-    timeout: 600_000, // 10 minutes per agent call — prevents infinite hangs
+    timeout: 1_800_000, // 30 minutes per agent call — prevents infinite hangs
     ...(state.model ? { model: state.model } : {}),
     ...overrides,
   };
@@ -131,8 +131,8 @@ export function shouldInterrupt(nodeName: string, gates: ApprovalGates | undefin
 export type ErrorCategory = 'retryable-api' | 'retryable-network' | 'non-retryable' | 'unknown';
 
 const API_ERROR_RE = /API Error: (400|429|5\d{2})/;
-const NETWORK_ERROR_RE = /ECONNREFUSED|ETIMEDOUT|ENOTFOUND|timed out/i;
-const NON_RETRYABLE_RE = /Process exited with code|ENOENT|SyntaxError/;
+const NETWORK_ERROR_RE = /ECONNREFUSED|ETIMEDOUT|ENOTFOUND|network timed out/i;
+const NON_RETRYABLE_RE = /Process exited with code|ENOENT|SyntaxError|Agent execution timed out/;
 
 /**
  * Classify an error message into a retry category.

--- a/tests/unit/infrastructure/services/agents/langgraph/node-helpers.test.ts
+++ b/tests/unit/infrastructure/services/agents/langgraph/node-helpers.test.ts
@@ -174,8 +174,14 @@ describe('classifyError', () => {
       expect(classifyError('getaddrinfo ENOTFOUND api.anthropic.com')).toBe('retryable-network');
     });
 
-    it('should classify execution timeout as retryable-network', () => {
-      expect(classifyError('Agent execution timed out')).toBe('retryable-network');
+    it('should classify network timeout as retryable-network', () => {
+      expect(classifyError('connect network timed out')).toBe('retryable-network');
+    });
+  });
+
+  describe('non-retryable errors - timeouts', () => {
+    it('should classify agent execution timeout as non-retryable', () => {
+      expect(classifyError('Agent execution timed out')).toBe('non-retryable');
     });
   });
 


### PR DESCRIPTION
## Summary
This PR refines error classification to distinguish between network-level timeouts (which are retryable) and agent execution timeouts (which are not). It also increases the agent execution timeout from 10 to 30 minutes to allow longer-running operations to complete.

## Key Changes
- **Error Classification**: Updated regex patterns to differentiate timeout types:
  - Network timeouts (`connect network timed out`) are classified as `retryable-network`
  - Agent execution timeouts (`Agent execution timed out`) are classified as `non-retryable`
  - Changed `NETWORK_ERROR_RE` from matching generic `timed out` to specifically `network timed out`
  - Added `Agent execution timed out` to `NON_RETRYABLE_RE`

- **Timeout Configuration**: Increased agent execution timeout from 600 seconds (10 minutes) to 1,800 seconds (30 minutes) to prevent premature termination of long-running operations

- **Test Updates**: Updated test cases to reflect the new classification behavior, separating network timeout tests from agent execution timeout tests

## Implementation Details
The distinction allows the system to retry transient network issues while treating agent execution timeouts as terminal failures that require investigation rather than automatic retry.

https://claude.ai/code/session_017zcifrfpeqV5yfQW97V5SC