### PR TITLE
feat(web): per-repo webhook enable/disable from node and drawer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ yarn.lock
 storybook-static/
 .worktrees/
 .plan/
+.superpowers/

--- a/docs/superpowers/plans/2026-03-16-per-repo-webhook-toggle.md
+++ b/docs/superpowers/plans/2026-03-16-per-repo-webhook-toggle.md
@@ -1,0 +1,1093 @@
+# Per-Repository Webhook Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable users to toggle GitHub webhook registration per repository from the repo node and drawer UI.
+
+**Architecture:** New public methods on `GitHubWebhookService` and `WebhookManagerService` for single-repo webhook CRUD. Three new Next.js API routes expose these. A `useWebhookAction` hook provides optimistic toggle state to both the repo node action button and drawer section.
+
+**Tech Stack:** TypeScript, Next.js API routes, React hooks, lucide-react icons, Storybook, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-16-per-repo-webhook-toggle-design.md`
+
+---
+
+## Chunk 1: Service Layer
+
+### Task 1: Add `registerWebhookForSingleRepo` and `removeWebhookForRepo` to GitHubWebhookService
+
+**Files:**
+
+- Modify: `packages/core/src/infrastructure/services/webhook/github-webhook.service.ts`
+- Create: `packages/core/src/infrastructure/services/webhook/github-webhook.service.test.ts`
+
+**Context:** The existing `registerWebhookForRepo()` is private and called from `registerWebhooks()` (bulk). We need to expose single-repo registration as a new public method with a duplicate guard, and add a method to remove a single repo's webhook. All path comparisons must normalize to forward slashes.
+
+- [ ] **Step 1: Write failing tests for `registerWebhookForSingleRepo`**
+
+Create the test file. Test three scenarios: (a) registers a webhook for a new repo, (b) no-ops when repo already has a webhook, (c) normalizes paths before comparing.
+
+```typescript
+// packages/core/src/infrastructure/services/webhook/github-webhook.service.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitHubWebhookService, type ExecFunction } from './github-webhook.service.js';
+
+// Minimal mocks for constructor dependencies
+const mockFeatureRepo = { list: vi.fn().mockResolvedValue([]) } as any;
+const mockGitPrService = {
+  getRemoteUrl: vi.fn().mockResolvedValue('https://github.com/owner/repo.git'),
+} as any;
+const mockNotificationService = { notify: vi.fn() } as any;
+
+function createService(execFn?: ExecFunction) {
+  const exec =
+    execFn ??
+    vi.fn().mockResolvedValue({
+      stdout: JSON.stringify({ id: 42 }),
+      stderr: '',
+    });
+  return {
+    service: new GitHubWebhookService(
+      mockFeatureRepo,
+      mockGitPrService,
+      mockNotificationService,
+      exec as ExecFunction
+    ),
+    exec,
+  };
+}
+
+describe('GitHubWebhookService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('registerWebhookForSingleRepo', () => {
+    it('registers a webhook and adds it to the registered list', async () => {
+      const { service, exec } = createService();
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      expect(exec).toHaveBeenCalled();
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+      expect(service.getRegisteredWebhooks()[0].repoFullName).toBe('owner/repo');
+    });
+
+    it('no-ops when a webhook is already registered for the repo path', async () => {
+      const { service, exec } = createService();
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      // exec is called for stale cleanup (list hooks) + create — only once for registration
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+    });
+
+    it('normalizes backslash paths before comparing', async () => {
+      const { service } = createService();
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      // Same path with backslashes (Windows)
+      await service.registerWebhookForSingleRepo(
+        '\\home\\user\\repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+    });
+  });
+
+  describe('removeWebhookForRepo', () => {
+    it('removes a webhook from GitHub and the registered list', async () => {
+      const { service, exec } = createService();
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+
+      await service.removeWebhookForRepo('/home/user/repo');
+      expect(service.getRegisteredWebhooks()).toHaveLength(0);
+      // Verify DELETE was called
+      const deleteCalls = (exec as any).mock.calls.filter((c: string[][]) =>
+        c[1]?.includes('DELETE')
+      );
+      expect(deleteCalls.length).toBeGreaterThan(0);
+    });
+
+    it('no-ops when repo path is not found', async () => {
+      const { service, exec } = createService();
+      await service.removeWebhookForRepo('/nonexistent/path');
+      // No DELETE calls
+      const deleteCalls = (exec as any).mock.calls.filter((c: string[][]) =>
+        c[1]?.includes('DELETE')
+      );
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    it('normalizes paths when finding webhook to remove', async () => {
+      const { service } = createService();
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      await service.removeWebhookForRepo('\\home\\user\\repo');
+      expect(service.getRegisteredWebhooks()).toHaveLength(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/core/src/infrastructure/services/webhook/github-webhook.service.test.ts`
+Expected: FAIL — `registerWebhookForSingleRepo` and `removeWebhookForRepo` do not exist.
+
+- [ ] **Step 3: Implement `registerWebhookForSingleRepo` and `removeWebhookForRepo`**
+
+In `github-webhook.service.ts`, add a helper function at the top of the file:
+
+```typescript
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+```
+
+Add two new public methods to `GitHubWebhookService`:
+
+```typescript
+/**
+ * Register a webhook for a single repository.
+ * No-ops if the repo already has a registered webhook (normalized path comparison).
+ */
+async registerWebhookForSingleRepo(repoPath: string, webhookUrl: string): Promise<RegisteredWebhook | null> {
+  const normalized = normalizePath(repoPath);
+  const existing = this.registeredWebhooks.find(
+    (w) => normalizePath(w.repositoryPath) === normalized
+  );
+  if (existing) return existing;
+
+  await this.registerWebhookForRepo(repoPath, webhookUrl);
+
+  // Return the newly registered webhook (last entry if registration succeeded)
+  const added = this.registeredWebhooks.find(
+    (w) => normalizePath(w.repositoryPath) === normalized
+  );
+  return added ?? null;
+}
+
+/**
+ * Remove the webhook for a single repository.
+ * No-ops if the repo has no registered webhook.
+ */
+async removeWebhookForRepo(repoPath: string): Promise<void> {
+  const normalized = normalizePath(repoPath);
+  const index = this.registeredWebhooks.findIndex(
+    (w) => normalizePath(w.repositoryPath) === normalized
+  );
+  if (index === -1) return;
+
+  const webhook = this.registeredWebhooks[index];
+
+  try {
+    await this.execFn(
+      'gh',
+      [
+        'api',
+        '--method',
+        'DELETE',
+        `-H`,
+        'Accept: application/vnd.github+json',
+        `/repos/${webhook.repoFullName}/hooks/${webhook.webhookId}`,
+      ],
+      { cwd: webhook.repositoryPath }
+    );
+    // eslint-disable-next-line no-console
+    console.log(`${TAG} Removed webhook #${webhook.webhookId} for ${webhook.repoFullName}`);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    // eslint-disable-next-line no-console
+    console.warn(`${TAG} Failed to remove webhook for ${webhook.repoFullName}: ${msg}`);
+  }
+
+  this.registeredWebhooks.splice(index, 1);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run packages/core/src/infrastructure/services/webhook/github-webhook.service.test.ts`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/infrastructure/services/webhook/github-webhook.service.ts packages/core/src/infrastructure/services/webhook/github-webhook.service.test.ts
+git commit -m "feat(web): add single-repo webhook register and remove methods"
+```
+
+---
+
+### Task 2: Add `enableWebhookForRepo`, `disableWebhookForRepo`, `isWebhookEnabledForRepo` to WebhookManagerService
+
+**Files:**
+
+- Modify: `packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts`
+- Create: `packages/core/src/infrastructure/services/webhook/webhook-manager.service.test.ts`
+
+**Context:** The manager orchestrates tunnel + webhook service. New methods delegate to `GitHubWebhookService` concrete methods (cast from `IWebhookService`, same pattern as `getStatus()`). `enableWebhookForRepo` must validate the tunnel is running and construct the webhook URL.
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// packages/core/src/infrastructure/services/webhook/webhook-manager.service.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WebhookManagerService } from './webhook-manager.service.js';
+
+function createMocks({ tunnelRunning = true, tunnelUrl = 'https://tunnel.example.com' } = {}) {
+  const tunnelService = {
+    start: vi.fn().mockResolvedValue(tunnelUrl),
+    stop: vi.fn().mockResolvedValue(undefined),
+    getPublicUrl: vi.fn().mockReturnValue(tunnelRunning ? tunnelUrl : null),
+    onUrlChange: vi.fn(),
+    isRunning: vi.fn().mockReturnValue(tunnelRunning),
+  };
+
+  const webhookService = {
+    registerWebhooks: vi.fn().mockResolvedValue(undefined),
+    updateWebhookUrl: vi.fn().mockResolvedValue(undefined),
+    removeWebhooks: vi.fn().mockResolvedValue(undefined),
+    validateSignature: vi.fn().mockReturnValue({ valid: true }),
+    handleEvent: vi.fn().mockResolvedValue(undefined),
+    // Concrete GitHubWebhookService methods
+    registerWebhookForSingleRepo: vi
+      .fn()
+      .mockResolvedValue({ repoFullName: 'owner/repo', webhookId: 42, repositoryPath: '/repo' }),
+    removeWebhookForRepo: vi.fn().mockResolvedValue(undefined),
+    getRegisteredWebhooks: vi.fn().mockReturnValue([]),
+    getDeliveryHistory: vi.fn().mockReturnValue([]),
+  };
+
+  return { tunnelService, webhookService };
+}
+
+describe('WebhookManagerService', () => {
+  describe('enableWebhookForRepo', () => {
+    it('returns error when tunnel is not running', async () => {
+      const { tunnelService, webhookService } = createMocks({ tunnelRunning: false });
+      const manager = new WebhookManagerService(tunnelService, webhookService);
+
+      const result = await manager.enableWebhookForRepo('/repo');
+      expect(result).toEqual({ success: false, error: 'tunnel_not_connected' });
+      expect(webhookService.registerWebhookForSingleRepo).not.toHaveBeenCalled();
+    });
+
+    it('registers webhook and returns success when tunnel is running', async () => {
+      const { tunnelService, webhookService } = createMocks();
+      const manager = new WebhookManagerService(tunnelService, webhookService);
+
+      const result = await manager.enableWebhookForRepo('/repo');
+      expect(result.success).toBe(true);
+      expect(result.webhook).toBeDefined();
+      expect(webhookService.registerWebhookForSingleRepo).toHaveBeenCalledWith(
+        '/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+    });
+  });
+
+  describe('disableWebhookForRepo', () => {
+    it('delegates to webhookService.removeWebhookForRepo', async () => {
+      const { tunnelService, webhookService } = createMocks();
+      const manager = new WebhookManagerService(tunnelService, webhookService);
+
+      const result = await manager.disableWebhookForRepo('/repo');
+      expect(result).toEqual({ success: true });
+      expect(webhookService.removeWebhookForRepo).toHaveBeenCalledWith('/repo');
+    });
+  });
+
+  describe('isWebhookEnabledForRepo', () => {
+    it('returns false when repo has no webhook', () => {
+      const { tunnelService, webhookService } = createMocks();
+      const manager = new WebhookManagerService(tunnelService, webhookService);
+
+      expect(manager.isWebhookEnabledForRepo('/repo')).toBe(false);
+    });
+
+    it('returns true when repo has a webhook (normalized path)', () => {
+      const { tunnelService, webhookService } = createMocks();
+      webhookService.getRegisteredWebhooks.mockReturnValue([
+        { repoFullName: 'owner/repo', webhookId: 42, repositoryPath: '/home/user/repo' },
+      ]);
+      const manager = new WebhookManagerService(tunnelService, webhookService);
+
+      expect(manager.isWebhookEnabledForRepo('/home/user/repo')).toBe(true);
+      expect(manager.isWebhookEnabledForRepo('\\home\\user\\repo')).toBe(true);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/core/src/infrastructure/services/webhook/webhook-manager.service.test.ts`
+Expected: FAIL — methods do not exist.
+
+- [ ] **Step 3: Implement the three methods**
+
+In `webhook-manager.service.ts`, add a `normalizePath` helper at the top:
+
+```typescript
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+```
+
+Add an interface for the enable result (above the class):
+
+```typescript
+export interface WebhookRepoResult {
+  success: boolean;
+  webhook?: RegisteredWebhook;
+  error?: string;
+}
+```
+
+Add three public methods to `WebhookManagerService`:
+
+```typescript
+async enableWebhookForRepo(repoPath: string): Promise<WebhookRepoResult> {
+  if (!this.tunnelService.isRunning() || !this.tunnelService.getPublicUrl()) {
+    return { success: false, error: 'tunnel_not_connected' };
+  }
+
+  const webhookUrl = `${this.tunnelService.getPublicUrl()}/api/webhooks/github`;
+  const ghService = this.webhookService as GitHubWebhookService;
+
+  try {
+    const webhook = await ghService.registerWebhookForSingleRepo(repoPath, webhookUrl);
+    return { success: true, webhook: webhook ?? undefined };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return { success: false, error: msg };
+  }
+}
+
+async disableWebhookForRepo(repoPath: string): Promise<{ success: boolean; error?: string }> {
+  const ghService = this.webhookService as GitHubWebhookService;
+
+  try {
+    await ghService.removeWebhookForRepo(repoPath);
+    return { success: true };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return { success: false, error: msg };
+  }
+}
+
+isWebhookEnabledForRepo(repoPath: string): boolean {
+  const ghService = this.webhookService as GitHubWebhookService;
+  const registered = typeof ghService.getRegisteredWebhooks === 'function'
+    ? ghService.getRegisteredWebhooks()
+    : [];
+  const normalized = normalizePath(repoPath);
+  return registered.some((w) => normalizePath(w.repositoryPath) === normalized);
+}
+```
+
+Also export `WebhookRepoResult` from the module.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run packages/core/src/infrastructure/services/webhook/webhook-manager.service.test.ts`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts packages/core/src/infrastructure/services/webhook/webhook-manager.service.test.ts
+git commit -m "feat(web): add per-repo enable disable and status methods to webhook manager"
+```
+
+---
+
+## Chunk 2: API Routes
+
+### Task 3: Create `/api/webhooks/repos/status` endpoint
+
+**Files:**
+
+- Create: `src/presentation/web/app/api/webhooks/repos/status/route.ts`
+
+**Context:** Follow the pattern from `src/presentation/web/app/api/webhooks/status/route.ts`. The endpoint takes `repositoryPath` as a query param and checks the webhook manager's `isWebhookEnabledForRepo()`.
+
+- [ ] **Step 1: Create the route handler**
+
+```typescript
+// src/presentation/web/app/api/webhooks/repos/status/route.ts
+/**
+ * Per-Repo Webhook Status: GET /api/webhooks/repos/status?repositoryPath=...
+ *
+ * Returns whether a webhook is enabled for a specific repository.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+import type { GitHubWebhookService } from '@shepai/core/infrastructure/services/webhook/github-webhook.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const repositoryPath = searchParams.get('repositoryPath');
+
+  if (!repositoryPath) {
+    return Response.json({ error: 'repositoryPath query parameter is required' }, { status: 400 });
+  }
+
+  if (!hasWebhookManager()) {
+    return Response.json({ enabled: false });
+  }
+
+  const manager = getWebhookManager();
+  const enabled = manager.isWebhookEnabledForRepo(repositoryPath);
+
+  if (!enabled) {
+    return Response.json({ enabled: false });
+  }
+
+  // Find the specific webhook details
+  const ghService = (manager as any).webhookService as GitHubWebhookService;
+  const normalized = repositoryPath.replace(/\\/g, '/');
+  const webhook = ghService
+    .getRegisteredWebhooks()
+    .find((w) => w.repositoryPath.replace(/\\/g, '/') === normalized);
+
+  return Response.json({
+    enabled: true,
+    webhookId: webhook?.webhookId,
+    repoFullName: webhook?.repoFullName,
+  });
+}
+```
+
+- [ ] **Step 2: Verify the route compiles**
+
+Run: `pnpm tsc --noEmit --project src/presentation/web/tsconfig.json 2>&1 | head -20`
+Expected: No type errors for this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/presentation/web/app/api/webhooks/repos/status/route.ts
+git commit -m "feat(web): add per-repo webhook status api endpoint"
+```
+
+---
+
+### Task 4: Create `/api/webhooks/repos/enable` endpoint
+
+**Files:**
+
+- Create: `src/presentation/web/app/api/webhooks/repos/enable/route.ts`
+
+- [ ] **Step 1: Create the route handler**
+
+```typescript
+// src/presentation/web/app/api/webhooks/repos/enable/route.ts
+/**
+ * Enable Webhook for Repo: POST /api/webhooks/repos/enable
+ *
+ * Body: { repositoryPath: string }
+ * Registers a GitHub webhook for the given repository.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request): Promise<Response> {
+  let body: { repositoryPath?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { repositoryPath } = body;
+  if (!repositoryPath) {
+    return Response.json({ success: false, error: 'repositoryPath is required' }, { status: 400 });
+  }
+
+  if (!hasWebhookManager()) {
+    return Response.json(
+      { success: false, error: 'Webhook system not initialized' },
+      { status: 503 }
+    );
+  }
+
+  const manager = getWebhookManager();
+  const result = await manager.enableWebhookForRepo(repositoryPath);
+  return Response.json(result, { status: result.success ? 200 : 422 });
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/presentation/web/app/api/webhooks/repos/enable/route.ts
+git commit -m "feat(web): add enable webhook api endpoint"
+```
+
+---
+
+### Task 5: Create `/api/webhooks/repos/disable` endpoint
+
+**Files:**
+
+- Create: `src/presentation/web/app/api/webhooks/repos/disable/route.ts`
+
+- [ ] **Step 1: Create the route handler**
+
+```typescript
+// src/presentation/web/app/api/webhooks/repos/disable/route.ts
+/**
+ * Disable Webhook for Repo: POST /api/webhooks/repos/disable
+ *
+ * Body: { repositoryPath: string }
+ * Removes the GitHub webhook for the given repository.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request): Promise<Response> {
+  let body: { repositoryPath?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { repositoryPath } = body;
+  if (!repositoryPath) {
+    return Response.json({ success: false, error: 'repositoryPath is required' }, { status: 400 });
+  }
+
+  if (!hasWebhookManager()) {
+    return Response.json(
+      { success: false, error: 'Webhook system not initialized' },
+      { status: 503 }
+    );
+  }
+
+  const manager = getWebhookManager();
+  const result = await manager.disableWebhookForRepo(repositoryPath);
+  return Response.json(result);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/presentation/web/app/api/webhooks/repos/disable/route.ts
+git commit -m "feat(web): add disable webhook api endpoint"
+```
+
+---
+
+## Chunk 3: UI Hook
+
+### Task 6: Create `useWebhookAction` hook
+
+**Files:**
+
+- Create: `src/presentation/web/hooks/use-webhook-action.ts`
+
+**Context:** Follow the `useRepositoryActions` pattern (error auto-clear after 5s) and `useDeployAction` pattern (mounted ref, cleanup). Fetches both tunnel status and per-repo webhook status on mount. Provides optimistic toggle with rollback.
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// src/presentation/web/hooks/use-webhook-action.ts
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+export interface WebhookActionState {
+  toggle: () => Promise<void>;
+  enabled: boolean;
+  loading: boolean;
+  error: string | null;
+  tunnelConnected: boolean;
+  webhookId: number | undefined;
+  repoFullName: string | undefined;
+  initializing: boolean;
+}
+
+const ERROR_CLEAR_DELAY = 5000;
+
+export function useWebhookAction(repositoryPath: string | null): WebhookActionState {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tunnelConnected, setTunnelConnected] = useState(false);
+  const [webhookId, setWebhookId] = useState<number | undefined>();
+  const [repoFullName, setRepoFullName] = useState<string | undefined>();
+  const [initializing, setInitializing] = useState(true);
+
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    };
+  }, []);
+
+  // Fetch initial status on mount
+  useEffect(() => {
+    if (!repositoryPath) {
+      setInitializing(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchStatus() {
+      try {
+        const [tunnelRes, repoRes] = await Promise.all([
+          fetch('/api/webhooks/status'),
+          fetch(`/api/webhooks/repos/status?repositoryPath=${encodeURIComponent(repositoryPath!)}`),
+        ]);
+
+        if (cancelled || !mountedRef.current) return;
+
+        const tunnelData = await tunnelRes.json();
+        const repoData = await repoRes.json();
+
+        if (cancelled || !mountedRef.current) return;
+
+        setTunnelConnected(tunnelData.tunnel?.connected ?? false);
+        setEnabled(repoData.enabled ?? false);
+        setWebhookId(repoData.webhookId);
+        setRepoFullName(repoData.repoFullName);
+      } catch {
+        // Silently fail — UI will show default disabled state
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setInitializing(false);
+        }
+      }
+    }
+
+    void fetchStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [repositoryPath]);
+
+  const handleToggle = useCallback(async () => {
+    if (!repositoryPath || loading) return;
+
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+
+    const wasEnabled = enabled;
+    const endpoint = wasEnabled ? '/api/webhooks/repos/disable' : '/api/webhooks/repos/enable';
+
+    // Optimistic update
+    setEnabled(!wasEnabled);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repositoryPath }),
+      });
+
+      if (!mountedRef.current) return;
+
+      const data = await res.json();
+
+      if (!data.success) {
+        // Rollback
+        setEnabled(wasEnabled);
+        const errorMsg = data.error ?? 'An unexpected error occurred';
+        setError(errorMsg);
+        errorTimerRef.current = setTimeout(() => {
+          if (mountedRef.current) setError(null);
+        }, ERROR_CLEAR_DELAY);
+      } else {
+        // Update details from server response
+        if (!wasEnabled && data.webhook) {
+          setWebhookId(data.webhook.webhookId);
+          setRepoFullName(data.webhook.repoFullName);
+        } else if (wasEnabled) {
+          setWebhookId(undefined);
+          setRepoFullName(undefined);
+        }
+      }
+    } catch (err: unknown) {
+      if (!mountedRef.current) return;
+      // Rollback
+      setEnabled(wasEnabled);
+      const errorMsg = err instanceof Error ? err.message : 'An unexpected error occurred';
+      setError(errorMsg);
+      errorTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setError(null);
+      }, ERROR_CLEAR_DELAY);
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [repositoryPath, loading, enabled]);
+
+  return {
+    toggle: handleToggle,
+    enabled,
+    loading,
+    error,
+    tunnelConnected,
+    webhookId,
+    repoFullName,
+    initializing,
+  };
+}
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `pnpm tsc --noEmit --project src/presentation/web/tsconfig.json 2>&1 | head -20`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/presentation/web/hooks/use-webhook-action.ts
+git commit -m "feat(web): add use-webhook-action hook with optimistic toggle"
+```
+
+---
+
+## Chunk 4: UI Components
+
+### Task 7: Add webhook action button to RepositoryNode
+
+**Files:**
+
+- Modify: `src/presentation/web/components/common/repository-node/repository-node.tsx`
+
+**Context:** Add a `Radio` icon button in the action row between `FolderOpen` and `FeatureSessionsDropdown`. Use the `useWebhookAction` hook. When `tunnelConnected` is false, the button is disabled. When `enabled` is true, the icon is green. Use existing `ActionButton` + `TooltipProvider` pattern from the adjacent buttons.
+
+- [ ] **Step 1: Add the webhook button to the node**
+
+In `repository-node.tsx`:
+
+1. Add imports:
+
+```typescript
+import { Radio } from 'lucide-react';
+import { useWebhookAction } from '@/hooks/use-webhook-action';
+```
+
+2. Inside the `RepositoryNode` function, add the hook call after `useRepositoryActions`:
+
+```typescript
+const webhookAction = useWebhookAction(data.repositoryPath ?? null);
+```
+
+3. After the `FolderOpen` `TooltipProvider` block (line ~233) and before `FeatureSessionsDropdown` (line ~234), insert:
+
+```tsx
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <span className="flex items-center">
+        <ActionButton
+          label={
+            !webhookAction.tunnelConnected
+              ? 'Webhook unavailable — tunnel not running'
+              : webhookAction.enabled
+                ? 'Disable webhook'
+                : 'Enable webhook'
+          }
+          onClick={webhookAction.toggle}
+          loading={webhookAction.loading}
+          error={!!webhookAction.error}
+          icon={Radio}
+          iconOnly
+          variant="ghost"
+          size="icon-xs"
+          disabled={!webhookAction.tunnelConnected}
+          className={
+            webhookAction.enabled && !webhookAction.error
+              ? 'text-green-500 hover:text-green-600'
+              : undefined
+          }
+        />
+      </span>
+    </TooltipTrigger>
+    <TooltipContent>
+      {!webhookAction.tunnelConnected
+        ? 'Webhook unavailable — tunnel not running'
+        : webhookAction.enabled
+          ? 'Disable webhook'
+          : 'Enable webhook'}
+    </TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+**Note:** The `ActionButton` component does not currently accept `disabled` or `className` props. Check if these need to be added. If `ActionButton` doesn't support `disabled`, pass it through by adding `disabled?: boolean` and `className?: string` to `ActionButtonProps` and forwarding them to the `<Button>` element. The `disabled` should combine with the existing `loading` check: `disabled={loading || disabled}`. The `className` should be merged with `cn()`.
+
+- [ ] **Step 2: Update `ActionButton` if needed**
+
+Check if `ActionButton` already supports `disabled` and `className` props. If not, modify `src/presentation/web/components/common/action-button/action-button.tsx`:
+
+Add to `ActionButtonProps`:
+
+```typescript
+/** Extra CSS classes for the button */
+className?: string;
+/** Explicitly disable the button (in addition to loading state) */
+disabled?: boolean;
+```
+
+Update the destructuring and `<Button>`:
+
+```typescript
+export function ActionButton({
+  label,
+  onClick,
+  loading,
+  error,
+  icon: Icon,
+  iconOnly = false,
+  variant = 'outline',
+  size = 'sm',
+  className: extraClassName,
+  disabled,
+}: ActionButtonProps) {
+  // ...
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      aria-label={label}
+      disabled={loading || disabled}
+      onClick={handleClick}
+      className={cn(
+        'gap-1.5',
+        error && 'text-destructive hover:text-destructive',
+        !error &&
+          iconOnly &&
+          variant === 'ghost' &&
+          'text-muted-foreground cursor-pointer rounded-full transition-colors hover:text-blue-500',
+        extraClassName
+      )}
+    >
+```
+
+- [ ] **Step 3: Verify no type errors and the button renders**
+
+Run: `pnpm tsc --noEmit --project src/presentation/web/tsconfig.json 2>&1 | head -20`
+Expected: No type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/presentation/web/components/common/repository-node/repository-node.tsx src/presentation/web/components/common/action-button/action-button.tsx
+git commit -m "feat(web): add webhook toggle button to repository node"
+```
+
+---
+
+### Task 8: Add webhook section to RepositoryDrawer
+
+**Files:**
+
+- Modify: `src/presentation/web/components/common/repository-node/repository-drawer.tsx`
+
+**Context:** Add a "WEBHOOKS" section below "OPEN WITH", following the same layout pattern (Separator + section with heading). Use `useWebhookAction` hook. Show ActionButton with label + detail badges when enabled.
+
+- [ ] **Step 1: Update the drawer**
+
+In `repository-drawer.tsx`:
+
+1. Add imports:
+
+```typescript
+import { Radio } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { useWebhookAction } from '@/hooks/use-webhook-action';
+```
+
+2. Inside the component, add the hook:
+
+```typescript
+const webhookAction = useWebhookAction(data?.repositoryPath ?? null);
+```
+
+3. After the closing `</div>` of the "OPEN WITH" section (before `</>`) add:
+
+```tsx
+<Separator />
+<div className="flex flex-col gap-3 p-4">
+  <div className="text-muted-foreground text-xs font-semibold tracking-wider">
+    WEBHOOKS
+  </div>
+  <div className="flex flex-col gap-2">
+    <ActionButton
+      label={
+        !webhookAction.tunnelConnected
+          ? 'Webhook unavailable — tunnel not running'
+          : webhookAction.enabled
+            ? 'Disable Webhook'
+            : 'Enable Webhook'
+      }
+      onClick={webhookAction.toggle}
+      loading={webhookAction.loading}
+      error={!!webhookAction.error}
+      icon={Radio}
+      variant="outline"
+      size="sm"
+      disabled={!webhookAction.tunnelConnected}
+      className={webhookAction.enabled && !webhookAction.error ? 'text-green-500 border-green-500/30 hover:text-green-600' : undefined}
+    />
+    {webhookAction.enabled && webhookAction.webhookId ? (
+      <div className="flex flex-col gap-2">
+        <div className="text-muted-foreground text-xs">
+          Webhook #{webhookAction.webhookId}
+          {webhookAction.repoFullName ? ` on ${webhookAction.repoFullName}` : ''}
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {['pull_request', 'check_suite', 'check_run'].map((event) => (
+            <Badge key={event} variant="secondary" className="text-xs">
+              {event}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    ) : null}
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Verify no type errors**
+
+Run: `pnpm tsc --noEmit --project src/presentation/web/tsconfig.json 2>&1 | head -20`
+Expected: No type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/presentation/web/components/common/repository-node/repository-drawer.tsx
+git commit -m "feat(web): add webhook section to repository drawer"
+```
+
+---
+
+## Chunk 5: Storybook Stories
+
+### Task 9: Add Storybook stories for webhook states
+
+**Files:**
+
+- Modify: `src/presentation/web/components/common/repository-node/repository-node.stories.tsx`
+- Modify: `src/presentation/web/components/common/repository-node/repository-drawer.stories.tsx`
+
+**Context:** The `useWebhookAction` hook calls `fetch()` internally, so stories need fetch mocks via Storybook's `msw` or parameter-based mocking. However, following the existing pattern in this project (stories use real components with no fetch mocking — they just show the visual states), we should mock at the module level using Storybook's module mock or simply accept that the webhook button will show its default (initializing) state in stories. The simplest approach: stories show the component as-is. The hook will fail to fetch in Storybook (no API server) and default to `enabled: false, tunnelConnected: false` — which shows the disabled state. This is acceptable for Storybook since the visual states are visible.
+
+**However**, to show all visual states, we need to add a Storybook mock for the fetch calls. Check if the project uses msw or a custom mock pattern for Storybook. If not, the stories just show the default disabled state, which is fine for now.
+
+- [ ] **Step 1: Add webhook-related stories to repository-node.stories.tsx**
+
+Add a story `WithWebhookButton` that shows the node with `repositoryPath` set (which enables the webhook button):
+
+```typescript
+export const WithWebhookButton: Story = {
+  args: {
+    repositoryPath: '/home/user/shep-ai/cli',
+  },
+  render: (args) => <RepositoryNodeCanvas data={args} />,
+};
+```
+
+This is essentially the same as `WithActions` but explicitly named for webhook visibility. The existing `WithActions` story already shows the button since it has `repositoryPath`.
+
+- [ ] **Step 2: Add webhook stories to repository-drawer.stories.tsx**
+
+Add a story showing the drawer with the webhook section:
+
+```typescript
+export const WithWebhookSection: Story = {
+  render: () => <RepositoryDrawerShellTemplate data={repoData} />,
+};
+```
+
+Again, the existing `Default`/`InDrawer` stories already show this since `repoData` has `repositoryPath`. Add the explicit story for documentation.
+
+- [ ] **Step 3: Verify Storybook builds**
+
+Run: `pnpm storybook build 2>&1 | tail -5` (or just typecheck)
+Expected: No build errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/presentation/web/components/common/repository-node/repository-node.stories.tsx src/presentation/web/components/common/repository-node/repository-drawer.stories.tsx
+git commit -m "feat(web): add storybook stories for webhook toggle states"
+```
+
+---
+
+## Chunk 6: Validation
+
+### Task 10: Run full validation
+
+- [ ] **Step 1: Run lint and typecheck**
+
+Run: `pnpm validate`
+Expected: All checks pass.
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `pnpm test:unit`
+Expected: All tests pass, including the new webhook service tests.
+
+- [ ] **Step 3: Fix any issues found**
+
+Address lint errors, type errors, or test failures.
+
+- [ ] **Step 4: Final commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix(web): address validation issues in webhook toggle feature"
+```

--- a/docs/superpowers/specs/2026-03-16-per-repo-webhook-toggle-design.md
+++ b/docs/superpowers/specs/2026-03-16-per-repo-webhook-toggle-design.md
@@ -14,14 +14,16 @@ Add a per-repo webhook toggle on the repository node (action button) and reposit
 
 New methods on `GitHubWebhookService`:
 
-- `registerWebhookForSingleRepo(repoPath: string, publicUrl: string)` — exposes the existing private `registerWebhookForRepo()` for single-repo registration
-- `removeWebhookForRepo(repoPath: string)` — finds and removes the webhook for a specific repo path from the `registeredWebhooks` array and GitHub API
+- `registerWebhookForSingleRepo(repoPath: string, webhookUrl: string)` — checks if a webhook is already registered for this repo path (after normalizing to forward slashes) and no-ops if so; otherwise delegates to the existing private `registerWebhookForRepo()`
+- `removeWebhookForRepo(repoPath: string)` — finds the registered webhook for this repo path (normalized comparison), removes it from GitHub via DELETE API, then removes from the in-memory `registeredWebhooks` array
 
 New methods on `WebhookManagerService`:
 
-- `enableWebhookForRepo(repoPath: string)` — validates tunnel is running, gets tunnel URL, delegates to `GitHubWebhookService.registerWebhookForSingleRepo()`
+- `enableWebhookForRepo(repoPath: string)` — validates tunnel is running (returns `{ success: false, error: "tunnel_not_connected" }` if not), constructs webhook URL as `${tunnelUrl}/api/webhooks/github`, delegates to `GitHubWebhookService.registerWebhookForSingleRepo()`
 - `disableWebhookForRepo(repoPath: string)` — delegates to `GitHubWebhookService.removeWebhookForRepo()`
-- `isWebhookEnabledForRepo(repoPath: string)` — checks if repo path exists in the registered webhooks list
+- `isWebhookEnabledForRepo(repoPath: string)` — checks if repo path exists in the registered webhooks list (normalized path comparison)
+
+**Path normalization**: All path comparisons in the service layer normalize to forward slashes before matching (`path.replace(/\\\\/g, '/')`). This applies to `isWebhookEnabledForRepo`, `removeWebhookForRepo`, and the duplicate check in `registerWebhookForSingleRepo`.
 
 These are concrete methods on the service classes, not on `IWebhookService`. This is consistent with how `getStatus()` and `getDeliveryHistory()` already bypass the interface.
 
@@ -35,7 +37,7 @@ Three new endpoints under `/api/webhooks/repos/`:
 | `POST` | `/api/webhooks/repos/disable` | `{ repositoryPath: string }` | `{ success: boolean, error?: string }`                              |
 | `GET`  | `/api/webhooks/repos/status`  | `?repositoryPath=...`        | `{ enabled: boolean, webhookId?: number, repoFullName?: string }`   |
 
-All endpoints check `hasWebhookManager()` and return appropriate errors if the system is not initialized.
+All endpoints check `hasWebhookManager()` and return appropriate errors if the system is not initialized. The enable endpoint returns a machine-readable error code when the tunnel is not connected: `{ success: false, error: "tunnel_not_connected" }`.
 
 ### UI Layer
 
@@ -66,8 +68,9 @@ New hook (similar pattern to `useRepositoryActions`):
 
 - **Input**: `repositoryPath: string | null`
 - **Fetches**: webhook status for the repo via `GET /api/webhooks/repos/status` on mount
-- **Checks**: tunnel status from `GET /api/webhooks/status` to determine if toggle should be disabled
+- **Checks**: tunnel status from `GET /api/webhooks/status` (only reads `tunnel.connected`, ignores the rest) — fetched once on mount, acceptably stale while drawer/node is open
 - **Exposes**: `toggle()`, `enabled`, `loading`, `error`, `tunnelConnected`, `webhookId`, `repoFullName`
+- **Optimistic updates**: on toggle, immediately flip `enabled` state in the hook before the server responds; on error, roll back to previous state and set `error`
 - **Error handling**: auto-clear after 5s (matching `useRepositoryActions` pattern)
 
 No changes to `RepositoryNodeData` — the hook derives everything from `repositoryPath`.
@@ -97,6 +100,12 @@ No changes to `RepositoryNodeData` — the hook derives everything from `reposit
 - `src/presentation/web/components/common/repository-node/repository-drawer.tsx` — add webhooks section
 - `src/presentation/web/components/common/repository-node/repository-node.stories.tsx` — add webhook state stories
 - `src/presentation/web/components/common/repository-node/repository-drawer.stories.tsx` — add webhook section stories
+
+### Edge Cases
+
+- **Duplicate registration**: `registerWebhookForSingleRepo` checks if a webhook is already registered for the repo path before creating a new one. If already registered, it no-ops and returns the existing webhook.
+- **Bulk + manual overlap**: If bulk registration on startup already registered a webhook for a repo, the toggle will show it as enabled. Disabling removes it for the current session. On next restart, bulk registration will re-register it. This is expected behavior given the in-memory non-goal.
+- **Tunnel disconnects while webhook is enabled**: The webhook remains registered on GitHub but events will fail delivery. The UI continues to show the webhook as enabled (accurate — it is registered). Re-enabling after tunnel reconnects is not needed since the webhook URL auto-updates via the existing `onUrlChange` handler.
 
 ### Non-Goals
 

--- a/docs/superpowers/specs/2026-03-16-per-repo-webhook-toggle-design.md
+++ b/docs/superpowers/specs/2026-03-16-per-repo-webhook-toggle-design.md
@@ -1,0 +1,105 @@
+# Per-Repository Webhook Enable/Disable
+
+## Problem
+
+The webhook system currently operates as all-or-nothing: it starts automatically with the web server and bulk-registers webhooks for all repos with features in the Review lifecycle. Users have no way to enable or disable webhooks for individual repositories from the UI.
+
+## Solution
+
+Add a per-repo webhook toggle on the repository node (action button) and repository drawer (labeled button with details). The toggle registers or removes a GitHub webhook for that specific repo using the already-running Cloudflare tunnel. When the tunnel is not running, the toggle is disabled with a tooltip.
+
+## Design
+
+### Service Layer
+
+New methods on `GitHubWebhookService`:
+
+- `registerWebhookForSingleRepo(repoPath: string, publicUrl: string)` — exposes the existing private `registerWebhookForRepo()` for single-repo registration
+- `removeWebhookForRepo(repoPath: string)` — finds and removes the webhook for a specific repo path from the `registeredWebhooks` array and GitHub API
+
+New methods on `WebhookManagerService`:
+
+- `enableWebhookForRepo(repoPath: string)` — validates tunnel is running, gets tunnel URL, delegates to `GitHubWebhookService.registerWebhookForSingleRepo()`
+- `disableWebhookForRepo(repoPath: string)` — delegates to `GitHubWebhookService.removeWebhookForRepo()`
+- `isWebhookEnabledForRepo(repoPath: string)` — checks if repo path exists in the registered webhooks list
+
+These are concrete methods on the service classes, not on `IWebhookService`. This is consistent with how `getStatus()` and `getDeliveryHistory()` already bypass the interface.
+
+### API Layer
+
+Three new endpoints under `/api/webhooks/repos/`:
+
+| Method | Path                          | Body/Query                   | Response                                                            |
+| ------ | ----------------------------- | ---------------------------- | ------------------------------------------------------------------- |
+| `POST` | `/api/webhooks/repos/enable`  | `{ repositoryPath: string }` | `{ success: boolean, webhook?: RegisteredWebhook, error?: string }` |
+| `POST` | `/api/webhooks/repos/disable` | `{ repositoryPath: string }` | `{ success: boolean, error?: string }`                              |
+| `GET`  | `/api/webhooks/repos/status`  | `?repositoryPath=...`        | `{ enabled: boolean, webhookId?: number, repoFullName?: string }`   |
+
+All endpoints check `hasWebhookManager()` and return appropriate errors if the system is not initialized.
+
+### UI Layer
+
+#### Repository Node
+
+A new action button in the existing action row (after Open Folder, before Sessions dropdown):
+
+- **Icon**: `Radio` from lucide-react
+- **States**:
+  - Tunnel not running: disabled, gray icon, tooltip "Webhook unavailable — tunnel not running"
+  - Tunnel running, webhook off: enabled, gray icon, tooltip "Enable webhook"
+  - Tunnel running, webhook on: enabled, green icon (`text-green-500`), tooltip "Disable webhook"
+  - Loading: spinner replacing icon (matches existing ActionButton pattern)
+  - Error: red alert icon, auto-clears after 5s (matches existing pattern)
+
+#### Repository Drawer
+
+A new "WEBHOOKS" section below the existing "OPEN WITH" section:
+
+- ActionButton with label text (not icon-only) — "Enable Webhook" / "Disable Webhook"
+- When enabled: displays webhook ID and subscribed event badges (`pull_request`, `check_suite`, `check_run`)
+- When disabled: just the enable button
+- Same disabled state when tunnel is not running
+
+#### Hook: `useWebhookAction`
+
+New hook (similar pattern to `useRepositoryActions`):
+
+- **Input**: `repositoryPath: string | null`
+- **Fetches**: webhook status for the repo via `GET /api/webhooks/repos/status` on mount
+- **Checks**: tunnel status from `GET /api/webhooks/status` to determine if toggle should be disabled
+- **Exposes**: `toggle()`, `enabled`, `loading`, `error`, `tunnelConnected`, `webhookId`, `repoFullName`
+- **Error handling**: auto-clear after 5s (matching `useRepositoryActions` pattern)
+
+No changes to `RepositoryNodeData` — the hook derives everything from `repositoryPath`.
+
+### Testing
+
+| Layer   | Test                                                                         | Approach                                                   |
+| ------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Service | `enableWebhookForRepo` / `disableWebhookForRepo` / `isWebhookEnabledForRepo` | Unit tests with mocked `execFn` and tunnel service         |
+| API     | Enable / disable / status endpoints                                          | Unit tests with mocked webhook manager                     |
+| Hook    | `useWebhookAction`                                                           | Unit tests with mocked fetch for all states                |
+| UI      | Repository node webhook button                                               | Storybook stories: enabled, disabled, tunnel down, loading |
+| UI      | Repository drawer webhook section                                            | Storybook stories with webhook details                     |
+
+### Files to Create
+
+- `src/presentation/web/app/api/webhooks/repos/enable/route.ts`
+- `src/presentation/web/app/api/webhooks/repos/disable/route.ts`
+- `src/presentation/web/app/api/webhooks/repos/status/route.ts`
+- `src/presentation/web/hooks/use-webhook-action.ts`
+
+### Files to Modify
+
+- `packages/core/src/infrastructure/services/webhook/github-webhook.service.ts` — add `registerWebhookForSingleRepo()`, `removeWebhookForRepo()`
+- `packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts` — add `enableWebhookForRepo()`, `disableWebhookForRepo()`, `isWebhookEnabledForRepo()`
+- `src/presentation/web/components/common/repository-node/repository-node.tsx` — add webhook action button
+- `src/presentation/web/components/common/repository-node/repository-drawer.tsx` — add webhooks section
+- `src/presentation/web/components/common/repository-node/repository-node.stories.tsx` — add webhook state stories
+- `src/presentation/web/components/common/repository-node/repository-drawer.stories.tsx` — add webhook section stories
+
+### Non-Goals
+
+- Persisting webhook state across restarts (webhooks are in-memory, cleaned up on shutdown)
+- Auto-registering webhooks on startup (existing bulk behavior stays, this is additive)
+- Modifying the `IWebhookService` interface

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3",
+      "cloudflared",
       "esbuild",
       "sharp"
     ],
@@ -181,6 +182,7 @@
     "ajv-formats": "^3.0.1",
     "better-sqlite3": "^12.6.2",
     "cli-table3": "^0.6.5",
+    "cloudflared": "^0.7.1",
     "commander": "^14.0.3",
     "js-yaml": "^4.1.1",
     "minimatch": "^7.x",

--- a/packages/core/src/application/ports/output/services/index.ts
+++ b/packages/core/src/application/ports/output/services/index.ts
@@ -39,3 +39,9 @@ export type {
 } from './ide-launcher-service.interface.js';
 export type { IDaemonService, DaemonState } from './daemon-service.interface.js';
 export type { IDeploymentService, DeploymentStatus } from './deployment-service.interface.js';
+export type { ITunnelService, TunnelUrlChangeHandler } from './tunnel-service.interface.js';
+export type {
+  IWebhookService,
+  WebhookEvent,
+  WebhookValidationResult,
+} from './webhook-service.interface.js';

--- a/packages/core/src/application/ports/output/services/tunnel-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/tunnel-service.interface.ts
@@ -1,0 +1,46 @@
+/**
+ * Tunnel Service Interface
+ *
+ * Output port for managing a reverse tunnel that exposes local endpoints
+ * to the public internet. Used to receive webhooks from external services
+ * (e.g., GitHub) when running locally.
+ *
+ * Implementations must:
+ * - Start a tunnel process pointing at a local port
+ * - Expose only a specific URL path (e.g., /api/webhooks)
+ * - Detect when the public URL changes (tunnel reconnection)
+ * - Support graceful shutdown
+ */
+
+export type TunnelUrlChangeHandler = (newUrl: string) => void | Promise<void>;
+
+export interface ITunnelService {
+  /**
+   * Start the tunnel, exposing a local port to the internet.
+   *
+   * @param localPort - Local port to tunnel traffic to
+   * @returns The public URL assigned by the tunnel provider
+   */
+  start(localPort: number): Promise<string>;
+
+  /**
+   * Stop the tunnel and clean up the child process.
+   */
+  stop(): Promise<void>;
+
+  /**
+   * Get the current public URL, or null if the tunnel is not running.
+   */
+  getPublicUrl(): string | null;
+
+  /**
+   * Register a callback that fires when the tunnel URL changes
+   * (e.g., after a reconnection assigns a new random subdomain).
+   */
+  onUrlChange(handler: TunnelUrlChangeHandler): void;
+
+  /**
+   * Whether the tunnel process is currently running.
+   */
+  isRunning(): boolean;
+}

--- a/packages/core/src/application/ports/output/services/webhook-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/webhook-service.interface.ts
@@ -1,0 +1,71 @@
+/**
+ * Webhook Service Interface
+ *
+ * Output port for managing webhook registrations with external services
+ * (e.g., GitHub) and processing incoming webhook events.
+ *
+ * Works alongside the polling-based PrSyncWatcher to provide near-instant
+ * event delivery when a tunnel is available, with polling as fallback.
+ */
+
+/**
+ * Parsed webhook event from an external service.
+ */
+export interface WebhookEvent {
+  /** Source service (e.g., 'github') */
+  source: string;
+  /** Event type (e.g., 'pull_request', 'check_suite') */
+  eventType: string;
+  /** Delivery ID for deduplication */
+  deliveryId: string;
+  /** Full event payload */
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Result of webhook signature validation.
+ */
+export interface WebhookValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+export interface IWebhookService {
+  /**
+   * Register webhooks for all tracked repositories.
+   *
+   * @param publicUrl - The public tunnel URL where webhooks will be received
+   */
+  registerWebhooks(publicUrl: string): Promise<void>;
+
+  /**
+   * Update the webhook URL for all registered webhooks.
+   * Called when the tunnel reconnects with a new URL.
+   *
+   * @param newUrl - The new public tunnel URL
+   */
+  updateWebhookUrl(newUrl: string): Promise<void>;
+
+  /**
+   * Remove all registered webhooks (cleanup on shutdown).
+   */
+  removeWebhooks(): Promise<void>;
+
+  /**
+   * Validate an incoming webhook request signature.
+   *
+   * @param payload - Raw request body
+   * @param signature - Signature header value
+   * @param secret - The webhook secret used for HMAC
+   * @returns Validation result
+   */
+  validateSignature(payload: string, signature: string, secret: string): WebhookValidationResult;
+
+  /**
+   * Process an incoming webhook event.
+   * Routes the event to the appropriate handler (e.g., PR status update).
+   *
+   * @param event - The parsed webhook event
+   */
+  handleEvent(event: WebhookEvent): Promise<void>;
+}

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -47,6 +47,10 @@ import { DaemonPidService } from '../services/daemon/daemon-pid.service.js';
 import type { IDeploymentService } from '../../application/ports/output/services/deployment-service.interface.js';
 import { DeploymentService } from '../services/deployment/deployment.service.js';
 import { AttachmentStorageService } from '../services/attachment-storage.service.js';
+import type { ITunnelService } from '../../application/ports/output/services/tunnel-service.interface.js';
+import type { IWebhookService } from '../../application/ports/output/services/webhook-service.interface.js';
+import { CloudflareTunnelService } from '../services/tunnel/cloudflare-tunnel.service.js';
+import { GitHubWebhookService } from '../services/webhook/github-webhook.service.js';
 
 // Agent infrastructure interfaces and implementations
 import type { IAgentExecutorFactory } from '../../application/ports/output/agents/agent-executor-factory.interface.js';
@@ -222,6 +226,20 @@ export async function initializeContainer(): Promise<typeof container> {
   container.register('AttachmentStorageService', { useToken: AttachmentStorageService });
   const deploymentService = new DeploymentService();
   container.registerInstance<IDeploymentService>('IDeploymentService', deploymentService);
+
+  // Register tunnel and webhook services
+  container.register<ITunnelService>('ITunnelService', {
+    useFactory: () => new CloudflareTunnelService(),
+  });
+
+  container.register<IWebhookService>('IWebhookService', {
+    useFactory: (c) => {
+      const featureRepo = c.resolve<IFeatureRepository>('IFeatureRepository');
+      const gitPrService = c.resolve<IGitPrService>('IGitPrService');
+      const notifService = c.resolve<INotificationService>('INotificationService');
+      return new GitHubWebhookService(featureRepo, gitPrService, notifService, execFn);
+    },
+  });
 
   // Register agent infrastructure
   container.register<IAgentRunRepository>('IAgentRunRepository', {

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -232,12 +232,21 @@ export async function initializeContainer(): Promise<typeof container> {
     useFactory: () => new CloudflareTunnelService(),
   });
 
+  let webhookServiceInstance: IWebhookService | null = null;
   container.register<IWebhookService>('IWebhookService', {
     useFactory: (c) => {
-      const featureRepo = c.resolve<IFeatureRepository>('IFeatureRepository');
-      const gitPrService = c.resolve<IGitPrService>('IGitPrService');
-      const notifService = c.resolve<INotificationService>('INotificationService');
-      return new GitHubWebhookService(featureRepo, gitPrService, notifService, execFn);
+      if (!webhookServiceInstance) {
+        const featureRepo = c.resolve<IFeatureRepository>('IFeatureRepository');
+        const gitPrService = c.resolve<IGitPrService>('IGitPrService');
+        const notifService = c.resolve<INotificationService>('INotificationService');
+        webhookServiceInstance = new GitHubWebhookService(
+          featureRepo,
+          gitPrService,
+          notifService,
+          execFn
+        );
+      }
+      return webhookServiceInstance;
     },
   });
 

--- a/packages/core/src/infrastructure/services/tunnel/cloudflare-tunnel.service.ts
+++ b/packages/core/src/infrastructure/services/tunnel/cloudflare-tunnel.service.ts
@@ -1,0 +1,180 @@
+/**
+ * Cloudflare Tunnel Service
+ *
+ * Manages a `cloudflared` quick-tunnel process that exposes a local port
+ * to the public internet via a random *.trycloudflare.com subdomain.
+ *
+ * Key behaviors:
+ * - Spawns `cloudflared tunnel --url http://localhost:<port>`
+ * - Parses the assigned public URL from process stderr
+ * - Detects URL changes on reconnection and notifies listeners
+ * - Gracefully kills the process on stop()
+ *
+ * The tunnel exposes the full local port but only the webhook API route
+ * should be registered with external services. Path-level filtering
+ * happens at the webhook route handler, not the tunnel layer.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import type {
+  ITunnelService,
+  TunnelUrlChangeHandler,
+} from '../../../application/ports/output/services/tunnel-service.interface.js';
+import { IS_WINDOWS } from '../../platform.js';
+
+const TAG = '[CloudflareTunnel]';
+const CLOUDFLARED_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+const STARTUP_TIMEOUT_MS = 30_000;
+
+export interface CloudflareTunnelDeps {
+  spawnProcess: typeof spawn;
+}
+
+const defaultDeps: CloudflareTunnelDeps = {
+  spawnProcess: spawn,
+};
+
+export class CloudflareTunnelService implements ITunnelService {
+  private process: ChildProcess | null = null;
+  private publicUrl: string | null = null;
+  private readonly urlChangeHandlers: TunnelUrlChangeHandler[] = [];
+  private readonly deps: CloudflareTunnelDeps;
+
+  constructor(deps: Partial<CloudflareTunnelDeps> = {}) {
+    this.deps = { ...defaultDeps, ...deps };
+  }
+
+  async start(localPort: number): Promise<string> {
+    if (this.process) {
+      throw new Error(`${TAG} Tunnel already running at ${this.publicUrl}`);
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.killProcess();
+        reject(new Error(`${TAG} Timed out waiting for tunnel URL (${STARTUP_TIMEOUT_MS}ms)`));
+      }, STARTUP_TIMEOUT_MS);
+
+      const args = ['tunnel', '--url', `http://localhost:${localPort}`];
+
+      const child = this.deps.spawnProcess('cloudflared', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        ...(IS_WINDOWS ? { windowsHide: true } : {}),
+      });
+
+      this.process = child;
+
+      const handleOutput = (data: Buffer) => {
+        const line = data.toString();
+        const match = line.match(CLOUDFLARED_URL_REGEX);
+        if (match) {
+          const url = match[0];
+
+          if (!this.publicUrl) {
+            // First URL — startup complete
+            this.publicUrl = url;
+            clearTimeout(timeout);
+            // eslint-disable-next-line no-console
+            console.log(`${TAG} Tunnel ready: ${url}`);
+            resolve(url);
+          } else if (url !== this.publicUrl) {
+            // URL changed — reconnection with new subdomain
+            const oldUrl = this.publicUrl;
+            this.publicUrl = url;
+            // eslint-disable-next-line no-console
+            console.log(`${TAG} Tunnel URL changed: ${oldUrl} -> ${url}`);
+            this.notifyUrlChange(url);
+          }
+        }
+      };
+
+      child.stdout?.on('data', handleOutput);
+      child.stderr?.on('data', handleOutput);
+
+      child.on('error', (err) => {
+        clearTimeout(timeout);
+        this.process = null;
+        this.publicUrl = null;
+
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          reject(
+            new Error(
+              `${TAG} 'cloudflared' not found. Install it: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/`
+            )
+          );
+        } else {
+          reject(new Error(`${TAG} Failed to start tunnel: ${err.message}`));
+        }
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        if (this.process === child) {
+          this.process = null;
+          const wasRunning = this.publicUrl !== null;
+          this.publicUrl = null;
+
+          if (wasRunning) {
+            // eslint-disable-next-line no-console
+            console.log(`${TAG} Tunnel process exited (code ${code})`);
+          } else {
+            // Process exited before producing a URL
+            reject(new Error(`${TAG} cloudflared exited with code ${code} before producing a URL`));
+          }
+        }
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.killProcess();
+    this.publicUrl = null;
+  }
+
+  getPublicUrl(): string | null {
+    return this.publicUrl;
+  }
+
+  onUrlChange(handler: TunnelUrlChangeHandler): void {
+    this.urlChangeHandlers.push(handler);
+  }
+
+  isRunning(): boolean {
+    return this.process !== null && this.publicUrl !== null;
+  }
+
+  private killProcess(): void {
+    if (this.process) {
+      const child = this.process;
+      this.process = null;
+
+      try {
+        // On Windows, tree-kill is needed for child processes.
+        // cloudflared is well-behaved and exits on SIGTERM.
+        if (!child.killed) {
+          child.kill('SIGTERM');
+        }
+      } catch {
+        // Process already exited
+      }
+    }
+  }
+
+  private notifyUrlChange(newUrl: string): void {
+    for (const handler of this.urlChangeHandlers) {
+      try {
+        const result = handler(newUrl);
+        if (result instanceof Promise) {
+          result.catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn(`${TAG} URL change handler failed:`, err);
+          });
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(`${TAG} URL change handler threw:`, err);
+      }
+    }
+  }
+}

--- a/packages/core/src/infrastructure/services/tunnel/cloudflare-tunnel.service.ts
+++ b/packages/core/src/infrastructure/services/tunnel/cloudflare-tunnel.service.ts
@@ -1,42 +1,59 @@
 /**
  * Cloudflare Tunnel Service
  *
- * Manages a `cloudflared` quick-tunnel process that exposes a local port
- * to the public internet via a random *.trycloudflare.com subdomain.
+ * Manages a `cloudflared` quick-tunnel that exposes ONLY the webhook
+ * API routes to the public internet via a random *.trycloudflare.com
+ * subdomain.
  *
- * Key behaviors:
- * - Spawns `cloudflared tunnel --url http://localhost:<port>`
- * - Parses the assigned public URL from process stderr
- * - Detects URL changes on reconnection and notifies listeners
- * - Gracefully kills the process on stop()
+ * Uses the `cloudflared` npm package which handles binary installation
+ * and provides a typed Tunnel API — no need for the user to install
+ * cloudflared separately.
  *
- * The tunnel exposes the full local port but only the webhook API route
- * should be registered with external services. Path-level filtering
- * happens at the webhook route handler, not the tunnel layer.
+ * Security: A lightweight proxy HTTP server is started on a random port
+ * that only forwards requests matching the allowed path prefix
+ * (/api/webhooks) to the main app. The tunnel connects to this proxy,
+ * not the main app server. All other paths return 404.
  */
 
-import type { ChildProcess } from 'node:child_process';
-import { spawn } from 'node:child_process';
+import { createServer, request as httpRequest } from 'node:http';
+import type { Server, IncomingMessage, ServerResponse } from 'node:http';
 import type {
   ITunnelService,
   TunnelUrlChangeHandler,
 } from '../../../application/ports/output/services/tunnel-service.interface.js';
-import { IS_WINDOWS } from '../../platform.js';
 
 const TAG = '[CloudflareTunnel]';
-const CLOUDFLARED_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
 const STARTUP_TIMEOUT_MS = 30_000;
+const ALLOWED_PATH_PREFIX = '/api/webhooks';
 
 export interface CloudflareTunnelDeps {
-  spawnProcess: typeof spawn;
+  createTunnel: (origin: string) => TunnelLike | Promise<TunnelLike>;
+}
+
+export interface TunnelLike {
+  on(event: 'url', handler: (url: string) => void): void;
+  on(
+    event: 'connected',
+    handler: (connection: { id: string; ip: string; location: string }) => void
+  ): void;
+  on(event: 'error', handler: (error: Error) => void): void;
+  on(event: 'exit', handler: (code: number | null, signal: string | null) => void): void;
+  once(event: string, handler: (...args: unknown[]) => void): void;
+  stop(): void;
+}
+
+async function defaultCreateTunnel(origin: string): Promise<TunnelLike> {
+  const { Tunnel } = await import('cloudflared');
+  return Tunnel.quick(origin);
 }
 
 const defaultDeps: CloudflareTunnelDeps = {
-  spawnProcess: spawn,
+  createTunnel: defaultCreateTunnel,
 };
 
 export class CloudflareTunnelService implements ITunnelService {
-  private process: ChildProcess | null = null;
+  private tunnel: TunnelLike | null = null;
+  private proxyServer: Server | null = null;
   private publicUrl: string | null = null;
   private readonly urlChangeHandlers: TunnelUrlChangeHandler[] = [];
   private readonly deps: CloudflareTunnelDeps;
@@ -46,80 +63,69 @@ export class CloudflareTunnelService implements ITunnelService {
   }
 
   async start(localPort: number): Promise<string> {
-    if (this.process) {
+    if (this.tunnel) {
       throw new Error(`${TAG} Tunnel already running at ${this.publicUrl}`);
     }
 
+    // Start a proxy server that only forwards webhook routes
+    const proxyPort = await this.startProxyServer(localPort);
+
+    let tunnel: TunnelLike;
+    try {
+      tunnel = await Promise.resolve(this.deps.createTunnel(`http://localhost:${proxyPort}`));
+    } catch (err) {
+      this.stopProxyServer();
+      throw new Error(`${TAG} Failed to create tunnel: ${(err as Error).message}`);
+    }
+
+    this.tunnel = tunnel;
+
     return new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {
-        this.killProcess();
+        this.stopTunnel();
         reject(new Error(`${TAG} Timed out waiting for tunnel URL (${STARTUP_TIMEOUT_MS}ms)`));
       }, STARTUP_TIMEOUT_MS);
 
-      const args = ['tunnel', '--url', `http://localhost:${localPort}`];
-
-      const child = this.deps.spawnProcess('cloudflared', args, {
-        stdio: ['ignore', 'pipe', 'pipe'],
-        ...(IS_WINDOWS ? { windowsHide: true } : {}),
-      });
-
-      this.process = child;
-
-      const handleOutput = (data: Buffer) => {
-        const line = data.toString();
-        const match = line.match(CLOUDFLARED_URL_REGEX);
-        if (match) {
-          const url = match[0];
-
-          if (!this.publicUrl) {
-            // First URL — startup complete
-            this.publicUrl = url;
-            clearTimeout(timeout);
-            // eslint-disable-next-line no-console
-            console.log(`${TAG} Tunnel ready: ${url}`);
-            resolve(url);
-          } else if (url !== this.publicUrl) {
-            // URL changed — reconnection with new subdomain
-            const oldUrl = this.publicUrl;
-            this.publicUrl = url;
-            // eslint-disable-next-line no-console
-            console.log(`${TAG} Tunnel URL changed: ${oldUrl} -> ${url}`);
-            this.notifyUrlChange(url);
-          }
-        }
-      };
-
-      child.stdout?.on('data', handleOutput);
-      child.stderr?.on('data', handleOutput);
-
-      child.on('error', (err) => {
-        clearTimeout(timeout);
-        this.process = null;
-        this.publicUrl = null;
-
-        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-          reject(
-            new Error(
-              `${TAG} 'cloudflared' not found. Install it: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/`
-            )
+      tunnel.on('url', (url: string) => {
+        if (!this.publicUrl) {
+          // First URL — startup complete
+          this.publicUrl = url;
+          clearTimeout(timeout);
+          // eslint-disable-next-line no-console
+          console.log(
+            `${TAG} Tunnel ready: ${url} (proxying ${ALLOWED_PATH_PREFIX}/* to port ${localPort})`
           );
-        } else {
-          reject(new Error(`${TAG} Failed to start tunnel: ${err.message}`));
+          resolve(url);
+        } else if (url !== this.publicUrl) {
+          // URL changed — reconnection with new subdomain
+          const oldUrl = this.publicUrl;
+          this.publicUrl = url;
+          // eslint-disable-next-line no-console
+          console.log(`${TAG} Tunnel URL changed: ${oldUrl} -> ${url}`);
+          this.notifyUrlChange(url);
         }
       });
 
-      child.on('close', (code) => {
+      tunnel.on('error', (err: Error) => {
         clearTimeout(timeout);
-        if (this.process === child) {
-          this.process = null;
+        this.tunnel = null;
+        this.publicUrl = null;
+        this.stopProxyServer();
+        reject(new Error(`${TAG} Failed to start tunnel: ${err.message}`));
+      });
+
+      tunnel.on('exit', (code: number | null) => {
+        clearTimeout(timeout);
+        if (this.tunnel === tunnel) {
+          this.tunnel = null;
           const wasRunning = this.publicUrl !== null;
           this.publicUrl = null;
+          this.stopProxyServer();
 
           if (wasRunning) {
             // eslint-disable-next-line no-console
             console.log(`${TAG} Tunnel process exited (code ${code})`);
           } else {
-            // Process exited before producing a URL
             reject(new Error(`${TAG} cloudflared exited with code ${code} before producing a URL`));
           }
         }
@@ -128,7 +134,7 @@ export class CloudflareTunnelService implements ITunnelService {
   }
 
   async stop(): Promise<void> {
-    this.killProcess();
+    this.stopTunnel();
     this.publicUrl = null;
   }
 
@@ -141,24 +147,92 @@ export class CloudflareTunnelService implements ITunnelService {
   }
 
   isRunning(): boolean {
-    return this.process !== null && this.publicUrl !== null;
+    return this.tunnel !== null && this.publicUrl !== null;
   }
 
-  private killProcess(): void {
-    if (this.process) {
-      const child = this.process;
-      this.process = null;
+  /**
+   * Start a lightweight HTTP proxy on a random port that only forwards
+   * requests with paths starting with ALLOWED_PATH_PREFIX to the main app.
+   * Everything else gets a 404.
+   */
+  private startProxyServer(targetPort: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+        const url = req.url ?? '';
+
+        if (!url.startsWith(ALLOWED_PATH_PREFIX)) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Not found' }));
+          return;
+        }
+
+        // Proxy the request to the main app
+        const proxyReq = httpRequest(
+          {
+            hostname: 'localhost',
+            port: targetPort,
+            path: url,
+            method: req.method,
+            headers: req.headers,
+          },
+          (proxyRes) => {
+            res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+            proxyRes.pipe(res);
+          }
+        );
+
+        proxyReq.on('error', (err) => {
+          // eslint-disable-next-line no-console
+          console.warn(`${TAG} Proxy error: ${err.message}`);
+          if (!res.headersSent) {
+            res.writeHead(502, { 'Content-Type': 'application/json' });
+          }
+          res.end(JSON.stringify({ error: 'Bad gateway' }));
+        });
+
+        req.pipe(proxyReq);
+      });
+
+      // Listen on port 0 = OS assigns a random available port
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server.address();
+        if (addr && typeof addr === 'object') {
+          this.proxyServer = server;
+          // eslint-disable-next-line no-console
+          console.log(`${TAG} Webhook proxy listening on port ${addr.port}`);
+          resolve(addr.port);
+        } else {
+          server.close();
+          reject(new Error(`${TAG} Failed to start proxy server`));
+        }
+      });
+
+      server.on('error', (err) => {
+        reject(new Error(`${TAG} Proxy server error: ${err.message}`));
+      });
+    });
+  }
+
+  private stopProxyServer(): void {
+    if (this.proxyServer) {
+      this.proxyServer.close();
+      this.proxyServer = null;
+    }
+  }
+
+  private stopTunnel(): void {
+    if (this.tunnel) {
+      const tunnel = this.tunnel;
+      this.tunnel = null;
 
       try {
-        // On Windows, tree-kill is needed for child processes.
-        // cloudflared is well-behaved and exits on SIGTERM.
-        if (!child.killed) {
-          child.kill('SIGTERM');
-        }
+        tunnel.stop();
       } catch {
-        // Process already exited
+        // Tunnel already stopped
       }
     }
+
+    this.stopProxyServer();
   }
 
   private notifyUrlChange(newUrl: string): void {

--- a/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
@@ -26,6 +26,7 @@ import type { NotificationEvent, Feature } from '../../../domain/generated/outpu
 
 const TAG = '[GitHubWebhook]';
 const WEBHOOK_EVENTS = ['pull_request', 'check_suite', 'check_run'];
+const MAX_EVENT_HISTORY = 200;
 
 export type ExecFunction = (
   file: string,
@@ -33,10 +34,23 @@ export type ExecFunction = (
   options?: object
 ) => Promise<{ stdout: string; stderr: string }>;
 
-interface RegisteredWebhook {
+export interface RegisteredWebhook {
   repoFullName: string;
   webhookId: number;
   repositoryPath: string;
+}
+
+export type WebhookDeliveryStatus = 'success' | 'ignored' | 'error';
+
+export interface WebhookDeliveryRecord {
+  deliveryId: string;
+  eventType: string;
+  source: string;
+  receivedAt: string;
+  status: WebhookDeliveryStatus;
+  statusMessage: string;
+  durationMs: number;
+  payload: Record<string, unknown>;
 }
 
 export class GitHubWebhookService implements IWebhookService {
@@ -45,6 +59,7 @@ export class GitHubWebhookService implements IWebhookService {
   private readonly notificationService: INotificationService;
   private readonly execFn: ExecFunction;
   private readonly registeredWebhooks: RegisteredWebhook[] = [];
+  private readonly deliveryHistory: WebhookDeliveryRecord[] = [];
   private webhookSecret: string;
 
   constructor(
@@ -66,6 +81,20 @@ export class GitHubWebhookService implements IWebhookService {
    */
   getSecret(): string {
     return this.webhookSecret;
+  }
+
+  /**
+   * Get the list of registered webhooks (for dashboard display).
+   */
+  getRegisteredWebhooks(): readonly RegisteredWebhook[] {
+    return this.registeredWebhooks;
+  }
+
+  /**
+   * Get recent delivery history (newest first).
+   */
+  getDeliveryHistory(): readonly WebhookDeliveryRecord[] {
+    return this.deliveryHistory;
   }
 
   async registerWebhooks(publicUrl: string): Promise<void> {
@@ -183,24 +212,53 @@ export class GitHubWebhookService implements IWebhookService {
   }
 
   async handleEvent(event: WebhookEvent): Promise<void> {
+    const startTime = Date.now();
     // eslint-disable-next-line no-console
     console.log(
       `${TAG} Received ${event.source}/${event.eventType} (delivery: ${event.deliveryId})`
     );
 
-    switch (event.eventType) {
-      case 'pull_request':
-        await this.handlePullRequestEvent(event.payload);
-        break;
-      case 'check_suite':
-        await this.handleCheckSuiteEvent(event.payload);
-        break;
-      case 'check_run':
-        await this.handleCheckRunEvent(event.payload);
-        break;
-      default:
-        // eslint-disable-next-line no-console
-        console.log(`${TAG} Ignoring unhandled event type: ${event.eventType}`);
+    let status: WebhookDeliveryStatus = 'success';
+    let statusMessage = 'Processed successfully';
+
+    try {
+      switch (event.eventType) {
+        case 'pull_request':
+          await this.handlePullRequestEvent(event.payload);
+          break;
+        case 'check_suite':
+          await this.handleCheckSuiteEvent(event.payload);
+          break;
+        case 'check_run':
+          await this.handleCheckRunEvent(event.payload);
+          break;
+        default:
+          status = 'ignored';
+          statusMessage = `Unhandled event type: ${event.eventType}`;
+          // eslint-disable-next-line no-console
+          console.log(`${TAG} Ignoring unhandled event type: ${event.eventType}`);
+      }
+    } catch (error) {
+      status = 'error';
+      statusMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    this.recordDelivery({
+      deliveryId: event.deliveryId,
+      eventType: event.eventType,
+      source: event.source,
+      receivedAt: new Date().toISOString(),
+      status,
+      statusMessage,
+      durationMs: Date.now() - startTime,
+      payload: event.payload,
+    });
+  }
+
+  private recordDelivery(record: WebhookDeliveryRecord): void {
+    this.deliveryHistory.unshift(record);
+    if (this.deliveryHistory.length > MAX_EVENT_HISTORY) {
+      this.deliveryHistory.length = MAX_EVENT_HISTORY;
     }
   }
 

--- a/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
@@ -439,7 +439,7 @@ export class GitHubWebhookService implements IWebhookService {
           '-f',
           `config[secret]=${this.webhookSecret}`,
           ...WEBHOOK_EVENTS.flatMap((e) => ['-f', `events[]=${e}`]),
-          '-f',
+          '-F',
           'active=true',
         ],
         { cwd: repoPath }

--- a/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
@@ -1,0 +1,423 @@
+/**
+ * GitHub Webhook Service
+ *
+ * Manages GitHub webhook registration and incoming event processing.
+ * Uses the GitHub CLI (`gh api`) for webhook CRUD operations.
+ *
+ * Webhook events supplement the existing PR sync polling:
+ * - Webhooks provide near-instant event delivery
+ * - Polling remains as a fallback for missed events
+ *
+ * Registered events: pull_request, check_suite, check_run
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import type {
+  IWebhookService,
+  WebhookEvent,
+  WebhookValidationResult,
+} from '../../../application/ports/output/services/webhook-service.interface.js';
+import type { IFeatureRepository } from '../../../application/ports/output/repositories/feature-repository.interface.js';
+import type { IGitPrService } from '../../../application/ports/output/services/git-pr-service.interface.js';
+import type { INotificationService } from '../../../application/ports/output/services/notification-service.interface.js';
+import { SdlcLifecycle, PrStatus, CiStatus } from '../../../domain/generated/output.js';
+import { NotificationEventType, NotificationSeverity } from '../../../domain/generated/output.js';
+import type { NotificationEvent, Feature } from '../../../domain/generated/output.js';
+
+const TAG = '[GitHubWebhook]';
+const WEBHOOK_EVENTS = ['pull_request', 'check_suite', 'check_run'];
+
+export type ExecFunction = (
+  file: string,
+  args: string[],
+  options?: object
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface RegisteredWebhook {
+  repoFullName: string;
+  webhookId: number;
+  repositoryPath: string;
+}
+
+export class GitHubWebhookService implements IWebhookService {
+  private readonly featureRepo: IFeatureRepository;
+  private readonly gitPrService: IGitPrService;
+  private readonly notificationService: INotificationService;
+  private readonly execFn: ExecFunction;
+  private readonly registeredWebhooks: RegisteredWebhook[] = [];
+  private webhookSecret: string;
+
+  constructor(
+    featureRepo: IFeatureRepository,
+    gitPrService: IGitPrService,
+    notificationService: INotificationService,
+    execFn: ExecFunction
+  ) {
+    this.featureRepo = featureRepo;
+    this.gitPrService = gitPrService;
+    this.notificationService = notificationService;
+    this.execFn = execFn;
+    this.webhookSecret = randomBytes(32).toString('hex');
+  }
+
+  /**
+   * Get the webhook secret for signature validation.
+   * Exposed so the API route can validate incoming requests.
+   */
+  getSecret(): string {
+    return this.webhookSecret;
+  }
+
+  async registerWebhooks(publicUrl: string): Promise<void> {
+    const webhookUrl = `${publicUrl}/api/webhooks/github`;
+
+    // Find all repos with features in Review lifecycle
+    const features = await this.featureRepo.list({ lifecycle: SdlcLifecycle.Review });
+    const repoPaths = new Set<string>();
+    for (const feature of features) {
+      if (feature.repositoryPath) {
+        repoPaths.add(feature.repositoryPath);
+      }
+    }
+
+    for (const repoPath of repoPaths) {
+      await this.registerWebhookForRepo(repoPath, webhookUrl);
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`${TAG} Registered webhooks for ${this.registeredWebhooks.length} repositories`);
+  }
+
+  async updateWebhookUrl(newUrl: string): Promise<void> {
+    const webhookUrl = `${newUrl}/api/webhooks/github`;
+
+    for (const webhook of this.registeredWebhooks) {
+      try {
+        await this.execFn(
+          'gh',
+          [
+            'api',
+            '--method',
+            'PATCH',
+            `-H`,
+            'Accept: application/vnd.github+json',
+            `/repos/${webhook.repoFullName}/hooks/${webhook.webhookId}`,
+            '-f',
+            `config[url]=${webhookUrl}`,
+            '-f',
+            `config[content_type]=json`,
+            '-f',
+            `config[secret]=${this.webhookSecret}`,
+          ],
+          { cwd: webhook.repositoryPath }
+        );
+
+        // eslint-disable-next-line no-console
+        console.log(`${TAG} Updated webhook URL for ${webhook.repoFullName}`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        // eslint-disable-next-line no-console
+        console.warn(`${TAG} Failed to update webhook for ${webhook.repoFullName}: ${msg}`);
+      }
+    }
+  }
+
+  async removeWebhooks(): Promise<void> {
+    for (const webhook of this.registeredWebhooks) {
+      try {
+        await this.execFn(
+          'gh',
+          [
+            'api',
+            '--method',
+            'DELETE',
+            `-H`,
+            'Accept: application/vnd.github+json',
+            `/repos/${webhook.repoFullName}/hooks/${webhook.webhookId}`,
+          ],
+          { cwd: webhook.repositoryPath }
+        );
+
+        // eslint-disable-next-line no-console
+        console.log(`${TAG} Removed webhook for ${webhook.repoFullName}`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        // eslint-disable-next-line no-console
+        console.warn(`${TAG} Failed to remove webhook for ${webhook.repoFullName}: ${msg}`);
+      }
+    }
+
+    this.registeredWebhooks.length = 0;
+  }
+
+  validateSignature(payload: string, signature: string, secret: string): WebhookValidationResult {
+    if (!signature) {
+      return { valid: false, error: 'Missing signature header' };
+    }
+
+    const parts = signature.split('=');
+    if (parts.length !== 2 || parts[0] !== 'sha256') {
+      return { valid: false, error: 'Invalid signature format (expected sha256=...)' };
+    }
+
+    const expected = createHmac('sha256', secret).update(payload).digest('hex');
+    const actual = parts[1];
+
+    // Use timing-safe comparison to prevent timing attacks
+    try {
+      const expectedBuf = Buffer.from(expected, 'hex');
+      const actualBuf = Buffer.from(actual, 'hex');
+
+      if (expectedBuf.length !== actualBuf.length) {
+        return { valid: false, error: 'Signature length mismatch' };
+      }
+
+      if (!timingSafeEqual(expectedBuf, actualBuf)) {
+        return { valid: false, error: 'Signature mismatch' };
+      }
+
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Invalid signature encoding' };
+    }
+  }
+
+  async handleEvent(event: WebhookEvent): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.log(
+      `${TAG} Received ${event.source}/${event.eventType} (delivery: ${event.deliveryId})`
+    );
+
+    switch (event.eventType) {
+      case 'pull_request':
+        await this.handlePullRequestEvent(event.payload);
+        break;
+      case 'check_suite':
+        await this.handleCheckSuiteEvent(event.payload);
+        break;
+      case 'check_run':
+        await this.handleCheckRunEvent(event.payload);
+        break;
+      default:
+        // eslint-disable-next-line no-console
+        console.log(`${TAG} Ignoring unhandled event type: ${event.eventType}`);
+    }
+  }
+
+  private async handlePullRequestEvent(payload: Record<string, unknown>): Promise<void> {
+    const action = payload.action as string;
+    const pr = payload.pull_request as Record<string, unknown> | undefined;
+    if (!pr) return;
+
+    const prNumber = pr.number as number;
+    const prUrl = (pr.html_url as string) ?? '';
+    const headBranch = (pr.head as Record<string, unknown>)?.ref as string;
+
+    // Find feature by PR number or branch
+    const feature = await this.findFeatureByPrOrBranch(prNumber, headBranch);
+    if (!feature) return;
+
+    if (action === 'closed' && pr.merged === true) {
+      await this.updateFeaturePrStatus(feature, PrStatus.Merged, prNumber, prUrl);
+    } else if (action === 'closed') {
+      await this.updateFeaturePrStatus(feature, PrStatus.Closed, prNumber, prUrl);
+    } else if (action === 'reopened') {
+      await this.updateFeaturePrStatus(feature, PrStatus.Open, prNumber, prUrl);
+    }
+  }
+
+  private async handleCheckSuiteEvent(payload: Record<string, unknown>): Promise<void> {
+    const action = payload.action as string;
+    if (action !== 'completed') return;
+
+    const checkSuite = payload.check_suite as Record<string, unknown> | undefined;
+    if (!checkSuite) return;
+
+    const conclusion = checkSuite.conclusion as string;
+    const headBranch = checkSuite.head_branch as string;
+
+    const feature = await this.findFeatureByBranch(headBranch);
+    if (!feature) return;
+
+    const ciStatus = conclusion === 'success' ? CiStatus.Success : CiStatus.Failure;
+    await this.updateFeatureCiStatus(feature, ciStatus);
+  }
+
+  private async handleCheckRunEvent(payload: Record<string, unknown>): Promise<void> {
+    const action = payload.action as string;
+    if (action !== 'completed') return;
+
+    const checkRun = payload.check_run as Record<string, unknown> | undefined;
+    if (!checkRun) return;
+
+    const conclusion = checkRun.conclusion as string;
+    const checkSuite = checkRun.check_suite as Record<string, unknown> | undefined;
+    const headBranch = checkSuite?.head_branch as string | undefined;
+
+    if (!headBranch) return;
+
+    const feature = await this.findFeatureByBranch(headBranch);
+    if (!feature) return;
+
+    const ciStatus = conclusion === 'success' ? CiStatus.Success : CiStatus.Failure;
+    await this.updateFeatureCiStatus(feature, ciStatus);
+  }
+
+  private async findFeatureByPrOrBranch(prNumber: number, branch: string): Promise<Feature | null> {
+    const features = await this.featureRepo.list({ lifecycle: SdlcLifecycle.Review });
+
+    // Try matching by PR number first
+    const byPr = features.find((f) => f.pr?.number === prNumber);
+    if (byPr) return byPr;
+
+    // Fall back to branch matching
+    return features.find((f) => f.branch === branch) ?? null;
+  }
+
+  private async findFeatureByBranch(branch: string): Promise<Feature | null> {
+    const features = await this.featureRepo.list({ lifecycle: SdlcLifecycle.Review });
+    return features.find((f) => f.branch === branch) ?? null;
+  }
+
+  private async updateFeaturePrStatus(
+    feature: Feature,
+    status: PrStatus,
+    prNumber: number,
+    prUrl: string
+  ): Promise<void> {
+    const oldStatus = feature.pr?.status;
+    if (oldStatus === status) return;
+
+    feature.pr = { ...feature.pr!, status, url: prUrl, number: prNumber };
+
+    if (status === PrStatus.Merged) {
+      feature.lifecycle = SdlcLifecycle.Maintain;
+    }
+
+    await this.featureRepo.update(feature);
+
+    // Emit notification
+    const eventType =
+      status === PrStatus.Merged
+        ? NotificationEventType.PrMerged
+        : status === PrStatus.Closed
+          ? NotificationEventType.PrClosed
+          : NotificationEventType.PrChecksPassed; // reopened
+
+    const severity =
+      status === PrStatus.Merged
+        ? NotificationSeverity.Success
+        : status === PrStatus.Closed
+          ? NotificationSeverity.Warning
+          : NotificationSeverity.Info;
+
+    const event: NotificationEvent = {
+      eventType,
+      featureId: feature.id,
+      agentRunId: feature.agentRunId ?? '',
+      featureName: feature.name,
+      message: `PR #${prNumber} ${status.toLowerCase()} for ${feature.name} (via webhook)`,
+      severity,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.notificationService.notify(event);
+  }
+
+  private async updateFeatureCiStatus(feature: Feature, ciStatus: CiStatus): Promise<void> {
+    if (!feature.pr) return;
+    if (feature.pr.ciStatus === ciStatus) return;
+
+    feature.pr = { ...feature.pr, ciStatus };
+    await this.featureRepo.update(feature);
+
+    const eventType =
+      ciStatus === CiStatus.Success
+        ? NotificationEventType.PrChecksPassed
+        : NotificationEventType.PrChecksFailed;
+
+    const severity =
+      ciStatus === CiStatus.Success ? NotificationSeverity.Success : NotificationSeverity.Error;
+
+    const event: NotificationEvent = {
+      eventType,
+      featureId: feature.id,
+      agentRunId: feature.agentRunId ?? '',
+      featureName: feature.name,
+      message: `CI ${ciStatus === CiStatus.Success ? 'passed' : 'failed'} for ${feature.name} (via webhook)`,
+      severity,
+      timestamp: new Date().toISOString(),
+    };
+
+    this.notificationService.notify(event);
+  }
+
+  private async registerWebhookForRepo(repoPath: string, webhookUrl: string): Promise<void> {
+    try {
+      // Get the repo full name (owner/repo) from the remote URL
+      const repoFullName = await this.getRepoFullName(repoPath);
+      if (!repoFullName) {
+        // eslint-disable-next-line no-console
+        console.warn(`${TAG} Could not determine repo name for ${repoPath}`);
+        return;
+      }
+
+      // Create webhook via GitHub API
+      const { stdout } = await this.execFn(
+        'gh',
+        [
+          'api',
+          '--method',
+          'POST',
+          `-H`,
+          'Accept: application/vnd.github+json',
+          `/repos/${repoFullName}/hooks`,
+          '-f',
+          'name=web',
+          '-f',
+          `config[url]=${webhookUrl}`,
+          '-f',
+          'config[content_type]=json',
+          '-f',
+          `config[secret]=${this.webhookSecret}`,
+          ...WEBHOOK_EVENTS.flatMap((e) => ['-f', `events[]=${e}`]),
+          '-f',
+          'active=true',
+        ],
+        { cwd: repoPath }
+      );
+
+      const response = JSON.parse(stdout);
+      const webhookId = response.id as number;
+
+      this.registeredWebhooks.push({
+        repoFullName,
+        webhookId,
+        repositoryPath: repoPath,
+      });
+
+      // eslint-disable-next-line no-console
+      console.log(`${TAG} Registered webhook #${webhookId} for ${repoFullName}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.warn(`${TAG} Failed to register webhook for ${repoPath}: ${msg}`);
+    }
+  }
+
+  private async getRepoFullName(repoPath: string): Promise<string | null> {
+    try {
+      const remoteUrl = await this.gitPrService.getRemoteUrl(repoPath);
+      if (!remoteUrl) return null;
+
+      // Parse owner/repo from URL
+      // Handles both https://github.com/owner/repo and git@github.com:owner/repo.git
+      const match = remoteUrl.match(/github\.com[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+      if (!match) return null;
+
+      return `${match[1]}/${match[2]}`;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
@@ -420,6 +420,11 @@ export class GitHubWebhookService implements IWebhookService {
         return;
       }
 
+      // Clean up any stale webhooks from previous sessions before creating a new one.
+      // Without this, old webhooks remain on GitHub with an outdated secret, causing
+      // signature mismatches when GitHub delivers events signed with the old secret.
+      await this.removeStaleWebhooks(repoFullName, repoPath);
+
       // Create webhook via GitHub API
       const { stdout } = await this.execFn(
         'gh',
@@ -460,6 +465,53 @@ export class GitHubWebhookService implements IWebhookService {
       const msg = error instanceof Error ? error.message : String(error);
       // eslint-disable-next-line no-console
       console.warn(`${TAG} Failed to register webhook for ${repoPath}: ${msg}`);
+    }
+  }
+
+  /**
+   * Remove stale webhooks from a previous session that point to our webhook path.
+   * Lists all hooks on the repo and deletes any whose URL ends with /api/webhooks/github.
+   */
+  private async removeStaleWebhooks(repoFullName: string, repoPath: string): Promise<void> {
+    try {
+      const { stdout } = await this.execFn(
+        'gh',
+        ['api', `-H`, 'Accept: application/vnd.github+json', `/repos/${repoFullName}/hooks`],
+        { cwd: repoPath }
+      );
+
+      const hooks = JSON.parse(stdout) as {
+        id: number;
+        config?: { url?: string };
+      }[];
+
+      for (const hook of hooks) {
+        const hookUrl = hook.config?.url ?? '';
+        if (hookUrl.endsWith('/api/webhooks/github')) {
+          try {
+            await this.execFn(
+              'gh',
+              [
+                'api',
+                '--method',
+                'DELETE',
+                `-H`,
+                'Accept: application/vnd.github+json',
+                `/repos/${repoFullName}/hooks/${hook.id}`,
+              ],
+              { cwd: repoPath }
+            );
+            // eslint-disable-next-line no-console
+            console.log(`${TAG} Removed stale webhook #${hook.id} from ${repoFullName}`);
+          } catch (deleteError) {
+            const msg = deleteError instanceof Error ? deleteError.message : String(deleteError);
+            // eslint-disable-next-line no-console
+            console.warn(`${TAG} Failed to remove stale webhook #${hook.id}: ${msg}`);
+          }
+        }
+      }
+    } catch {
+      // If listing fails (e.g. permissions), proceed with creating a new webhook anyway
     }
   }
 

--- a/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/github-webhook.service.ts
@@ -25,8 +25,12 @@ import { NotificationEventType, NotificationSeverity } from '../../../domain/gen
 import type { NotificationEvent, Feature } from '../../../domain/generated/output.js';
 
 const TAG = '[GitHubWebhook]';
-const WEBHOOK_EVENTS = ['pull_request', 'check_suite', 'check_run'];
+const WEBHOOK_EVENTS = ['pull_request', 'check_suite', 'check_run'] as const;
 const MAX_EVENT_HISTORY = 200;
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
 
 export type ExecFunction = (
   file: string,
@@ -95,6 +99,65 @@ export class GitHubWebhookService implements IWebhookService {
    */
   getDeliveryHistory(): readonly WebhookDeliveryRecord[] {
     return this.deliveryHistory;
+  }
+
+  /**
+   * Register a webhook for a single repository.
+   * No-ops if the repo already has a registered webhook (normalized path comparison).
+   */
+  async registerWebhookForSingleRepo(
+    repoPath: string,
+    webhookUrl: string
+  ): Promise<RegisteredWebhook | null> {
+    const normalized = normalizePath(repoPath);
+    const existing = this.registeredWebhooks.find(
+      (w) => normalizePath(w.repositoryPath) === normalized
+    );
+    if (existing) return existing;
+
+    await this.registerWebhookForRepo(repoPath, webhookUrl);
+
+    const added = this.registeredWebhooks.find(
+      (w) => normalizePath(w.repositoryPath) === normalized
+    );
+    return added ?? null;
+  }
+
+  /**
+   * Remove the webhook for a single repository.
+   * No-ops if the repo has no registered webhook.
+   */
+  async removeWebhookForRepo(repoPath: string): Promise<void> {
+    const normalized = normalizePath(repoPath);
+    const index = this.registeredWebhooks.findIndex(
+      (w) => normalizePath(w.repositoryPath) === normalized
+    );
+    if (index === -1) return;
+
+    const webhook = this.registeredWebhooks[index];
+
+    try {
+      await this.execFn(
+        'gh',
+        [
+          'api',
+          '--method',
+          'DELETE',
+          `-H`,
+          'Accept: application/vnd.github+json',
+          `/repos/${webhook.repoFullName}/hooks/${webhook.webhookId}`,
+        ],
+        { cwd: webhook.repositoryPath }
+      );
+      // eslint-disable-next-line no-console
+      console.log(`${TAG} Removed webhook #${webhook.webhookId} for ${webhook.repoFullName}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.warn(`${TAG} Failed to remove webhook for ${webhook.repoFullName}: ${msg}`);
+    }
+
+    this.registeredWebhooks.splice(index, 1);
   }
 
   async registerWebhooks(publicUrl: string): Promise<void> {

--- a/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
@@ -184,9 +184,23 @@ export class WebhookManagerService {
   }
 }
 
-// --- Singleton accessors (follows NotificationWatcherService pattern) ---
+// --- Singleton accessors ---
+//
+// The singleton is stored on globalThis so that it survives module duplication
+// across bundler contexts (e.g. Next.js Turbopack bundles API routes separately
+// from the dev-server entry point, giving each its own copy of module-level
+// variables). By using globalThis, the same manager instance is visible to both
+// the initializer (dev-server.ts / CLI) and the API route handlers.
 
-let managerInstance: WebhookManagerService | null = null;
+const GLOBAL_KEY = '__shepWebhookManager' as const;
+
+function getInstance(): WebhookManagerService | null {
+  return ((globalThis as Record<string, unknown>)[GLOBAL_KEY] as WebhookManagerService) ?? null;
+}
+
+function setInstance(instance: WebhookManagerService | null): void {
+  (globalThis as Record<string, unknown>)[GLOBAL_KEY] = instance;
+}
 
 /**
  * Initialize the webhook manager singleton.
@@ -198,11 +212,11 @@ export function initializeWebhookManager(
   tunnelService: ITunnelService,
   webhookService: IWebhookService
 ): void {
-  if (managerInstance !== null) {
+  if (getInstance() !== null) {
     throw new Error('Webhook manager already initialized. Cannot re-initialize.');
   }
 
-  managerInstance = new WebhookManagerService(tunnelService, webhookService);
+  setInstance(new WebhookManagerService(tunnelService, webhookService));
 }
 
 /**
@@ -212,20 +226,21 @@ export function initializeWebhookManager(
  * @throws Error if the manager hasn't been initialized yet
  */
 export function getWebhookManager(): WebhookManagerService {
-  if (managerInstance === null) {
+  const instance = getInstance();
+  if (instance === null) {
     throw new Error(
       'Webhook manager not initialized. Call initializeWebhookManager() during web server startup.'
     );
   }
 
-  return managerInstance;
+  return instance;
 }
 
 /**
  * Check if the webhook manager has been initialized.
  */
 export function hasWebhookManager(): boolean {
-  return managerInstance !== null;
+  return getInstance() !== null;
 }
 
 /**
@@ -235,8 +250,9 @@ export function hasWebhookManager(): boolean {
  * @internal
  */
 export function resetWebhookManager(): void {
-  if (managerInstance !== null) {
-    void managerInstance.stop();
+  const instance = getInstance();
+  if (instance !== null) {
+    void instance.stop();
   }
-  managerInstance = null;
+  setInstance(null);
 }

--- a/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
@@ -174,13 +174,17 @@ export class WebhookManagerService {
   }
 
   isWebhookEnabledForRepo(repoPath: string): boolean {
+    return this.getWebhookForRepo(repoPath) !== undefined;
+  }
+
+  getWebhookForRepo(repoPath: string): RegisteredWebhook | undefined {
     const ghService = this.webhookService as GitHubWebhookService;
     const registered =
       typeof ghService.getRegisteredWebhooks === 'function'
         ? ghService.getRegisteredWebhooks()
         : [];
     const normalized = normalizePath(repoPath);
-    return registered.some((w) => normalizePath(w.repositoryPath) === normalized);
+    return registered.find((w) => normalizePath(w.repositoryPath) === normalized);
   }
 
   isRunning(): boolean {

--- a/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
@@ -1,0 +1,175 @@
+/**
+ * Webhook Manager Service
+ *
+ * Orchestrates the Cloudflare Tunnel and GitHub Webhook lifecycle.
+ * Follows the singleton pattern used by NotificationWatcherService
+ * and PrSyncWatcherService.
+ *
+ * Lifecycle:
+ * 1. Start Cloudflare Tunnel to get a public URL
+ * 2. Register GitHub webhooks pointing to the tunnel URL
+ * 3. Monitor for tunnel URL changes → update webhooks
+ * 4. On shutdown → remove webhooks → stop tunnel
+ *
+ * The manager is optional — if cloudflared is not installed or webhook
+ * registration fails, the system falls back to polling gracefully.
+ */
+
+import type { ITunnelService } from '../../../application/ports/output/services/tunnel-service.interface.js';
+import type { IWebhookService } from '../../../application/ports/output/services/webhook-service.interface.js';
+
+const TAG = '[WebhookManager]';
+
+export class WebhookManagerService {
+  private readonly tunnelService: ITunnelService;
+  private readonly webhookService: IWebhookService;
+  private running = false;
+
+  constructor(tunnelService: ITunnelService, webhookService: IWebhookService) {
+    this.tunnelService = tunnelService;
+    this.webhookService = webhookService;
+  }
+
+  /**
+   * Start the tunnel and register webhooks.
+   * Fails gracefully — logs warnings but does not throw.
+   *
+   * @param localPort - The local web server port to tunnel
+   */
+  async start(localPort: number): Promise<void> {
+    if (this.running) return;
+
+    try {
+      // Step 1: Start the tunnel
+      // eslint-disable-next-line no-console
+      console.log(`${TAG} Starting Cloudflare Tunnel for port ${localPort}...`);
+      const publicUrl = await this.tunnelService.start(localPort);
+
+      // Step 2: Listen for URL changes
+      this.tunnelService.onUrlChange(async (newUrl) => {
+        // eslint-disable-next-line no-console
+        console.log(`${TAG} Tunnel URL changed, updating webhooks...`);
+        try {
+          await this.webhookService.updateWebhookUrl(newUrl);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          // eslint-disable-next-line no-console
+          console.warn(`${TAG} Failed to update webhooks after URL change: ${msg}`);
+        }
+      });
+
+      // Step 3: Register webhooks with external services
+      await this.webhookService.registerWebhooks(publicUrl);
+
+      this.running = true;
+      // eslint-disable-next-line no-console
+      console.log(`${TAG} Webhook system ready (tunnel: ${publicUrl})`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.warn(`${TAG} Failed to start webhook system (falling back to polling): ${msg}`);
+
+      // Clean up partial state
+      try {
+        await this.tunnelService.stop();
+      } catch {
+        // Already stopped or never started
+      }
+    }
+  }
+
+  /**
+   * Stop the webhook system — remove webhooks, then stop the tunnel.
+   */
+  async stop(): Promise<void> {
+    if (!this.running) return;
+
+    // eslint-disable-next-line no-console
+    console.log(`${TAG} Shutting down webhook system...`);
+
+    try {
+      await this.webhookService.removeWebhooks();
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.warn(`${TAG} Failed to remove webhooks during shutdown: ${msg}`);
+    }
+
+    try {
+      await this.tunnelService.stop();
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.warn(`${TAG} Failed to stop tunnel during shutdown: ${msg}`);
+    }
+
+    this.running = false;
+    // eslint-disable-next-line no-console
+    console.log(`${TAG} Webhook system stopped`);
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  getTunnelUrl(): string | null {
+    return this.tunnelService.getPublicUrl();
+  }
+}
+
+// --- Singleton accessors (follows NotificationWatcherService pattern) ---
+
+let managerInstance: WebhookManagerService | null = null;
+
+/**
+ * Initialize the webhook manager singleton.
+ * Must be called once during web server startup.
+ *
+ * @throws Error if the manager is already initialized
+ */
+export function initializeWebhookManager(
+  tunnelService: ITunnelService,
+  webhookService: IWebhookService
+): void {
+  if (managerInstance !== null) {
+    throw new Error('Webhook manager already initialized. Cannot re-initialize.');
+  }
+
+  managerInstance = new WebhookManagerService(tunnelService, webhookService);
+}
+
+/**
+ * Get the webhook manager singleton.
+ *
+ * @returns The webhook manager service
+ * @throws Error if the manager hasn't been initialized yet
+ */
+export function getWebhookManager(): WebhookManagerService {
+  if (managerInstance === null) {
+    throw new Error(
+      'Webhook manager not initialized. Call initializeWebhookManager() during web server startup.'
+    );
+  }
+
+  return managerInstance;
+}
+
+/**
+ * Check if the webhook manager has been initialized.
+ */
+export function hasWebhookManager(): boolean {
+  return managerInstance !== null;
+}
+
+/**
+ * Reset the webhook manager singleton (for testing purposes only).
+ * Stops the manager if running before resetting.
+ *
+ * @internal
+ */
+export function resetWebhookManager(): void {
+  if (managerInstance !== null) {
+    void managerInstance.stop();
+  }
+  managerInstance = null;
+}

--- a/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
@@ -23,6 +23,8 @@ import type {
   GitHubWebhookService,
 } from './github-webhook.service.js';
 
+const SUBSCRIBED_EVENTS = ['pull_request', 'check_suite', 'check_run'] as const;
+
 export interface WebhookSystemStatus {
   running: boolean;
   tunnel: {
@@ -31,12 +33,23 @@ export interface WebhookSystemStatus {
   };
   webhooks: {
     registered: readonly RegisteredWebhook[];
+    subscribedEvents: readonly string[];
     totalDeliveries: number;
     successCount: number;
     errorCount: number;
     ignoredCount: number;
   };
   startedAt: string | null;
+}
+
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+export interface WebhookRepoResult {
+  success: boolean;
+  webhook?: RegisteredWebhook;
+  error?: string;
 }
 
 const TAG = '[WebhookManager]';
@@ -131,6 +144,45 @@ export class WebhookManagerService {
     console.log(`${TAG} Webhook system stopped`);
   }
 
+  async enableWebhookForRepo(repoPath: string): Promise<WebhookRepoResult> {
+    if (!this.tunnelService.isRunning() || !this.tunnelService.getPublicUrl()) {
+      return { success: false, error: 'tunnel_not_connected' };
+    }
+
+    const webhookUrl = `${this.tunnelService.getPublicUrl()}/api/webhooks/github`;
+    const ghService = this.webhookService as GitHubWebhookService;
+
+    try {
+      const webhook = await ghService.registerWebhookForSingleRepo(repoPath, webhookUrl);
+      return { success: true, webhook: webhook ?? undefined };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { success: false, error: msg };
+    }
+  }
+
+  async disableWebhookForRepo(repoPath: string): Promise<{ success: boolean; error?: string }> {
+    const ghService = this.webhookService as GitHubWebhookService;
+
+    try {
+      await ghService.removeWebhookForRepo(repoPath);
+      return { success: true };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      return { success: false, error: msg };
+    }
+  }
+
+  isWebhookEnabledForRepo(repoPath: string): boolean {
+    const ghService = this.webhookService as GitHubWebhookService;
+    const registered =
+      typeof ghService.getRegisteredWebhooks === 'function'
+        ? ghService.getRegisteredWebhooks()
+        : [];
+    const normalized = normalizePath(repoPath);
+    return registered.some((w) => normalizePath(w.repositoryPath) === normalized);
+  }
+
   isRunning(): boolean {
     return this.running;
   }
@@ -166,6 +218,7 @@ export class WebhookManagerService {
       },
       webhooks: {
         registered,
+        subscribedEvents: SUBSCRIBED_EVENTS,
         totalDeliveries: deliveries.length,
         successCount,
         errorCount,

--- a/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
+++ b/packages/core/src/infrastructure/services/webhook/webhook-manager.service.ts
@@ -17,6 +17,27 @@
 
 import type { ITunnelService } from '../../../application/ports/output/services/tunnel-service.interface.js';
 import type { IWebhookService } from '../../../application/ports/output/services/webhook-service.interface.js';
+import type {
+  RegisteredWebhook,
+  WebhookDeliveryRecord,
+  GitHubWebhookService,
+} from './github-webhook.service.js';
+
+export interface WebhookSystemStatus {
+  running: boolean;
+  tunnel: {
+    connected: boolean;
+    publicUrl: string | null;
+  };
+  webhooks: {
+    registered: readonly RegisteredWebhook[];
+    totalDeliveries: number;
+    successCount: number;
+    errorCount: number;
+    ignoredCount: number;
+  };
+  startedAt: string | null;
+}
 
 const TAG = '[WebhookManager]';
 
@@ -24,6 +45,7 @@ export class WebhookManagerService {
   private readonly tunnelService: ITunnelService;
   private readonly webhookService: IWebhookService;
   private running = false;
+  private startedAt: string | null = null;
 
   constructor(tunnelService: ITunnelService, webhookService: IWebhookService) {
     this.tunnelService = tunnelService;
@@ -62,6 +84,7 @@ export class WebhookManagerService {
       await this.webhookService.registerWebhooks(publicUrl);
 
       this.running = true;
+      this.startedAt = new Date().toISOString();
       // eslint-disable-next-line no-console
       console.log(`${TAG} Webhook system ready (tunnel: ${publicUrl})`);
     } catch (error) {
@@ -114,6 +137,50 @@ export class WebhookManagerService {
 
   getTunnelUrl(): string | null {
     return this.tunnelService.getPublicUrl();
+  }
+
+  getStatus(): WebhookSystemStatus {
+    const ghService = this.webhookService as GitHubWebhookService;
+    const deliveries =
+      typeof ghService.getDeliveryHistory === 'function' ? ghService.getDeliveryHistory() : [];
+
+    const registered =
+      typeof ghService.getRegisteredWebhooks === 'function'
+        ? ghService.getRegisteredWebhooks()
+        : [];
+
+    let successCount = 0;
+    let errorCount = 0;
+    let ignoredCount = 0;
+    for (const d of deliveries) {
+      if (d.status === 'success') successCount++;
+      else if (d.status === 'error') errorCount++;
+      else ignoredCount++;
+    }
+
+    return {
+      running: this.running,
+      tunnel: {
+        connected: this.tunnelService.isRunning(),
+        publicUrl: this.tunnelService.getPublicUrl(),
+      },
+      webhooks: {
+        registered,
+        totalDeliveries: deliveries.length,
+        successCount,
+        errorCount,
+        ignoredCount,
+      },
+      startedAt: this.startedAt,
+    };
+  }
+
+  getDeliveryHistory(): readonly WebhookDeliveryRecord[] {
+    const ghService = this.webhookService as GitHubWebhookService;
+    if (typeof ghService.getDeliveryHistory === 'function') {
+      return ghService.getDeliveryHistory();
+    }
+    return [];
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       cli-table3:
         specifier: ^0.6.5
         version: 0.6.5
+      cloudflared:
+        specifier: ^0.7.1
+        version: 0.7.1
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -3497,6 +3500,10 @@ packages:
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
+
+  cloudflared@0.7.1:
+    resolution: {integrity: sha512-jJn1Gu9Tf4qnIu8tfiHZ25Hs8rNcRYSVf8zAd97wvYdOCzftm1CTs1S/RPhijjGi8gUT1p9yzfDi9zYlU/0RwA==}
+    hasBin: true
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -10204,6 +10211,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
+
+  cloudflared@0.7.1: {}
 
   clsx@2.1.1: {}
 

--- a/src/presentation/cli/commands/ui.command.ts
+++ b/src/presentation/cli/commands/ui.command.ts
@@ -37,6 +37,13 @@ import {
 } from '@/infrastructure/services/pr-sync/pr-sync-watcher.service.js';
 import { getExistingConnection } from '@/infrastructure/persistence/sqlite/connection.js';
 import { BrowserOpenerService } from '@/infrastructure/services/browser-opener.service.js';
+import type { ITunnelService } from '@/application/ports/output/services/tunnel-service.interface.js';
+import type { IWebhookService } from '@/application/ports/output/services/webhook-service.interface.js';
+import {
+  initializeWebhookManager,
+  getWebhookManager,
+  hasWebhookManager,
+} from '@/infrastructure/services/webhook/webhook-manager.service.js';
 import { colors, fmt, messages } from '../ui/index.js';
 
 function parsePort(value: string): number {
@@ -102,6 +109,17 @@ Examples:
         );
         getPrSyncWatcher().start();
 
+        // Start webhook system (optional — falls back to polling if cloudflared is not available)
+        try {
+          const tunnelService = container.resolve<ITunnelService>('ITunnelService');
+          const webhookService = container.resolve<IWebhookService>('IWebhookService');
+          initializeWebhookManager(tunnelService, webhookService);
+          // Start is async and non-blocking — failures are logged, not thrown
+          void getWebhookManager().start(port);
+        } catch {
+          // Webhook system is optional; polling continues to work
+        }
+
         const url = `http://localhost:${port}`;
         messages.success(`Server ready at ${fmt.code(url)}`);
         messages.info('Press Ctrl+C to stop');
@@ -126,6 +144,9 @@ Examples:
           const forceExit = setTimeout(() => process.exit(0), 5000);
           forceExit.unref();
 
+          if (hasWebhookManager()) {
+            await getWebhookManager().stop();
+          }
           getPrSyncWatcher().stop();
           getNotificationWatcher().stop();
           await service.stop();

--- a/src/presentation/web/app/actions/load-webhook-status.ts
+++ b/src/presentation/web/app/actions/load-webhook-status.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+import type { WebhookSystemStatus } from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export async function loadWebhookStatus(): Promise<WebhookSystemStatus> {
+  if (!hasWebhookManager()) {
+    return {
+      running: false,
+      tunnel: { connected: false, publicUrl: null },
+      webhooks: {
+        registered: [],
+        totalDeliveries: 0,
+        successCount: 0,
+        errorCount: 0,
+        ignoredCount: 0,
+      },
+      startedAt: null,
+    };
+  }
+
+  return getWebhookManager().getStatus();
+}

--- a/src/presentation/web/app/api/webhooks/deliveries/route.ts
+++ b/src/presentation/web/app/api/webhooks/deliveries/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Webhook Delivery History: GET /api/webhooks/deliveries
+ *
+ * Returns recent webhook delivery records with optional filtering.
+ * Query params: ?status=success|error|ignored&eventType=pull_request&limit=50
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<Response> {
+  if (!hasWebhookManager()) {
+    return Response.json({ deliveries: [] });
+  }
+
+  const url = new URL(request.url);
+  const statusFilter = url.searchParams.get('status');
+  const eventTypeFilter = url.searchParams.get('eventType');
+  const limitParam = url.searchParams.get('limit');
+  const limit = limitParam ? Math.min(parseInt(limitParam, 10) || 50, 200) : 50;
+
+  const manager = getWebhookManager();
+  let deliveries = [...manager.getDeliveryHistory()];
+
+  if (statusFilter) {
+    deliveries = deliveries.filter((d) => d.status === statusFilter);
+  }
+  if (eventTypeFilter) {
+    deliveries = deliveries.filter((d) => d.eventType === eventTypeFilter);
+  }
+
+  return Response.json({ deliveries: deliveries.slice(0, limit) });
+}

--- a/src/presentation/web/app/api/webhooks/github/route.ts
+++ b/src/presentation/web/app/api/webhooks/github/route.ts
@@ -1,0 +1,86 @@
+/**
+ * GitHub Webhook Receiver: POST /api/webhooks/github
+ *
+ * Receives webhook events from GitHub, validates the HMAC-SHA256 signature,
+ * and routes the event to the GitHubWebhookService for processing.
+ *
+ * This endpoint is exposed via a Cloudflare Tunnel so GitHub can reach it.
+ * Only POST requests are accepted; all other methods return 405.
+ */
+
+import { resolve } from '@/lib/server-container';
+import type { GitHubWebhookService } from '@shepai/core/infrastructure/services/webhook/github-webhook.service';
+import { hasWebhookManager } from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request): Promise<Response> {
+  // Verify webhook system is running
+  if (!hasWebhookManager()) {
+    return Response.json({ error: 'Webhook system not initialized' }, { status: 503 });
+  }
+
+  // Read raw body for signature validation
+  const rawBody = await request.text();
+  if (!rawBody) {
+    return Response.json({ error: 'Empty request body' }, { status: 400 });
+  }
+
+  // Get the webhook service from DI container
+  let webhookService: GitHubWebhookService;
+  try {
+    webhookService = resolve<GitHubWebhookService>('IWebhookService');
+  } catch {
+    return Response.json({ error: 'Webhook service not available' }, { status: 503 });
+  }
+
+  // Validate GitHub signature
+  const signature = request.headers.get('x-hub-signature-256') ?? '';
+  const validation = webhookService.validateSignature(
+    rawBody,
+    signature,
+    webhookService.getSecret()
+  );
+
+  if (!validation.valid) {
+    // eslint-disable-next-line no-console
+    console.warn(`[WebhookRoute] Invalid signature: ${validation.error}`);
+    return Response.json({ error: `Invalid signature: ${validation.error}` }, { status: 401 });
+  }
+
+  // Parse the event
+  const eventType = request.headers.get('x-github-event') ?? 'unknown';
+  const deliveryId = request.headers.get('x-github-delivery') ?? 'unknown';
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  // Process the event asynchronously (respond immediately to GitHub)
+  void webhookService.handleEvent({
+    source: 'github',
+    eventType,
+    deliveryId,
+    payload,
+  });
+
+  return Response.json({ received: true, deliveryId });
+}
+
+/**
+ * Health check: GET /api/webhooks/github
+ * Returns whether the webhook system is active.
+ */
+export async function GET(): Promise<Response> {
+  const active = hasWebhookManager();
+
+  return Response.json({
+    active,
+    message: active
+      ? 'Webhook receiver is active'
+      : 'Webhook system not initialized (cloudflared may not be installed)',
+  });
+}

--- a/src/presentation/web/app/api/webhooks/repos/disable/route.ts
+++ b/src/presentation/web/app/api/webhooks/repos/disable/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Disable Webhook for Repo: POST /api/webhooks/repos/disable
+ *
+ * Body: { repositoryPath: string }
+ * Removes the GitHub webhook for the given repository.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request): Promise<Response> {
+  let body: { repositoryPath?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { repositoryPath } = body;
+  if (!repositoryPath) {
+    return Response.json({ success: false, error: 'repositoryPath is required' }, { status: 400 });
+  }
+
+  if (!hasWebhookManager()) {
+    return Response.json(
+      { success: false, error: 'Webhook system not initialized' },
+      { status: 503 }
+    );
+  }
+
+  const manager = getWebhookManager();
+  const result = await manager.disableWebhookForRepo(repositoryPath);
+  return Response.json(result);
+}

--- a/src/presentation/web/app/api/webhooks/repos/enable/route.ts
+++ b/src/presentation/web/app/api/webhooks/repos/enable/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Enable Webhook for Repo: POST /api/webhooks/repos/enable
+ *
+ * Body: { repositoryPath: string }
+ * Registers a GitHub webhook for the given repository.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request): Promise<Response> {
+  let body: { repositoryPath?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ success: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { repositoryPath } = body;
+  if (!repositoryPath) {
+    return Response.json({ success: false, error: 'repositoryPath is required' }, { status: 400 });
+  }
+
+  if (!hasWebhookManager()) {
+    return Response.json(
+      { success: false, error: 'Webhook system not initialized' },
+      { status: 503 }
+    );
+  }
+
+  const manager = getWebhookManager();
+  const result = await manager.enableWebhookForRepo(repositoryPath);
+  return Response.json(result, { status: result.success ? 200 : 422 });
+}

--- a/src/presentation/web/app/api/webhooks/repos/status/route.ts
+++ b/src/presentation/web/app/api/webhooks/repos/status/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Per-Repo Webhook Status: GET /api/webhooks/repos/status?repositoryPath=...
+ *
+ * Returns whether a webhook is enabled for a specific repository.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const repositoryPath = searchParams.get('repositoryPath');
+
+  if (!repositoryPath) {
+    return Response.json({ error: 'repositoryPath query parameter is required' }, { status: 400 });
+  }
+
+  if (!hasWebhookManager()) {
+    return Response.json({ enabled: false });
+  }
+
+  const manager = getWebhookManager();
+  const webhook = manager.getWebhookForRepo(repositoryPath);
+
+  if (!webhook) {
+    return Response.json({ enabled: false });
+  }
+
+  return Response.json({
+    enabled: true,
+    webhookId: webhook.webhookId,
+    repoFullName: webhook.repoFullName,
+  });
+}

--- a/src/presentation/web/app/api/webhooks/status/route.ts
+++ b/src/presentation/web/app/api/webhooks/status/route.ts
@@ -1,0 +1,33 @@
+/**
+ * Webhook System Status: GET /api/webhooks/status
+ *
+ * Returns the full webhook system status including tunnel state,
+ * registered webhooks, and delivery statistics.
+ */
+
+import {
+  hasWebhookManager,
+  getWebhookManager,
+} from '@shepai/core/infrastructure/services/webhook/webhook-manager.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(): Promise<Response> {
+  if (!hasWebhookManager()) {
+    return Response.json({
+      running: false,
+      tunnel: { connected: false, publicUrl: null },
+      webhooks: {
+        registered: [],
+        totalDeliveries: 0,
+        successCount: 0,
+        errorCount: 0,
+        ignoredCount: 0,
+      },
+      startedAt: null,
+    });
+  }
+
+  const manager = getWebhookManager();
+  return Response.json(manager.getStatus());
+}

--- a/src/presentation/web/app/webhooks/page.tsx
+++ b/src/presentation/web/app/webhooks/page.tsx
@@ -1,0 +1,15 @@
+import { loadWebhookStatus } from '@/app/actions/load-webhook-status';
+import { WebhooksPageClient } from '@/components/features/webhooks/webhooks-page-client';
+
+/** Skip static pre-rendering since we need runtime webhook manager. */
+export const dynamic = 'force-dynamic';
+
+export default async function WebhooksPage() {
+  const status = await loadWebhookStatus();
+
+  return (
+    <div className="flex h-full flex-col px-6 pb-6">
+      <WebhooksPageClient initialStatus={status} />
+    </div>
+  );
+}

--- a/src/presentation/web/components/common/action-button/action-button.tsx
+++ b/src/presentation/web/components/common/action-button/action-button.tsx
@@ -18,6 +18,10 @@ export interface ActionButtonProps {
   variant?: 'outline' | 'ghost' | 'default' | 'destructive' | 'secondary' | 'link';
   /** Button size. @default 'sm' */
   size?: 'default' | 'xs' | 'sm' | 'lg' | 'icon' | 'icon-xs' | 'icon-sm' | 'icon-lg';
+  /** Extra CSS classes for the button. */
+  className?: string;
+  /** Explicitly disable the button (in addition to loading state). */
+  disabled?: boolean;
 }
 
 export function ActionButton({
@@ -29,6 +33,8 @@ export function ActionButton({
   iconOnly = false,
   variant = 'outline',
   size = 'sm',
+  className: extraClassName,
+  disabled,
 }: ActionButtonProps) {
   const clickSound = useSoundAction('click');
 
@@ -42,7 +48,7 @@ export function ActionButton({
       variant={variant}
       size={size}
       aria-label={label}
-      disabled={loading}
+      disabled={loading || disabled}
       onClick={handleClick}
       className={cn(
         'gap-1.5',
@@ -50,7 +56,8 @@ export function ActionButton({
         !error &&
           iconOnly &&
           variant === 'ghost' &&
-          'text-muted-foreground cursor-pointer rounded-full transition-colors hover:text-blue-500'
+          'text-muted-foreground cursor-pointer rounded-full transition-colors hover:text-blue-500',
+        extraClassName
       )}
     >
       {loading ? (

--- a/src/presentation/web/components/common/repository-node/repository-drawer.stories.tsx
+++ b/src/presentation/web/components/common/repository-node/repository-drawer.stories.tsx
@@ -82,3 +82,7 @@ function RepositoryDrawerShellTemplate({ data }: { data: RepositoryNodeData }) {
 export const InDrawer: Story = {
   render: () => <RepositoryDrawerShellTemplate data={repoData} />,
 };
+
+export const WithWebhookSection: Story = {
+  render: () => <RepositoryDrawerShellTemplate data={repoData} />,
+};

--- a/src/presentation/web/components/common/repository-node/repository-drawer.tsx
+++ b/src/presentation/web/components/common/repository-node/repository-drawer.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useCallback } from 'react';
-import { Code2, Terminal, FolderOpen } from 'lucide-react';
+import { Code2, Terminal, FolderOpen, Radio } from 'lucide-react';
 import { BaseDrawer } from '@/components/common/base-drawer';
 import { DrawerTitle, DrawerDescription } from '@/components/ui/drawer';
 import { Separator } from '@/components/ui/separator';
+import { Badge } from '@/components/ui/badge';
 import { ActionButton } from '@/components/common/action-button';
+import { useWebhookAction } from '@/hooks/use-webhook-action';
 import type { RepositoryNodeData } from './repository-node-config';
 import { useRepositoryActions } from './use-repository-actions';
 
@@ -22,6 +24,13 @@ export function RepositoryDrawer({ data, onClose }: RepositoryDrawerProps) {
   const actions = useRepositoryActions(
     data?.repositoryPath ? { repositoryPath: data.repositoryPath } : null
   );
+  const webhookAction = useWebhookAction(data?.repositoryPath ?? null);
+
+  const webhookLabel = !webhookAction.tunnelConnected
+    ? 'Webhook unavailable \u2014 tunnel not running'
+    : webhookAction.enabled
+      ? 'Disable Webhook'
+      : 'Enable Webhook';
 
   return (
     <BaseDrawer
@@ -87,6 +96,44 @@ export function RepositoryDrawer({ data, onClose }: RepositoryDrawerProps) {
                 variant="outline"
                 size="sm"
               />
+            </div>
+          </div>
+          <Separator />
+          <div className="flex flex-col gap-3 p-4">
+            <div className="text-muted-foreground text-xs font-semibold tracking-wider">
+              WEBHOOKS
+            </div>
+            <div className="flex flex-col gap-2">
+              <ActionButton
+                label={webhookLabel}
+                onClick={webhookAction.toggle}
+                loading={webhookAction.loading}
+                error={!!webhookAction.error}
+                icon={Radio}
+                variant="outline"
+                size="sm"
+                disabled={!webhookAction.tunnelConnected}
+                className={
+                  webhookAction.enabled && !webhookAction.error
+                    ? 'border-green-500/30 text-green-500 hover:text-green-600'
+                    : undefined
+                }
+              />
+              {webhookAction.enabled && webhookAction.webhookId ? (
+                <div className="flex flex-col gap-2">
+                  <div className="text-muted-foreground text-xs">
+                    Webhook #{webhookAction.webhookId}
+                    {webhookAction.repoFullName ? ` on ${webhookAction.repoFullName}` : ''}
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {['pull_request', 'check_suite', 'check_run'].map((event) => (
+                      <Badge key={event} variant="secondary" className="text-xs">
+                        {event}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
             </div>
           </div>
         </>

--- a/src/presentation/web/components/common/repository-node/repository-node.stories.tsx
+++ b/src/presentation/web/components/common/repository-node/repository-node.stories.tsx
@@ -207,6 +207,13 @@ const multipleReposWithActions: RepositoryNodeData[] = [
   },
 ];
 
+export const WithWebhookButton: Story = {
+  args: {
+    repositoryPath: '/home/user/shep-ai/cli',
+  },
+  render: (args) => <RepositoryNodeCanvas data={args} />,
+};
+
 export const MultipleWithActions: Story = {
   render: () => {
     const nodes: RepositoryNodeType[] = multipleReposWithActions.map((data, i) => ({

--- a/src/presentation/web/components/common/repository-node/repository-node.tsx
+++ b/src/presentation/web/components/common/repository-node/repository-node.tsx
@@ -3,7 +3,17 @@
 import { useState, useCallback } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import { useRouter } from 'next/navigation';
-import { Github, Plus, Code2, Terminal, FolderOpen, Trash2, Play, Square } from 'lucide-react';
+import {
+  Github,
+  Plus,
+  Code2,
+  Terminal,
+  FolderOpen,
+  Trash2,
+  Play,
+  Square,
+  Radio,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ActionButton } from '@/components/common/action-button';
 import {
@@ -19,6 +29,7 @@ import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DeploymentStatusBadge } from '@/components/common/deployment-status-badge';
 import { useDeployAction } from '@/hooks/use-deploy-action';
+import { useWebhookAction } from '@/hooks/use-webhook-action';
 import { useFeatureFlags } from '@/hooks/feature-flags-context';
 import type { RepositoryNodeData } from './repository-node-config';
 import { useRepositoryActions } from './use-repository-actions';
@@ -44,6 +55,13 @@ export function RepositoryNode({ data }: { data: RepositoryNodeData; [key: strin
       : null
   );
   const isDeploymentActive = deployAction.status === 'Booting' || deployAction.status === 'Ready';
+  const webhookAction = useWebhookAction(data.repositoryPath ?? null);
+
+  const webhookTooltip = !webhookAction.tunnelConnected
+    ? 'Webhook unavailable \u2014 tunnel not running'
+    : webhookAction.enabled
+      ? 'Disable webhook'
+      : 'Enable webhook';
 
   const handleCreateFromSession = useCallback(
     (session: SessionSummary, sessionFilePath: string) => {
@@ -229,6 +247,31 @@ export function RepositoryNode({ data }: { data: RepositoryNodeData; [key: strin
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>Open Folder</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="flex items-center">
+                      <ActionButton
+                        label={webhookTooltip}
+                        onClick={webhookAction.toggle}
+                        loading={webhookAction.loading}
+                        error={!!webhookAction.error}
+                        icon={Radio}
+                        iconOnly
+                        variant="ghost"
+                        size="icon-xs"
+                        disabled={!webhookAction.tunnelConnected}
+                        className={
+                          webhookAction.enabled && !webhookAction.error
+                            ? 'text-green-500 hover:text-green-600'
+                            : undefined
+                        }
+                      />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{webhookTooltip}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
               <FeatureSessionsDropdown

--- a/src/presentation/web/components/features/webhooks/types.ts
+++ b/src/presentation/web/components/features/webhooks/types.ts
@@ -1,0 +1,34 @@
+export type WebhookDeliveryStatus = 'success' | 'ignored' | 'error';
+
+export interface WebhookDeliveryRecord {
+  deliveryId: string;
+  eventType: string;
+  source: string;
+  receivedAt: string;
+  status: WebhookDeliveryStatus;
+  statusMessage: string;
+  durationMs: number;
+  payload: Record<string, unknown>;
+}
+
+export interface RegisteredWebhookInfo {
+  repoFullName: string;
+  webhookId: number;
+  repositoryPath: string;
+}
+
+export interface WebhookSystemStatus {
+  running: boolean;
+  tunnel: {
+    connected: boolean;
+    publicUrl: string | null;
+  };
+  webhooks: {
+    registered: readonly RegisteredWebhookInfo[];
+    totalDeliveries: number;
+    successCount: number;
+    errorCount: number;
+    ignoredCount: number;
+  };
+  startedAt: string | null;
+}

--- a/src/presentation/web/components/features/webhooks/webhook-delivery-table.stories.tsx
+++ b/src/presentation/web/components/features/webhooks/webhook-delivery-table.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { WebhookDeliveryTable } from './webhook-delivery-table';
+import type { WebhookDeliveryRecord } from './types';
+
+const mockDeliveries: WebhookDeliveryRecord[] = [
+  {
+    deliveryId: 'abc-123-def',
+    eventType: 'pull_request',
+    source: 'github',
+    receivedAt: new Date(Date.now() - 60000).toISOString(),
+    status: 'success',
+    statusMessage: 'Processed successfully',
+    durationMs: 12,
+    payload: {
+      action: 'closed',
+      pull_request: {
+        number: 42,
+        merged: true,
+        html_url: 'https://github.com/acme/web-app/pull/42',
+      },
+    },
+  },
+  {
+    deliveryId: 'abc-456-ghi',
+    eventType: 'check_suite',
+    source: 'github',
+    receivedAt: new Date(Date.now() - 120000).toISOString(),
+    status: 'success',
+    statusMessage: 'Processed successfully',
+    durationMs: 8,
+    payload: {
+      action: 'completed',
+      check_suite: { conclusion: 'success', head_branch: 'feat/login' },
+    },
+  },
+  {
+    deliveryId: 'abc-789-jkl',
+    eventType: 'check_run',
+    source: 'github',
+    receivedAt: new Date(Date.now() - 180000).toISOString(),
+    status: 'error',
+    statusMessage: 'Feature not found for branch refs/heads/unknown',
+    durationMs: 3,
+    payload: { action: 'completed', check_run: { conclusion: 'failure' } },
+  },
+  {
+    deliveryId: 'abc-012-mno',
+    eventType: 'ping',
+    source: 'github',
+    receivedAt: new Date(Date.now() - 240000).toISOString(),
+    status: 'ignored',
+    statusMessage: 'Unhandled event type: ping',
+    durationMs: 0,
+    payload: { zen: 'Keep it logically awesome.' },
+  },
+];
+
+const meta: Meta<typeof WebhookDeliveryTable> = {
+  title: 'Features/Webhooks/WebhookDeliveryTable',
+  component: WebhookDeliveryTable,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithDeliveries: Story = {
+  args: { deliveries: mockDeliveries },
+};
+
+export const Empty: Story = {
+  args: { deliveries: [] },
+};
+
+export const OnlyErrors: Story = {
+  args: { deliveries: mockDeliveries.filter((d) => d.status === 'error') },
+};

--- a/src/presentation/web/components/features/webhooks/webhook-delivery-table.tsx
+++ b/src/presentation/web/components/features/webhooks/webhook-delivery-table.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useState } from 'react';
+import { CheckCircle, XCircle, MinusCircle, ChevronDown, ChevronRight } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import type { WebhookDeliveryRecord, WebhookDeliveryStatus } from './types';
+
+export interface WebhookDeliveryTableProps {
+  deliveries: WebhookDeliveryRecord[];
+}
+
+const STATUS_ICON: Record<WebhookDeliveryStatus, React.ReactNode> = {
+  success: <CheckCircle className="h-4 w-4 text-green-500" />,
+  error: <XCircle className="h-4 w-4 text-red-500" />,
+  ignored: <MinusCircle className="h-4 w-4 text-yellow-500" />,
+};
+
+const STATUS_LABEL: Record<WebhookDeliveryStatus, string> = {
+  success: 'Success',
+  error: 'Error',
+  ignored: 'Ignored',
+};
+
+export function WebhookDeliveryTable({ deliveries }: WebhookDeliveryTableProps) {
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [eventTypeFilter, setEventTypeFilter] = useState<string>('all');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const eventTypes = [...new Set(deliveries.map((d) => d.eventType))];
+
+  const filtered = deliveries.filter((d) => {
+    if (statusFilter !== 'all' && d.status !== statusFilter) return false;
+    if (eventTypeFilter !== 'all' && d.eventType !== eventTypeFilter) return false;
+    return true;
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            Delivery History ({filtered.length})
+          </CardTitle>
+          <div className="flex items-center gap-2">
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="h-8 w-[120px]">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Status</SelectItem>
+                <SelectItem value="success">Success</SelectItem>
+                <SelectItem value="error">Error</SelectItem>
+                <SelectItem value="ignored">Ignored</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={eventTypeFilter} onValueChange={setEventTypeFilter}>
+              <SelectTrigger className="h-8 w-[150px]">
+                <SelectValue placeholder="Event Type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Events</SelectItem>
+                {eventTypes.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {type}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {filtered.length === 0 ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            No delivery records yet. Webhook events will appear here when received.
+          </p>
+        ) : (
+          <div className="space-y-1">
+            {filtered.map((delivery) => (
+              <DeliveryRow
+                key={delivery.deliveryId}
+                delivery={delivery}
+                expanded={expandedId === delivery.deliveryId}
+                onToggle={() =>
+                  setExpandedId(expandedId === delivery.deliveryId ? null : delivery.deliveryId)
+                }
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DeliveryRow({
+  delivery,
+  expanded,
+  onToggle,
+}: {
+  delivery: WebhookDeliveryRecord;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const time = new Date(delivery.receivedAt);
+  const timeStr = time.toLocaleTimeString();
+  const dateStr = time.toLocaleDateString();
+
+  return (
+    <div className={cn('rounded-lg border', expanded && 'bg-muted/50')}>
+      <button
+        type="button"
+        className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm"
+        onClick={onToggle}
+      >
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0" />
+        )}
+        {STATUS_ICON[delivery.status]}
+        <Badge variant="outline" className="text-xs">
+          {delivery.eventType}
+        </Badge>
+        <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
+          {delivery.deliveryId}
+        </span>
+        <span className="text-muted-foreground shrink-0 text-xs">{delivery.durationMs}ms</span>
+        <span className="text-muted-foreground shrink-0 text-xs">{timeStr}</span>
+      </button>
+      {expanded ? (
+        <div className="border-t px-3 py-3">
+          <div className="mb-2 grid grid-cols-2 gap-2 text-xs">
+            <div>
+              <span className="text-muted-foreground">Status:</span>{' '}
+              <Badge
+                variant={delivery.status === 'error' ? 'destructive' : 'secondary'}
+                className="text-xs"
+              >
+                {STATUS_LABEL[delivery.status]}
+              </Badge>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Date:</span> {dateStr} {timeStr}
+            </div>
+            <div>
+              <span className="text-muted-foreground">Duration:</span> {delivery.durationMs}ms
+            </div>
+            <div>
+              <span className="text-muted-foreground">Source:</span> {delivery.source}
+            </div>
+          </div>
+          <div className="mb-2">
+            <span className="text-muted-foreground text-xs">Message:</span>
+            <p className="text-sm">{delivery.statusMessage}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground text-xs">Payload:</span>
+            <pre className="bg-muted mt-1 max-h-60 overflow-auto rounded-md p-2 text-xs">
+              {JSON.stringify(delivery.payload, null, 2)}
+            </pre>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/presentation/web/components/features/webhooks/webhook-repo-list.stories.tsx
+++ b/src/presentation/web/components/features/webhooks/webhook-repo-list.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { WebhookRepoList } from './webhook-repo-list';
+
+const mockWebhooks = [
+  { repoFullName: 'acme/web-app', webhookId: 12345, repositoryPath: '/home/user/web-app' },
+  { repoFullName: 'acme/api-service', webhookId: 12346, repositoryPath: '/home/user/api-service' },
+  { repoFullName: 'acme/shared-lib', webhookId: 12347, repositoryPath: '/home/user/shared-lib' },
+];
+
+const meta: Meta<typeof WebhookRepoList> = {
+  title: 'Features/Webhooks/WebhookRepoList',
+  component: WebhookRepoList,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithWebhooks: Story = {
+  args: {
+    webhooks: mockWebhooks,
+    tunnelUrl: 'https://random-subdomain.trycloudflare.com',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    webhooks: [],
+    tunnelUrl: null,
+  },
+};
+
+export const SingleRepo: Story = {
+  args: {
+    webhooks: [mockWebhooks[0]],
+    tunnelUrl: 'https://random-subdomain.trycloudflare.com',
+  },
+};

--- a/src/presentation/web/components/features/webhooks/webhook-repo-list.tsx
+++ b/src/presentation/web/components/features/webhooks/webhook-repo-list.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { GitBranch, ExternalLink } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { RegisteredWebhookInfo } from './types';
+
+export interface WebhookRepoListProps {
+  webhooks: readonly RegisteredWebhookInfo[];
+  tunnelUrl: string | null;
+}
+
+export function WebhookRepoList({ webhooks, tunnelUrl }: WebhookRepoListProps) {
+  if (webhooks.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Registered Repositories</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-sm">
+            No webhooks registered. Webhooks are automatically created for repositories with
+            features in the Review lifecycle when cloudflared is available.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium">
+          Registered Repositories ({webhooks.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {webhooks.map((webhook) => (
+            <div
+              key={webhook.webhookId}
+              className="flex items-center justify-between rounded-lg border p-3"
+            >
+              <div className="flex items-center gap-3">
+                <GitBranch className="text-muted-foreground h-4 w-4" />
+                <div>
+                  <p className="text-sm font-medium">{webhook.repoFullName}</p>
+                  <p className="text-muted-foreground text-xs">Webhook #{webhook.webhookId}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant="outline" className="text-xs">
+                  Active
+                </Badge>
+                {tunnelUrl ? (
+                  <a
+                    href={`https://github.com/${webhook.repoFullName}/settings/hooks/${webhook.webhookId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/presentation/web/components/features/webhooks/webhook-status-cards.stories.tsx
+++ b/src/presentation/web/components/features/webhooks/webhook-status-cards.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { WebhookStatusCards } from './webhook-status-cards';
+import type { WebhookSystemStatus } from './types';
+
+const activeStatus: WebhookSystemStatus = {
+  running: true,
+  tunnel: {
+    connected: true,
+    publicUrl: 'https://random-subdomain.trycloudflare.com',
+  },
+  webhooks: {
+    registered: [
+      { repoFullName: 'acme/web-app', webhookId: 12345, repositoryPath: '/home/user/web-app' },
+      {
+        repoFullName: 'acme/api-service',
+        webhookId: 12346,
+        repositoryPath: '/home/user/api-service',
+      },
+    ],
+    totalDeliveries: 42,
+    successCount: 38,
+    errorCount: 2,
+    ignoredCount: 2,
+  },
+  startedAt: new Date(Date.now() - 3600000).toISOString(),
+};
+
+const inactiveStatus: WebhookSystemStatus = {
+  running: false,
+  tunnel: { connected: false, publicUrl: null },
+  webhooks: {
+    registered: [],
+    totalDeliveries: 0,
+    successCount: 0,
+    errorCount: 0,
+    ignoredCount: 0,
+  },
+  startedAt: null,
+};
+
+const meta: Meta<typeof WebhookStatusCards> = {
+  title: 'Features/Webhooks/WebhookStatusCards',
+  component: WebhookStatusCards,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  args: { status: activeStatus },
+};
+
+export const Inactive: Story = {
+  args: { status: inactiveStatus },
+};
+
+export const TunnelDisconnected: Story = {
+  args: {
+    status: {
+      ...activeStatus,
+      tunnel: { connected: false, publicUrl: null },
+    },
+  },
+};

--- a/src/presentation/web/components/features/webhooks/webhook-status-cards.tsx
+++ b/src/presentation/web/components/features/webhooks/webhook-status-cards.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Activity, Globe, Webhook, CheckCircle, XCircle, MinusCircle } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { WebhookSystemStatus } from './types';
+
+export interface WebhookStatusCardsProps {
+  status: WebhookSystemStatus;
+}
+
+export function WebhookStatusCards({ status }: WebhookStatusCardsProps) {
+  const uptime = status.startedAt ? formatUptime(new Date(status.startedAt)) : null;
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {/* System Status */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">System Status</CardTitle>
+          <Activity className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2">
+            <div
+              className={cn('h-2 w-2 rounded-full', status.running ? 'bg-green-500' : 'bg-red-500')}
+            />
+            <span className="text-2xl font-bold">{status.running ? 'Active' : 'Inactive'}</span>
+          </div>
+          {uptime ? (
+            <p className="text-muted-foreground text-xs">Up for {uptime}</p>
+          ) : (
+            <p className="text-muted-foreground text-xs">Webhook system not started</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Tunnel Status */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Tunnel</CardTitle>
+          <Globe className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2">
+            <Badge variant={status.tunnel.connected ? 'default' : 'destructive'}>
+              {status.tunnel.connected ? 'Connected' : 'Disconnected'}
+            </Badge>
+          </div>
+          {status.tunnel.publicUrl ? (
+            <p
+              className="text-muted-foreground mt-1 truncate text-xs"
+              title={status.tunnel.publicUrl}
+            >
+              {status.tunnel.publicUrl}
+            </p>
+          ) : (
+            <p className="text-muted-foreground mt-1 text-xs">No tunnel URL</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Registered Webhooks */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Webhooks</CardTitle>
+          <Webhook className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{status.webhooks.registered.length}</div>
+          <p className="text-muted-foreground text-xs">
+            {status.webhooks.registered.length === 1 ? 'repository' : 'repositories'} registered
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Delivery Stats */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Deliveries</CardTitle>
+          <CheckCircle className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{status.webhooks.totalDeliveries}</div>
+          <div className="text-muted-foreground flex items-center gap-3 text-xs">
+            <span className="flex items-center gap-1">
+              <CheckCircle className="h-3 w-3 text-green-500" />
+              {status.webhooks.successCount}
+            </span>
+            <span className="flex items-center gap-1">
+              <XCircle className="h-3 w-3 text-red-500" />
+              {status.webhooks.errorCount}
+            </span>
+            <span className="flex items-center gap-1">
+              <MinusCircle className="h-3 w-3 text-yellow-500" />
+              {status.webhooks.ignoredCount}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function formatUptime(startedAt: Date): string {
+  const ms = Date.now() - startedAt.getTime();
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) return `${hours}h ${minutes % 60}m`;
+  if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+  return `${seconds}s`;
+}

--- a/src/presentation/web/components/features/webhooks/webhooks-page-client.stories.tsx
+++ b/src/presentation/web/components/features/webhooks/webhooks-page-client.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { WebhooksPageClient } from './webhooks-page-client';
+import type { WebhookSystemStatus } from './types';
+
+const activeStatus: WebhookSystemStatus = {
+  running: true,
+  tunnel: {
+    connected: true,
+    publicUrl: 'https://random-subdomain.trycloudflare.com',
+  },
+  webhooks: {
+    registered: [
+      { repoFullName: 'acme/web-app', webhookId: 12345, repositoryPath: '/home/user/web-app' },
+      {
+        repoFullName: 'acme/api-service',
+        webhookId: 12346,
+        repositoryPath: '/home/user/api-service',
+      },
+    ],
+    totalDeliveries: 15,
+    successCount: 12,
+    errorCount: 1,
+    ignoredCount: 2,
+  },
+  startedAt: new Date(Date.now() - 7200000).toISOString(),
+};
+
+const inactiveStatus: WebhookSystemStatus = {
+  running: false,
+  tunnel: { connected: false, publicUrl: null },
+  webhooks: {
+    registered: [],
+    totalDeliveries: 0,
+    successCount: 0,
+    errorCount: 0,
+    ignoredCount: 0,
+  },
+  startedAt: null,
+};
+
+const meta: Meta<typeof WebhooksPageClient> = {
+  title: 'Features/Webhooks/WebhooksPageClient',
+  component: WebhooksPageClient,
+  parameters: {
+    layout: 'padded',
+    mockData: [
+      { url: '/api/webhooks/status', method: 'GET', status: 200, response: activeStatus },
+      {
+        url: '/api/webhooks/deliveries?limit=100',
+        method: 'GET',
+        status: 200,
+        response: { deliveries: [] },
+      },
+    ],
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Active: Story = {
+  args: { initialStatus: activeStatus },
+};
+
+export const Inactive: Story = {
+  args: { initialStatus: inactiveStatus },
+};

--- a/src/presentation/web/components/features/webhooks/webhooks-page-client.tsx
+++ b/src/presentation/web/components/features/webhooks/webhooks-page-client.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { PageHeader } from '@/components/common/page-header';
+import { WebhookStatusCards } from './webhook-status-cards';
+import { WebhookRepoList } from './webhook-repo-list';
+import { WebhookDeliveryTable } from './webhook-delivery-table';
+import type { WebhookSystemStatus, WebhookDeliveryRecord } from './types';
+
+export interface WebhooksPageClientProps {
+  initialStatus: WebhookSystemStatus;
+}
+
+export function WebhooksPageClient({ initialStatus }: WebhooksPageClientProps) {
+  const [status, setStatus] = useState<WebhookSystemStatus>(initialStatus);
+  const [deliveries, setDeliveries] = useState<WebhookDeliveryRecord[]>([]);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      const [statusRes, deliveriesRes] = await Promise.all([
+        fetch('/api/webhooks/status'),
+        fetch('/api/webhooks/deliveries?limit=100'),
+      ]);
+      if (statusRes.ok) {
+        setStatus(await statusRes.json());
+      }
+      if (deliveriesRes.ok) {
+        const data = await deliveriesRes.json();
+        setDeliveries(data.deliveries);
+      }
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const interval = setInterval(() => void refresh(), 5000);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Webhooks"
+        description="Monitor GitHub webhook deliveries and tunnel status"
+      >
+        <Button variant="outline" size="sm" onClick={() => void refresh()} disabled={refreshing}>
+          <RefreshCw className={refreshing ? 'mr-2 h-4 w-4 animate-spin' : 'mr-2 h-4 w-4'} />
+          Refresh
+        </Button>
+      </PageHeader>
+
+      <WebhookStatusCards status={status} />
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-1">
+          <WebhookRepoList
+            webhooks={status.webhooks.registered}
+            tunnelUrl={status.tunnel.publicUrl}
+          />
+        </div>
+        <div className="lg:col-span-2">
+          <WebhookDeliveryTable deliveries={deliveries} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/presentation/web/components/layouts/app-sidebar/app-sidebar.tsx
+++ b/src/presentation/web/components/layouts/app-sidebar/app-sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { Home, Wrench, Puzzle, Settings } from 'lucide-react';
+import { Home, Wrench, Puzzle, Settings, Webhook } from 'lucide-react';
 import {
   Sidebar,
   SidebarHeader,
@@ -112,6 +112,12 @@ export function AppSidebar({
               active={pathname === '/skills'}
             />
           ) : null}
+          <SidebarNavItem
+            icon={Webhook}
+            label="Webhooks"
+            href="/webhooks"
+            active={pathname === '/webhooks'}
+          />
           <SidebarNavItem
             icon={Settings}
             label="Settings"

--- a/src/presentation/web/dev-server.ts
+++ b/src/presentation/web/dev-server.ts
@@ -34,6 +34,13 @@ import {
   getPrSyncWatcher,
 } from '@/infrastructure/services/pr-sync/pr-sync-watcher.service.js';
 import { getExistingConnection } from '@/infrastructure/persistence/sqlite/connection.js';
+import type { ITunnelService } from '@/application/ports/output/services/tunnel-service.interface.js';
+import type { IWebhookService } from '@/application/ports/output/services/webhook-service.interface.js';
+import {
+  initializeWebhookManager,
+  getWebhookManager,
+  hasWebhookManager,
+} from '@/infrastructure/services/webhook/webhook-manager.service.js';
 
 const DEFAULT_PORT = 3000;
 
@@ -90,6 +97,17 @@ async function main() {
     const db = getExistingConnection();
     initializePrSyncWatcher(featureRepo, runRepo, gitPrService, notificationService, undefined, db);
     getPrSyncWatcher().start();
+
+    // Start webhook system (optional — falls back to polling if cloudflared is not installed)
+    try {
+      const tunnelService = container.resolve<ITunnelService>('ITunnelService');
+      const webhookService = container.resolve<IWebhookService>('IWebhookService');
+      initializeWebhookManager(tunnelService, webhookService);
+      // Start is async and non-blocking — failures are logged, not thrown
+      void getWebhookManager().start(port);
+    } catch (error) {
+      console.warn('[dev-server] Webhook system init failed (using polling fallback):', error);
+    }
   } catch (error) {
     console.warn('[dev-server] DI initialization failed — features will be empty:', error);
   }
@@ -132,6 +150,13 @@ async function main() {
     console.log('\n[dev-server] Shutting down...');
     const forceExit = setTimeout(() => process.exit(0), 2000);
     try {
+      try {
+        if (hasWebhookManager()) {
+          await getWebhookManager().stop();
+        }
+      } catch {
+        /* not initialized */
+      }
       try {
         getNotificationWatcher().stop();
       } catch {

--- a/src/presentation/web/hooks/use-webhook-action.ts
+++ b/src/presentation/web/hooks/use-webhook-action.ts
@@ -1,0 +1,153 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+export interface WebhookActionState {
+  toggle: () => Promise<void>;
+  enabled: boolean;
+  loading: boolean;
+  error: string | null;
+  tunnelConnected: boolean;
+  webhookId: number | undefined;
+  repoFullName: string | undefined;
+  initializing: boolean;
+}
+
+const ERROR_CLEAR_DELAY = 5000;
+
+export function useWebhookAction(repositoryPath: string | null): WebhookActionState {
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tunnelConnected, setTunnelConnected] = useState(false);
+  const [webhookId, setWebhookId] = useState<number | undefined>();
+  const [repoFullName, setRepoFullName] = useState<string | undefined>();
+  const [initializing, setInitializing] = useState(true);
+
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    };
+  }, []);
+
+  // Fetch initial status on mount
+  useEffect(() => {
+    if (!repositoryPath) {
+      setInitializing(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchStatus() {
+      try {
+        const [tunnelRes, repoRes] = await Promise.all([
+          fetch('/api/webhooks/status'),
+          fetch(`/api/webhooks/repos/status?repositoryPath=${encodeURIComponent(repositoryPath!)}`),
+        ]);
+
+        if (cancelled || !mountedRef.current) return;
+
+        const tunnelData = await tunnelRes.json();
+        const repoData = await repoRes.json();
+
+        if (cancelled || !mountedRef.current) return;
+
+        setTunnelConnected(tunnelData.tunnel?.connected ?? false);
+        setEnabled(repoData.enabled ?? false);
+        setWebhookId(repoData.webhookId);
+        setRepoFullName(repoData.repoFullName);
+      } catch {
+        // Silently fail — UI will show default disabled state
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setInitializing(false);
+        }
+      }
+    }
+
+    void fetchStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [repositoryPath]);
+
+  const handleToggle = useCallback(async () => {
+    if (!repositoryPath || loading) return;
+
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+
+    const wasEnabled = enabled;
+    const endpoint = wasEnabled ? '/api/webhooks/repos/disable' : '/api/webhooks/repos/enable';
+
+    // Optimistic update
+    setEnabled(!wasEnabled);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repositoryPath }),
+      });
+
+      if (!mountedRef.current) return;
+
+      const data = await res.json();
+
+      if (!data.success) {
+        // Rollback
+        setEnabled(wasEnabled);
+        const errorMsg = data.error ?? 'An unexpected error occurred';
+        setError(errorMsg);
+        errorTimerRef.current = setTimeout(() => {
+          if (mountedRef.current) setError(null);
+        }, ERROR_CLEAR_DELAY);
+      } else {
+        // Update details from server response
+        if (!wasEnabled && data.webhook) {
+          setWebhookId(data.webhook.webhookId);
+          setRepoFullName(data.webhook.repoFullName);
+        } else if (wasEnabled) {
+          setWebhookId(undefined);
+          setRepoFullName(undefined);
+        }
+      }
+    } catch (err: unknown) {
+      if (!mountedRef.current) return;
+      // Rollback
+      setEnabled(wasEnabled);
+      const errorMsg = err instanceof Error ? err.message : 'An unexpected error occurred';
+      setError(errorMsg);
+      errorTimerRef.current = setTimeout(() => {
+        if (mountedRef.current) setError(null);
+      }, ERROR_CLEAR_DELAY);
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [repositoryPath, loading, enabled]);
+
+  return {
+    toggle: handleToggle,
+    enabled,
+    loading,
+    error,
+    tunnelConnected,
+    webhookId,
+    repoFullName,
+    initializing,
+  };
+}

--- a/tests/unit/infrastructure/services/tunnel/cloudflare-tunnel.service.test.ts
+++ b/tests/unit/infrastructure/services/tunnel/cloudflare-tunnel.service.test.ts
@@ -2,98 +2,99 @@
  * Cloudflare Tunnel Service Unit Tests
  *
  * Tests for tunnel lifecycle management, URL detection,
- * and URL change notifications.
+ * URL change notifications, and webhook-only proxy filtering.
  *
  * TDD Phase: GREEN
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
+import http from 'node:http';
 import { CloudflareTunnelService } from '@/infrastructure/services/tunnel/cloudflare-tunnel.service.js';
+import type { TunnelLike } from '@/infrastructure/services/tunnel/cloudflare-tunnel.service.js';
 
-vi.mock('@/infrastructure/platform.js', () => ({
-  get IS_WINDOWS() {
-    return process.platform === 'win32';
-  },
-}));
+function createMockTunnel() {
+  const emitter = new EventEmitter() as EventEmitter & TunnelLike;
+  (emitter as EventEmitter & TunnelLike & { stop: () => void }).stop = vi.fn();
+  return emitter as EventEmitter & TunnelLike & { stop: ReturnType<typeof vi.fn> };
+}
 
-function createMockProcess() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    killed: boolean;
-    kill: ReturnType<typeof vi.fn>;
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  proc.killed = false;
-  proc.kill = vi.fn(() => {
-    proc.killed = true;
+/**
+ * Emit an event on the next macrotask tick.
+ * Required because `start()` uses `await` internally, so event listeners
+ * aren't attached until after the microtask queue drains.
+ */
+function emitNext(emitter: EventEmitter, event: string, ...args: unknown[]): void {
+  setTimeout(() => emitter.emit(event, ...args), 0);
+}
+
+/**
+ * Helper: make an HTTP request and return status + body.
+ */
+function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`http://127.0.0.1:${port}${path}`, (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on('error', reject);
   });
-  return proc;
 }
 
 describe('CloudflareTunnelService', () => {
   let service: CloudflareTunnelService;
-  let mockSpawn: ReturnType<typeof vi.fn>;
-  let mockProcess: ReturnType<typeof createMockProcess>;
+  let mockCreateTunnel: (origin: string) => TunnelLike;
+  let mockTunnel: ReturnType<typeof createMockTunnel>;
+  let capturedOrigin: string | null;
 
   beforeEach(() => {
-    mockProcess = createMockProcess();
-    mockSpawn = vi.fn().mockReturnValue(mockProcess);
-    service = new CloudflareTunnelService({ spawnProcess: mockSpawn as any });
+    capturedOrigin = null;
+    mockTunnel = createMockTunnel();
+    mockCreateTunnel = vi.fn((origin: string) => {
+      capturedOrigin = origin;
+      return mockTunnel;
+    }) as unknown as (origin: string) => TunnelLike;
+    service = new CloudflareTunnelService({ createTunnel: mockCreateTunnel });
+  });
+
+  afterEach(async () => {
+    await service.stop();
   });
 
   describe('start', () => {
-    it('should spawn cloudflared with correct arguments', async () => {
-      const startPromise = service.start(3000);
+    it('should create a tunnel pointing to the proxy port, not the app port', async () => {
+      emitNext(mockTunnel, 'url', 'https://test-abc123.trycloudflare.com');
 
-      // Simulate cloudflared emitting its URL on stderr
-      mockProcess.stderr.emit(
-        'data',
-        Buffer.from('INF |  https://test-abc123.trycloudflare.com\n')
-      );
+      await service.start(3000);
 
-      const url = await startPromise;
-      expect(url).toBe('https://test-abc123.trycloudflare.com');
-      expect(mockSpawn).toHaveBeenCalledWith(
-        'cloudflared',
-        ['tunnel', '--url', 'http://localhost:3000'],
-        expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
-      );
+      // The tunnel should connect to the proxy port, not 3000
+      expect(capturedOrigin).toMatch(/^http:\/\/localhost:\d+$/);
+      expect(capturedOrigin).not.toBe('http://localhost:3000');
     });
 
-    it('should detect URL from stdout', async () => {
-      const startPromise = service.start(4050);
+    it('should resolve with tunnel URL from url event', async () => {
+      emitNext(mockTunnel, 'url', 'https://my-tunnel-url.trycloudflare.com');
 
-      mockProcess.stdout.emit('data', Buffer.from('https://my-tunnel-url.trycloudflare.com'));
-
-      const url = await startPromise;
+      const url = await service.start(4050);
       expect(url).toBe('https://my-tunnel-url.trycloudflare.com');
     });
 
-    it('should reject if process errors with ENOENT', async () => {
-      const startPromise = service.start(3000);
+    it('should reject if tunnel emits an error', async () => {
+      emitNext(mockTunnel, 'error', new Error('tunnel failed'));
 
-      const error = new Error('spawn cloudflared ENOENT') as NodeJS.ErrnoException;
-      error.code = 'ENOENT';
-      mockProcess.emit('error', error);
-
-      await expect(startPromise).rejects.toThrow("'cloudflared' not found");
+      await expect(service.start(3000)).rejects.toThrow('Failed to start tunnel');
     });
 
-    it('should reject if process exits before emitting URL', async () => {
-      const startPromise = service.start(3000);
+    it('should reject if tunnel exits before emitting URL', async () => {
+      emitNext(mockTunnel, 'exit', 1, null);
 
-      mockProcess.emit('close', 1);
-
-      await expect(startPromise).rejects.toThrow('exited with code 1');
+      await expect(service.start(3000)).rejects.toThrow('exited with code 1');
     });
 
     it('should throw if tunnel is already running', async () => {
-      const startPromise = service.start(3000);
-      mockProcess.stderr.emit('data', Buffer.from('https://first.trycloudflare.com'));
-      await startPromise;
+      emitNext(mockTunnel, 'url', 'https://first.trycloudflare.com');
+      await service.start(3000);
 
       await expect(service.start(3000)).rejects.toThrow('already running');
     });
@@ -101,12 +102,102 @@ describe('CloudflareTunnelService', () => {
     it('should report isRunning correctly', async () => {
       expect(service.isRunning()).toBe(false);
 
-      const startPromise = service.start(3000);
-      mockProcess.stderr.emit('data', Buffer.from('https://test.trycloudflare.com'));
-      await startPromise;
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(3000);
 
       expect(service.isRunning()).toBe(true);
       expect(service.getPublicUrl()).toBe('https://test.trycloudflare.com');
+    });
+
+    it('should reject if createTunnel throws', async () => {
+      const failingService = new CloudflareTunnelService({
+        createTunnel: () => {
+          throw new Error('binary not found');
+        },
+      });
+
+      await expect(failingService.start(3000)).rejects.toThrow('Failed to create tunnel');
+    });
+  });
+
+  describe('webhook-only proxy', () => {
+    let targetServer: http.Server;
+    let targetPort: number;
+
+    beforeEach(async () => {
+      // Start a simple target server that echoes paths
+      targetServer = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ path: req.url, method: req.method }));
+      });
+
+      await new Promise<void>((resolve) => {
+        targetServer.listen(0, '127.0.0.1', () => {
+          const addr = targetServer.address();
+          targetPort = (addr as { port: number }).port;
+          resolve();
+        });
+      });
+    });
+
+    afterEach(async () => {
+      await service.stop();
+      await new Promise<void>((resolve) => targetServer.close(() => resolve()));
+    });
+
+    it('should forward /api/webhooks/github to the main app', async () => {
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(targetPort);
+
+      // Extract the proxy port from the captured origin
+      const proxyPort = parseInt(capturedOrigin!.split(':').pop()!, 10);
+      const result = await httpGet(proxyPort, '/api/webhooks/github');
+
+      expect(result.status).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.path).toBe('/api/webhooks/github');
+    });
+
+    it('should forward /api/webhooks/status to the main app', async () => {
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(targetPort);
+
+      const proxyPort = parseInt(capturedOrigin!.split(':').pop()!, 10);
+      const result = await httpGet(proxyPort, '/api/webhooks/status');
+
+      expect(result.status).toBe(200);
+      const body = JSON.parse(result.body);
+      expect(body.path).toBe('/api/webhooks/status');
+    });
+
+    it('should block non-webhook paths with 404', async () => {
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(targetPort);
+
+      const proxyPort = parseInt(capturedOrigin!.split(':').pop()!, 10);
+      const result = await httpGet(proxyPort, '/');
+
+      expect(result.status).toBe(404);
+    });
+
+    it('should block /api/agent-events with 404', async () => {
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(targetPort);
+
+      const proxyPort = parseInt(capturedOrigin!.split(':').pop()!, 10);
+      const result = await httpGet(proxyPort, '/api/agent-events');
+
+      expect(result.status).toBe(404);
+    });
+
+    it('should block /_next paths with 404', async () => {
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(targetPort);
+
+      const proxyPort = parseInt(capturedOrigin!.split(':').pop()!, 10);
+      const result = await httpGet(proxyPort, '/_next/static/chunks/main.js');
+
+      expect(result.status).toBe(404);
     });
   });
 
@@ -115,12 +206,11 @@ describe('CloudflareTunnelService', () => {
       const handler = vi.fn();
       service.onUrlChange(handler);
 
-      const startPromise = service.start(3000);
-      mockProcess.stderr.emit('data', Buffer.from('https://first-url.trycloudflare.com'));
-      await startPromise;
+      emitNext(mockTunnel, 'url', 'https://first-url.trycloudflare.com');
+      await service.start(3000);
 
       // Simulate reconnection with new URL
-      mockProcess.stderr.emit('data', Buffer.from('https://second-url.trycloudflare.com'));
+      mockTunnel.emit('url', 'https://second-url.trycloudflare.com');
 
       expect(handler).toHaveBeenCalledWith('https://second-url.trycloudflare.com');
       expect(service.getPublicUrl()).toBe('https://second-url.trycloudflare.com');
@@ -130,12 +220,11 @@ describe('CloudflareTunnelService', () => {
       const handler = vi.fn();
       service.onUrlChange(handler);
 
-      const startPromise = service.start(3000);
-      mockProcess.stderr.emit('data', Buffer.from('https://same-url.trycloudflare.com'));
-      await startPromise;
+      emitNext(mockTunnel, 'url', 'https://same-url.trycloudflare.com');
+      await service.start(3000);
 
       // Emit same URL again
-      mockProcess.stderr.emit('data', Buffer.from('https://same-url.trycloudflare.com'));
+      mockTunnel.emit('url', 'https://same-url.trycloudflare.com');
 
       expect(handler).not.toHaveBeenCalled();
     });
@@ -144,26 +233,24 @@ describe('CloudflareTunnelService', () => {
       const handler = vi.fn().mockRejectedValue(new Error('handler error'));
       service.onUrlChange(handler);
 
-      const startPromise = service.start(3000);
-      mockProcess.stderr.emit('data', Buffer.from('https://first.trycloudflare.com'));
-      await startPromise;
+      emitNext(mockTunnel, 'url', 'https://first.trycloudflare.com');
+      await service.start(3000);
 
       // Should not throw even if handler rejects
-      mockProcess.stderr.emit('data', Buffer.from('https://second.trycloudflare.com'));
+      mockTunnel.emit('url', 'https://second.trycloudflare.com');
 
       expect(handler).toHaveBeenCalled();
     });
   });
 
   describe('stop', () => {
-    it('should kill the process and clear URL', async () => {
-      const startPromise = service.start(3000);
-      mockProcess.stderr.emit('data', Buffer.from('https://test.trycloudflare.com'));
-      await startPromise;
+    it('should stop the tunnel, proxy, and clear URL', async () => {
+      emitNext(mockTunnel, 'url', 'https://test.trycloudflare.com');
+      await service.start(3000);
 
       await service.stop();
 
-      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(mockTunnel.stop).toHaveBeenCalled();
       expect(service.isRunning()).toBe(false);
       expect(service.getPublicUrl()).toBeNull();
     });

--- a/tests/unit/infrastructure/services/tunnel/cloudflare-tunnel.service.test.ts
+++ b/tests/unit/infrastructure/services/tunnel/cloudflare-tunnel.service.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Cloudflare Tunnel Service Unit Tests
+ *
+ * Tests for tunnel lifecycle management, URL detection,
+ * and URL change notifications.
+ *
+ * TDD Phase: GREEN
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { CloudflareTunnelService } from '@/infrastructure/services/tunnel/cloudflare-tunnel.service.js';
+
+vi.mock('@/infrastructure/platform.js', () => ({
+  get IS_WINDOWS() {
+    return process.platform === 'win32';
+  },
+}));
+
+function createMockProcess() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.killed = false;
+  proc.kill = vi.fn(() => {
+    proc.killed = true;
+  });
+  return proc;
+}
+
+describe('CloudflareTunnelService', () => {
+  let service: CloudflareTunnelService;
+  let mockSpawn: ReturnType<typeof vi.fn>;
+  let mockProcess: ReturnType<typeof createMockProcess>;
+
+  beforeEach(() => {
+    mockProcess = createMockProcess();
+    mockSpawn = vi.fn().mockReturnValue(mockProcess);
+    service = new CloudflareTunnelService({ spawnProcess: mockSpawn as any });
+  });
+
+  describe('start', () => {
+    it('should spawn cloudflared with correct arguments', async () => {
+      const startPromise = service.start(3000);
+
+      // Simulate cloudflared emitting its URL on stderr
+      mockProcess.stderr.emit(
+        'data',
+        Buffer.from('INF |  https://test-abc123.trycloudflare.com\n')
+      );
+
+      const url = await startPromise;
+      expect(url).toBe('https://test-abc123.trycloudflare.com');
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'cloudflared',
+        ['tunnel', '--url', 'http://localhost:3000'],
+        expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] })
+      );
+    });
+
+    it('should detect URL from stdout', async () => {
+      const startPromise = service.start(4050);
+
+      mockProcess.stdout.emit('data', Buffer.from('https://my-tunnel-url.trycloudflare.com'));
+
+      const url = await startPromise;
+      expect(url).toBe('https://my-tunnel-url.trycloudflare.com');
+    });
+
+    it('should reject if process errors with ENOENT', async () => {
+      const startPromise = service.start(3000);
+
+      const error = new Error('spawn cloudflared ENOENT') as NodeJS.ErrnoException;
+      error.code = 'ENOENT';
+      mockProcess.emit('error', error);
+
+      await expect(startPromise).rejects.toThrow("'cloudflared' not found");
+    });
+
+    it('should reject if process exits before emitting URL', async () => {
+      const startPromise = service.start(3000);
+
+      mockProcess.emit('close', 1);
+
+      await expect(startPromise).rejects.toThrow('exited with code 1');
+    });
+
+    it('should throw if tunnel is already running', async () => {
+      const startPromise = service.start(3000);
+      mockProcess.stderr.emit('data', Buffer.from('https://first.trycloudflare.com'));
+      await startPromise;
+
+      await expect(service.start(3000)).rejects.toThrow('already running');
+    });
+
+    it('should report isRunning correctly', async () => {
+      expect(service.isRunning()).toBe(false);
+
+      const startPromise = service.start(3000);
+      mockProcess.stderr.emit('data', Buffer.from('https://test.trycloudflare.com'));
+      await startPromise;
+
+      expect(service.isRunning()).toBe(true);
+      expect(service.getPublicUrl()).toBe('https://test.trycloudflare.com');
+    });
+  });
+
+  describe('URL change detection', () => {
+    it('should notify handlers when URL changes', async () => {
+      const handler = vi.fn();
+      service.onUrlChange(handler);
+
+      const startPromise = service.start(3000);
+      mockProcess.stderr.emit('data', Buffer.from('https://first-url.trycloudflare.com'));
+      await startPromise;
+
+      // Simulate reconnection with new URL
+      mockProcess.stderr.emit('data', Buffer.from('https://second-url.trycloudflare.com'));
+
+      expect(handler).toHaveBeenCalledWith('https://second-url.trycloudflare.com');
+      expect(service.getPublicUrl()).toBe('https://second-url.trycloudflare.com');
+    });
+
+    it('should not notify when same URL is emitted', async () => {
+      const handler = vi.fn();
+      service.onUrlChange(handler);
+
+      const startPromise = service.start(3000);
+      mockProcess.stderr.emit('data', Buffer.from('https://same-url.trycloudflare.com'));
+      await startPromise;
+
+      // Emit same URL again
+      mockProcess.stderr.emit('data', Buffer.from('https://same-url.trycloudflare.com'));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should handle async URL change handlers gracefully', async () => {
+      const handler = vi.fn().mockRejectedValue(new Error('handler error'));
+      service.onUrlChange(handler);
+
+      const startPromise = service.start(3000);
+      mockProcess.stderr.emit('data', Buffer.from('https://first.trycloudflare.com'));
+      await startPromise;
+
+      // Should not throw even if handler rejects
+      mockProcess.stderr.emit('data', Buffer.from('https://second.trycloudflare.com'));
+
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+
+  describe('stop', () => {
+    it('should kill the process and clear URL', async () => {
+      const startPromise = service.start(3000);
+      mockProcess.stderr.emit('data', Buffer.from('https://test.trycloudflare.com'));
+      await startPromise;
+
+      await service.stop();
+
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(service.isRunning()).toBe(false);
+      expect(service.getPublicUrl()).toBeNull();
+    });
+
+    it('should be safe to call stop when not running', async () => {
+      await expect(service.stop()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/webhook/github-webhook.service.test.ts
+++ b/tests/unit/infrastructure/services/webhook/github-webhook.service.test.ts
@@ -413,4 +413,111 @@ describe('GitHubWebhookService', () => {
       expect(registered[0].webhookId).toBe(555);
     });
   });
+
+  describe('registerWebhookForSingleRepo', () => {
+    it('should register a webhook and add it to the registered list', async () => {
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 42 }), stderr: '' });
+
+      const result = await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.repoFullName).toBe('owner/repo');
+      expect(result!.webhookId).toBe(42);
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+    });
+
+    it('should no-op when a webhook is already registered for the repo path', async () => {
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 42 }), stderr: '' });
+
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      const callCountAfterFirst = mockExecFn.mock.calls.length;
+
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+
+      // No additional gh api calls for the second registration
+      expect(mockExecFn.mock.calls.length).toBe(callCountAfterFirst);
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+    });
+
+    it('should normalize backslash paths before comparing', async () => {
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 42 }), stderr: '' });
+
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      await service.registerWebhookForSingleRepo(
+        '\\home\\user\\repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+    });
+
+    it('should return the existing webhook when already registered', async () => {
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 42 }), stderr: '' });
+
+      const first = await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      const second = await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      expect(first).toEqual(second);
+    });
+  });
+
+  describe('removeWebhookForRepo', () => {
+    it('should remove a webhook from GitHub and the registered list', async () => {
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 42 }), stderr: '' });
+
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      expect(service.getRegisteredWebhooks()).toHaveLength(1);
+      mockExecFn.mockClear();
+
+      await service.removeWebhookForRepo('/home/user/repo');
+      expect(service.getRegisteredWebhooks()).toHaveLength(0);
+      expect(mockExecFn).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['api', '--method', 'DELETE']),
+        expect.any(Object)
+      );
+    });
+
+    it('should no-op when repo path is not found', async () => {
+      mockExecFn.mockClear();
+      await service.removeWebhookForRepo('/nonexistent/path');
+      expect(mockExecFn).not.toHaveBeenCalled();
+    });
+
+    it('should normalize paths when finding webhook to remove', async () => {
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 42 }), stderr: '' });
+
+      await service.registerWebhookForSingleRepo(
+        '/home/user/repo',
+        'https://tunnel.example.com/api/webhooks/github'
+      );
+      await service.removeWebhookForRepo('\\home\\user\\repo');
+      expect(service.getRegisteredWebhooks()).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/infrastructure/services/webhook/github-webhook.service.test.ts
+++ b/tests/unit/infrastructure/services/webhook/github-webhook.service.test.ts
@@ -1,0 +1,337 @@
+/**
+ * GitHub Webhook Service Unit Tests
+ *
+ * Tests for signature validation, event handling, and webhook registration.
+ *
+ * TDD Phase: GREEN
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { GitHubWebhookService } from '@/infrastructure/services/webhook/github-webhook.service.js';
+import { SdlcLifecycle, PrStatus, CiStatus } from '@/domain/generated/output.js';
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import type { IGitPrService } from '@/application/ports/output/services/git-pr-service.interface.js';
+import type { INotificationService } from '@/application/ports/output/services/notification-service.interface.js';
+import type { Feature } from '@/domain/generated/output.js';
+
+function createMockFeature(overrides: Partial<Feature> = {}): Feature {
+  return {
+    id: 'feat-1',
+    name: 'Test Feature',
+    slug: 'test-feature',
+    description: 'A test feature',
+    lifecycle: SdlcLifecycle.Review,
+    branch: 'feat/test',
+    repositoryPath: '/repo/path',
+    pr: {
+      url: 'https://github.com/owner/repo/pull/42',
+      number: 42,
+      status: PrStatus.Open,
+    },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  } as Feature;
+}
+
+describe('GitHubWebhookService', () => {
+  let service: GitHubWebhookService;
+  let mockFeatureRepo: IFeatureRepository;
+  let mockGitPrService: IGitPrService;
+  let mockNotificationService: INotificationService;
+
+  let mockExecFn: any;
+
+  beforeEach(() => {
+    mockFeatureRepo = {
+      list: vi.fn().mockResolvedValue([]),
+      findById: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+    } as unknown as IFeatureRepository;
+
+    mockGitPrService = {
+      getRemoteUrl: vi.fn().mockResolvedValue('https://github.com/owner/repo'),
+      hasRemote: vi.fn().mockResolvedValue(true),
+    } as unknown as IGitPrService;
+
+    mockNotificationService = {
+      notify: vi.fn(),
+    } as unknown as INotificationService;
+
+    mockExecFn = vi.fn().mockResolvedValue({ stdout: '{}', stderr: '' });
+
+    service = new GitHubWebhookService(
+      mockFeatureRepo,
+      mockGitPrService,
+      mockNotificationService,
+      mockExecFn
+    );
+  });
+
+  describe('validateSignature', () => {
+    it('should accept valid HMAC-SHA256 signature', () => {
+      const secret = service.getSecret();
+      const payload = '{"action":"opened"}';
+      const hmac = createHmac('sha256', secret).update(payload).digest('hex');
+      const signature = `sha256=${hmac}`;
+
+      const result = service.validateSignature(payload, signature, secret);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject missing signature', () => {
+      const result = service.validateSignature('payload', '', 'secret');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Missing signature');
+    });
+
+    it('should reject invalid signature format', () => {
+      const result = service.validateSignature('payload', 'md5=abc', 'secret');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Invalid signature format');
+    });
+
+    it('should reject wrong signature value', () => {
+      const result = service.validateSignature(
+        'payload',
+        'sha256=0000000000000000000000000000000000000000000000000000000000000000',
+        'secret'
+      );
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('mismatch');
+    });
+
+    it('should reject invalid hex encoding', () => {
+      const result = service.validateSignature('payload', 'sha256=notvalidhex', 'secret');
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('handleEvent — pull_request', () => {
+    it('should update feature when PR is merged', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'pull_request',
+        deliveryId: 'del-1',
+        payload: {
+          action: 'closed',
+          pull_request: {
+            number: 42,
+            html_url: 'https://github.com/owner/repo/pull/42',
+            merged: true,
+            head: { ref: 'feat/test' },
+          },
+        },
+      });
+
+      expect(mockFeatureRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lifecycle: SdlcLifecycle.Maintain,
+          pr: expect.objectContaining({ status: PrStatus.Merged }),
+        })
+      );
+      expect(mockNotificationService.notify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('merged'),
+        })
+      );
+    });
+
+    it('should update feature when PR is closed without merge', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'pull_request',
+        deliveryId: 'del-2',
+        payload: {
+          action: 'closed',
+          pull_request: {
+            number: 42,
+            html_url: 'https://github.com/owner/repo/pull/42',
+            merged: false,
+            head: { ref: 'feat/test' },
+          },
+        },
+      });
+
+      expect(mockFeatureRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pr: expect.objectContaining({ status: PrStatus.Closed }),
+        })
+      );
+    });
+
+    it('should match by branch when PR number does not match', async () => {
+      const feature = createMockFeature({ pr: undefined });
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'pull_request',
+        deliveryId: 'del-3',
+        payload: {
+          action: 'closed',
+          pull_request: {
+            number: 99,
+            html_url: 'https://github.com/owner/repo/pull/99',
+            merged: true,
+            head: { ref: 'feat/test' },
+          },
+        },
+      });
+
+      expect(mockFeatureRepo.update).toHaveBeenCalled();
+    });
+
+    it('should ignore events for unknown features', async () => {
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'pull_request',
+        deliveryId: 'del-4',
+        payload: {
+          action: 'closed',
+          pull_request: {
+            number: 999,
+            html_url: 'https://github.com/owner/repo/pull/999',
+            merged: true,
+            head: { ref: 'unknown-branch' },
+          },
+        },
+      });
+
+      expect(mockFeatureRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleEvent — check_suite', () => {
+    it('should update CI status on check_suite completion', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'check_suite',
+        deliveryId: 'del-5',
+        payload: {
+          action: 'completed',
+          check_suite: {
+            conclusion: 'success',
+            head_branch: 'feat/test',
+          },
+        },
+      });
+
+      expect(mockFeatureRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pr: expect.objectContaining({ ciStatus: CiStatus.Success }),
+        })
+      );
+    });
+
+    it('should ignore non-completed check_suite actions', async () => {
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'check_suite',
+        deliveryId: 'del-6',
+        payload: {
+          action: 'requested',
+          check_suite: {
+            conclusion: null,
+            head_branch: 'feat/test',
+          },
+        },
+      });
+
+      expect(mockFeatureRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('registerWebhooks', () => {
+    it('should register webhooks for repos with review features', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 123 }), stderr: '' });
+
+      await service.registerWebhooks('https://tunnel.trycloudflare.com');
+
+      expect(mockExecFn).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining([
+          'api',
+          '--method',
+          'POST',
+          expect.stringContaining('/repos/owner/repo/hooks'),
+        ]),
+        expect.objectContaining({ cwd: '/repo/path' })
+      );
+    });
+
+    it('should handle registration failure gracefully', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockRejectedValue(new Error('gh api failed'));
+
+      // Should not throw
+      await expect(
+        service.registerWebhooks('https://tunnel.trycloudflare.com')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('removeWebhooks', () => {
+    it('should remove all registered webhooks', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 456 }), stderr: '' });
+
+      await service.registerWebhooks('https://tunnel.trycloudflare.com');
+      mockExecFn.mockClear();
+
+      await service.removeWebhooks();
+
+      expect(mockExecFn).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['api', '--method', 'DELETE']),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('updateWebhookUrl', () => {
+    it('should update URL for all registered webhooks', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 789 }), stderr: '' });
+
+      await service.registerWebhooks('https://old-url.trycloudflare.com');
+      mockExecFn.mockClear();
+
+      await service.updateWebhookUrl('https://new-url.trycloudflare.com');
+
+      expect(mockExecFn).toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining([
+          'api',
+          '--method',
+          'PATCH',
+          expect.stringContaining('/repos/owner/repo/hooks/'),
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/webhook/github-webhook.service.test.ts
+++ b/tests/unit/infrastructure/services/webhook/github-webhook.service.test.ts
@@ -334,4 +334,83 @@ describe('GitHubWebhookService', () => {
       );
     });
   });
+
+  describe('delivery history tracking', () => {
+    it('should record successful deliveries', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'pull_request',
+        deliveryId: 'hist-1',
+        payload: {
+          action: 'closed',
+          pull_request: {
+            number: 42,
+            html_url: 'https://github.com/owner/repo/pull/42',
+            merged: true,
+            head: { ref: 'feat/test' },
+          },
+        },
+      });
+
+      const history = service.getDeliveryHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0].deliveryId).toBe('hist-1');
+      expect(history[0].status).toBe('success');
+      expect(history[0].eventType).toBe('pull_request');
+      expect(history[0].durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should record ignored events for unhandled types', async () => {
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'ping',
+        deliveryId: 'hist-2',
+        payload: { zen: 'Keep it logically awesome.' },
+      });
+
+      const history = service.getDeliveryHistory();
+      expect(history).toHaveLength(1);
+      expect(history[0].status).toBe('ignored');
+      expect(history[0].statusMessage).toContain('Unhandled event type');
+    });
+
+    it('should return newest deliveries first', async () => {
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([]);
+
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'ping',
+        deliveryId: 'first',
+        payload: {},
+      });
+      await service.handleEvent({
+        source: 'github',
+        eventType: 'ping',
+        deliveryId: 'second',
+        payload: {},
+      });
+
+      const history = service.getDeliveryHistory();
+      expect(history).toHaveLength(2);
+      expect(history[0].deliveryId).toBe('second');
+      expect(history[1].deliveryId).toBe('first');
+    });
+
+    it('should expose registered webhooks via getter', async () => {
+      const feature = createMockFeature();
+      vi.mocked(mockFeatureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(mockGitPrService.getRemoteUrl).mockResolvedValue('https://github.com/owner/repo');
+      mockExecFn.mockResolvedValue({ stdout: JSON.stringify({ id: 555 }), stderr: '' });
+
+      await service.registerWebhooks('https://tunnel.trycloudflare.com');
+
+      const registered = service.getRegisteredWebhooks();
+      expect(registered).toHaveLength(1);
+      expect(registered[0].repoFullName).toBe('owner/repo');
+      expect(registered[0].webhookId).toBe(555);
+    });
+  });
 });

--- a/tests/unit/infrastructure/services/webhook/webhook-manager.service.test.ts
+++ b/tests/unit/infrastructure/services/webhook/webhook-manager.service.test.ts
@@ -207,3 +207,101 @@ describe('Singleton accessors', () => {
     expect(hasWebhookManager()).toBe(false);
   });
 });
+
+describe('Per-repo webhook methods', () => {
+  function createMockWebhookServiceWithSingleRepo() {
+    return {
+      ...createMockWebhookService(),
+      registerWebhookForSingleRepo: vi
+        .fn()
+        .mockResolvedValue({ repoFullName: 'owner/repo', webhookId: 42, repositoryPath: '/repo' }),
+      removeWebhookForRepo: vi.fn().mockResolvedValue(undefined),
+      getRegisteredWebhooks: vi.fn().mockReturnValue([]),
+      getDeliveryHistory: vi.fn().mockReturnValue([]),
+    };
+  }
+
+  describe('enableWebhookForRepo', () => {
+    it('should return error when tunnel is not running', async () => {
+      const tunnel = createMockTunnelService();
+      vi.mocked(tunnel.isRunning).mockReturnValue(false);
+      vi.mocked(tunnel.getPublicUrl).mockReturnValue(null);
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      const result = await manager.enableWebhookForRepo('/repo');
+      expect(result).toEqual({ success: false, error: 'tunnel_not_connected' });
+      expect(webhook.registerWebhookForSingleRepo).not.toHaveBeenCalled();
+    });
+
+    it('should register webhook and return success when tunnel is running', async () => {
+      const tunnel = createMockTunnelService();
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      const result = await manager.enableWebhookForRepo('/repo');
+      expect(result.success).toBe(true);
+      expect(result.webhook).toBeDefined();
+      expect(webhook.registerWebhookForSingleRepo).toHaveBeenCalledWith(
+        '/repo',
+        'https://test.trycloudflare.com/api/webhooks/github'
+      );
+    });
+
+    it('should return error when registration throws', async () => {
+      const tunnel = createMockTunnelService();
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      webhook.registerWebhookForSingleRepo.mockRejectedValue(new Error('gh api failed'));
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      const result = await manager.enableWebhookForRepo('/repo');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('gh api failed');
+    });
+  });
+
+  describe('disableWebhookForRepo', () => {
+    it('should delegate to webhookService.removeWebhookForRepo', async () => {
+      const tunnel = createMockTunnelService();
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      const result = await manager.disableWebhookForRepo('/repo');
+      expect(result).toEqual({ success: true });
+      expect(webhook.removeWebhookForRepo).toHaveBeenCalledWith('/repo');
+    });
+
+    it('should return error when removal throws', async () => {
+      const tunnel = createMockTunnelService();
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      webhook.removeWebhookForRepo.mockRejectedValue(new Error('api error'));
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      const result = await manager.disableWebhookForRepo('/repo');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('api error');
+    });
+  });
+
+  describe('isWebhookEnabledForRepo', () => {
+    it('should return false when repo has no webhook', () => {
+      const tunnel = createMockTunnelService();
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      expect(manager.isWebhookEnabledForRepo('/repo')).toBe(false);
+    });
+
+    it('should return true when repo has a webhook (normalized path)', () => {
+      const tunnel = createMockTunnelService();
+      const webhook = createMockWebhookServiceWithSingleRepo();
+      webhook.getRegisteredWebhooks.mockReturnValue([
+        { repoFullName: 'owner/repo', webhookId: 42, repositoryPath: '/home/user/repo' },
+      ]);
+      const manager = new WebhookManagerService(tunnel, webhook);
+
+      expect(manager.isWebhookEnabledForRepo('/home/user/repo')).toBe(true);
+      expect(manager.isWebhookEnabledForRepo('\\home\\user\\repo')).toBe(true);
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/webhook/webhook-manager.service.test.ts
+++ b/tests/unit/infrastructure/services/webhook/webhook-manager.service.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Webhook Manager Service Unit Tests
+ *
+ * Tests for the orchestrator that ties tunnel + webhook lifecycle together.
+ *
+ * TDD Phase: GREEN
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  WebhookManagerService,
+  initializeWebhookManager,
+  getWebhookManager,
+  hasWebhookManager,
+  resetWebhookManager,
+} from '@/infrastructure/services/webhook/webhook-manager.service.js';
+import type { ITunnelService } from '@/application/ports/output/services/tunnel-service.interface.js';
+import type { IWebhookService } from '@/application/ports/output/services/webhook-service.interface.js';
+
+function createMockTunnelService(): ITunnelService {
+  return {
+    start: vi.fn().mockResolvedValue('https://test.trycloudflare.com'),
+    stop: vi.fn().mockResolvedValue(undefined),
+    getPublicUrl: vi.fn().mockReturnValue('https://test.trycloudflare.com'),
+    onUrlChange: vi.fn(),
+    isRunning: vi.fn().mockReturnValue(true),
+  };
+}
+
+function createMockWebhookService(): IWebhookService {
+  return {
+    registerWebhooks: vi.fn().mockResolvedValue(undefined),
+    updateWebhookUrl: vi.fn().mockResolvedValue(undefined),
+    removeWebhooks: vi.fn().mockResolvedValue(undefined),
+    validateSignature: vi.fn().mockReturnValue({ valid: true }),
+    handleEvent: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('WebhookManagerService', () => {
+  let tunnelService: ReturnType<typeof createMockTunnelService>;
+  let webhookService: ReturnType<typeof createMockWebhookService>;
+  let manager: WebhookManagerService;
+
+  beforeEach(() => {
+    tunnelService = createMockTunnelService();
+    webhookService = createMockWebhookService();
+    manager = new WebhookManagerService(tunnelService, webhookService);
+  });
+
+  describe('start', () => {
+    it('should start tunnel and register webhooks', async () => {
+      await manager.start(3000);
+
+      expect(tunnelService.start).toHaveBeenCalledWith(3000);
+      expect(tunnelService.onUrlChange).toHaveBeenCalled();
+      expect(webhookService.registerWebhooks).toHaveBeenCalledWith(
+        'https://test.trycloudflare.com'
+      );
+      expect(manager.isRunning()).toBe(true);
+    });
+
+    it('should register URL change handler that updates webhooks', async () => {
+      await manager.start(3000);
+
+      // Get the URL change handler that was registered
+      const onUrlChange = vi.mocked(tunnelService.onUrlChange);
+      expect(onUrlChange).toHaveBeenCalledTimes(1);
+      const handler = onUrlChange.mock.calls[0][0];
+
+      // Simulate URL change
+      await handler('https://new-url.trycloudflare.com');
+
+      expect(webhookService.updateWebhookUrl).toHaveBeenCalledWith(
+        'https://new-url.trycloudflare.com'
+      );
+    });
+
+    it('should not throw if tunnel start fails (graceful fallback)', async () => {
+      vi.mocked(tunnelService.start).mockRejectedValue(new Error("'cloudflared' not found"));
+
+      // Should not throw
+      await expect(manager.start(3000)).resolves.toBeUndefined();
+      expect(manager.isRunning()).toBe(false);
+    });
+
+    it('should clean up tunnel if webhook registration fails', async () => {
+      vi.mocked(webhookService.registerWebhooks).mockRejectedValue(new Error('GitHub API error'));
+
+      await expect(manager.start(3000)).resolves.toBeUndefined();
+      expect(tunnelService.stop).toHaveBeenCalled();
+      expect(manager.isRunning()).toBe(false);
+    });
+
+    it('should be idempotent when already running', async () => {
+      await manager.start(3000);
+      await manager.start(3000);
+
+      expect(tunnelService.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('stop', () => {
+    it('should remove webhooks and stop tunnel', async () => {
+      await manager.start(3000);
+      await manager.stop();
+
+      expect(webhookService.removeWebhooks).toHaveBeenCalled();
+      expect(tunnelService.stop).toHaveBeenCalled();
+      expect(manager.isRunning()).toBe(false);
+    });
+
+    it('should handle webhook removal failure gracefully', async () => {
+      await manager.start(3000);
+      vi.mocked(webhookService.removeWebhooks).mockRejectedValue(new Error('API error'));
+
+      await expect(manager.stop()).resolves.toBeUndefined();
+      expect(tunnelService.stop).toHaveBeenCalled();
+    });
+
+    it('should be safe to call stop when not running', async () => {
+      await expect(manager.stop()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('getTunnelUrl', () => {
+    it('should return tunnel URL when running', async () => {
+      await manager.start(3000);
+      expect(manager.getTunnelUrl()).toBe('https://test.trycloudflare.com');
+    });
+  });
+});
+
+describe('Singleton accessors', () => {
+  afterEach(() => {
+    resetWebhookManager();
+  });
+
+  it('should initialize and retrieve singleton', () => {
+    const tunnel = createMockTunnelService();
+    const webhook = createMockWebhookService();
+
+    expect(hasWebhookManager()).toBe(false);
+
+    initializeWebhookManager(tunnel, webhook);
+
+    expect(hasWebhookManager()).toBe(true);
+    expect(getWebhookManager()).toBeInstanceOf(WebhookManagerService);
+  });
+
+  it('should throw on double initialization', () => {
+    const tunnel = createMockTunnelService();
+    const webhook = createMockWebhookService();
+
+    initializeWebhookManager(tunnel, webhook);
+
+    expect(() => initializeWebhookManager(tunnel, webhook)).toThrow('already initialized');
+  });
+
+  it('should throw when getting uninitialized manager', () => {
+    expect(() => getWebhookManager()).toThrow('not initialized');
+  });
+
+  it('should reset cleanly', () => {
+    const tunnel = createMockTunnelService();
+    const webhook = createMockWebhookService();
+
+    initializeWebhookManager(tunnel, webhook);
+    resetWebhookManager();
+
+    expect(hasWebhookManager()).toBe(false);
+  });
+});

--- a/tests/unit/infrastructure/services/webhook/webhook-manager.service.test.ts
+++ b/tests/unit/infrastructure/services/webhook/webhook-manager.service.test.ts
@@ -129,6 +129,42 @@ describe('WebhookManagerService', () => {
       expect(manager.getTunnelUrl()).toBe('https://test.trycloudflare.com');
     });
   });
+
+  describe('getStatus', () => {
+    it('should return inactive status when not started', () => {
+      const status = manager.getStatus();
+      expect(status.running).toBe(false);
+      expect(status.startedAt).toBeNull();
+    });
+
+    it('should return active status with tunnel info when running', async () => {
+      await manager.start(3000);
+      const status = manager.getStatus();
+
+      expect(status.running).toBe(true);
+      expect(status.startedAt).not.toBeNull();
+      expect(status.tunnel.connected).toBe(true);
+      expect(status.tunnel.publicUrl).toBe('https://test.trycloudflare.com');
+    });
+
+    it('should return delivery statistics', async () => {
+      await manager.start(3000);
+      const status = manager.getStatus();
+
+      expect(status.webhooks.totalDeliveries).toBe(0);
+      expect(status.webhooks.successCount).toBe(0);
+      expect(status.webhooks.errorCount).toBe(0);
+      expect(status.webhooks.ignoredCount).toBe(0);
+    });
+  });
+
+  describe('getDeliveryHistory', () => {
+    it('should return empty array when webhook service has no delivery tracking', async () => {
+      await manager.start(3000);
+      const history = manager.getDeliveryHistory();
+      expect(history).toEqual([]);
+    });
+  });
 });
 
 describe('Singleton accessors', () => {


### PR DESCRIPTION
## Summary

- Adds per-repository webhook toggle on the repo node (Radio icon button) and repo drawer (labeled button with event badges)
- New service layer methods on `GitHubWebhookService` and `WebhookManagerService` for single-repo webhook registration/removal with duplicate guards and cross-platform path normalization
- Three new API endpoints: `POST /api/webhooks/repos/enable`, `POST /api/webhooks/repos/disable`, `GET /api/webhooks/repos/status`
- `useWebhookAction` hook with optimistic toggle and rollback on error
- When the Cloudflare tunnel is not running, the toggle is disabled with a tooltip

## Test plan

- [ ] Verify webhook Radio button appears on repo nodes with `repositoryPath`
- [ ] Verify button is disabled (gray) when tunnel is not running
- [ ] Start tunnel, click enable — button turns green, GitHub webhook created
- [ ] Click disable — button turns gray, webhook removed from GitHub
- [ ] Open repo drawer — verify WEBHOOKS section shows toggle + event badges when enabled
- [ ] All 4130 unit tests pass, including 14 new service-layer tests
- [ ] `pnpm validate` passes (lint, format, typecheck, tsp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)