### PR TITLE
feat: add github webhook tunnel support

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -232,6 +232,9 @@ export default tseslint.config(
       },
     },
     settings: {
+      next: {
+        rootDir: 'src/presentation/web',
+      },
       react: {
         version: 'detect',
       },

--- a/packages/core/src/infrastructure/services/pr-sync/pr-sync-watcher.service.ts
+++ b/packages/core/src/infrastructure/services/pr-sync/pr-sync-watcher.service.ts
@@ -10,7 +10,7 @@
  * repositoryPath for batch `gh pr list` queries.
  */
 
-import type { Feature, NotificationEvent } from '../../../domain/generated/output.js';
+import type { Feature, NotificationEvent } from '../../../domain/generated/output';
 import {
   SdlcLifecycle,
   PrStatus,
@@ -18,15 +18,15 @@ import {
   AgentRunStatus,
   NotificationEventType,
   NotificationSeverity,
-} from '../../../domain/generated/output.js';
-import type { IFeatureRepository } from '../../../application/ports/output/repositories/feature-repository.interface.js';
-import type { IAgentRunRepository } from '../../../application/ports/output/agents/agent-run-repository.interface.js';
-import type { IGitPrService } from '../../../application/ports/output/services/git-pr-service.interface.js';
+} from '../../../domain/generated/output';
+import type { IFeatureRepository } from '../../../application/ports/output/repositories/feature-repository.interface';
+import type { IAgentRunRepository } from '../../../application/ports/output/agents/agent-run-repository.interface';
+import type { IGitPrService } from '../../../application/ports/output/services/git-pr-service.interface';
 import type {
   CiStatusResult,
   PrStatusInfo,
-} from '../../../application/ports/output/services/git-pr-service.interface.js';
-import type { INotificationService } from '../../../application/ports/output/services/notification-service.interface.js';
+} from '../../../application/ports/output/services/git-pr-service.interface';
+import type { INotificationService } from '../../../application/ports/output/services/notification-service.interface';
 import type Database from 'better-sqlite3';
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -47,6 +47,22 @@ const CI_STATUS_MAP: Record<string, CiStatus> = {
   failure: CiStatus.Failure,
   pending: CiStatus.Pending,
 };
+
+function parseGitHubFullName(remoteUrl: string | null): string | null {
+  if (!remoteUrl) return null;
+
+  const httpsMatch = remoteUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    return `${httpsMatch[1]}/${httpsMatch[2]}`;
+  }
+
+  const sshMatch = remoteUrl.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return `${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  return null;
+}
 
 export class PrSyncWatcherService {
   private readonly featureRepo: IFeatureRepository;
@@ -104,6 +120,39 @@ export class PrSyncWatcherService {
       // eslint-disable-next-line no-console
       console.log(`${TAG} Stopped`);
     }
+  }
+
+  /**
+   * Immediately refresh a repository identified by GitHub owner/repo.
+   * Used by the webhook route to accelerate sync without waiting for the next poll.
+   */
+  async syncRepositoryByGitHubFullName(fullName: string): Promise<boolean> {
+    try {
+      const allFeatures = await this.featureRepo.list({ lifecycle: SdlcLifecycle.Review });
+      const features = allFeatures.filter((f) => f.repositoryPath);
+      if (features.length === 0) return false;
+
+      const byRepo = new Map<string, Feature[]>();
+      for (const feature of features) {
+        const group = byRepo.get(feature.repositoryPath) ?? [];
+        group.push(feature);
+        byRepo.set(feature.repositoryPath, group);
+      }
+
+      for (const [repoPath, repoFeatures] of byRepo) {
+        const remoteUrl = await this.gitPrService.getRemoteUrl(repoPath);
+        if (parseGitHubFullName(remoteUrl) !== fullName) continue;
+
+        await this.processRepository(repoPath, repoFeatures);
+        return true;
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // eslint-disable-next-line no-console
+      console.warn(`${TAG} Webhook refresh failed for ${fullName}: ${msg}`);
+    }
+
+    return false;
   }
 
   /** Attempt to acquire the cross-process poll lock. Returns true if acquired. */

--- a/packages/core/src/infrastructure/services/webhooks/github-webhook-runtime.service.ts
+++ b/packages/core/src/infrastructure/services/webhooks/github-webhook-runtime.service.ts
@@ -1,0 +1,261 @@
+import http from 'node:http';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { SdlcLifecycle } from '../../../domain/generated/output';
+import type { IFeatureRepository } from '../../../application/ports/output/repositories/feature-repository.interface';
+import { findAvailablePort } from '../port.service';
+import type { GitHubWebhookService } from './github-webhook.service';
+import { getOrCreateGitHubWebhookSecret } from './webhook-secret.service';
+
+const DEFAULT_GATEWAY_PORT = 4590;
+const DEFAULT_RECONCILE_INTERVAL_MS = 60_000;
+const TUNNEL_READY_TIMEOUT_MS = 15_000;
+const GITHUB_WEBHOOK_CALLBACK_PATH = '/api/webhooks/github?source=shep';
+const ENABLE_ENV = 'SHEP_ENABLE_GITHUB_WEBHOOKS';
+
+type FetchFn = typeof fetch;
+
+interface GitHubWebhookRuntimeDeps {
+  createServer: typeof http.createServer;
+  spawnProcess: typeof spawn;
+  findAvailablePort: typeof findAvailablePort;
+  fetchImpl: FetchFn;
+  getSecret: typeof getOrCreateGitHubWebhookSecret;
+  logInfo: (message: string) => void;
+  logWarn: (message: string) => void;
+}
+
+const defaultDeps: GitHubWebhookRuntimeDeps = {
+  createServer: http.createServer,
+  spawnProcess: spawn,
+  findAvailablePort,
+  fetchImpl: fetch,
+  getSecret: getOrCreateGitHubWebhookSecret,
+  logInfo: (message) => process.stdout.write(`${message}\n`),
+  logWarn: (message) => process.stderr.write(`${message}\n`),
+};
+
+export function isGitHubWebhookRuntimeEnabled(): boolean {
+  return process.env[ENABLE_ENV] === '1' || process.env[ENABLE_ENV] === 'true';
+}
+
+export class GitHubWebhookRuntimeService {
+  private readonly deps: GitHubWebhookRuntimeDeps;
+  private gatewayServer: http.Server | null = null;
+  private tunnelProcess: ChildProcess | null = null;
+  private reconcileTimer: ReturnType<typeof setInterval> | null = null;
+  private publicBaseUrl: string | null = null;
+  private gatewayPort: number | null = null;
+  private secret: string | null = null;
+
+  constructor(
+    private readonly featureRepo: IFeatureRepository,
+    private readonly webhookService: Pick<GitHubWebhookService, 'ensureRepositoryWebhook'>,
+    private readonly appPort: number,
+    private readonly reconcileIntervalMs: number = DEFAULT_RECONCILE_INTERVAL_MS,
+    deps: Partial<GitHubWebhookRuntimeDeps> = {}
+  ) {
+    this.deps = { ...defaultDeps, ...deps };
+  }
+
+  getPublicBaseUrl(): string | null {
+    return this.publicBaseUrl;
+  }
+
+  getGatewayPort(): number | null {
+    return this.gatewayPort;
+  }
+
+  async start(): Promise<string | null> {
+    if (!isGitHubWebhookRuntimeEnabled()) {
+      return null;
+    }
+
+    if (this.publicBaseUrl) {
+      return this.publicBaseUrl;
+    }
+
+    this.secret = this.deps.getSecret();
+
+    try {
+      this.gatewayPort = await this.deps.findAvailablePort(DEFAULT_GATEWAY_PORT);
+      await this.startGateway();
+      this.publicBaseUrl = await this.startTunnel();
+      await this.reconcileHooks();
+
+      this.reconcileTimer = setInterval(() => {
+        void this.reconcileHooks();
+      }, this.reconcileIntervalMs);
+      this.reconcileTimer.unref?.();
+
+      return this.publicBaseUrl;
+    } catch (error) {
+      await this.stop();
+      throw error;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.reconcileTimer) {
+      clearInterval(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
+
+    if (this.tunnelProcess) {
+      this.tunnelProcess.kill('SIGTERM');
+      this.tunnelProcess = null;
+    }
+
+    if (this.gatewayServer) {
+      await new Promise<void>((resolve) => {
+        this.gatewayServer!.close(() => resolve());
+      });
+      this.gatewayServer = null;
+    }
+
+    this.publicBaseUrl = null;
+    this.gatewayPort = null;
+  }
+
+  private async startGateway(): Promise<void> {
+    const port = this.gatewayPort;
+    if (!port) {
+      throw new Error('Gateway port not allocated');
+    }
+
+    const server = this.deps.createServer((req, res) => {
+      void this.handleGatewayRequest(req, res);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, '127.0.0.1', () => resolve());
+    });
+
+    this.gatewayServer = server;
+  }
+
+  private async handleGatewayRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    if (!req.url?.startsWith('/api/webhooks/')) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+
+    const body = await this.readRequestBody(req);
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (!value) continue;
+      if (key === 'host' || key === 'connection' || key === 'content-length') continue;
+      if (Array.isArray(value)) {
+        for (const item of value) headers.append(key, item);
+      } else {
+        headers.set(key, value);
+      }
+    }
+
+    const requestBody = this.requestCanHaveBody(req.method) ? new Uint8Array(body) : undefined;
+
+    const response = await this.deps.fetchImpl(`http://127.0.0.1:${this.appPort}${req.url}`, {
+      method: req.method,
+      headers,
+      body: requestBody,
+    });
+
+    res.statusCode = response.status;
+    response.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+    const buffer = Buffer.from(await response.arrayBuffer());
+    res.end(buffer);
+  }
+
+  private requestCanHaveBody(method: string | undefined): boolean {
+    return method !== undefined && method !== 'GET' && method !== 'HEAD';
+  }
+
+  private async readRequestBody(req: http.IncomingMessage): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  private async startTunnel(): Promise<string> {
+    const port = this.gatewayPort;
+    if (!port) {
+      throw new Error('Gateway port not allocated');
+    }
+
+    const child = this.deps.spawnProcess(
+      process.env.SHEP_CLOUDFLARED_BIN ?? 'cloudflared',
+      ['tunnel', '--url', `http://127.0.0.1:${port}`],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    this.tunnelProcess = child;
+
+    const publicUrl = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error('Timed out waiting for cloudflared public URL'));
+      }, TUNNEL_READY_TIMEOUT_MS);
+
+      const onData = (chunk: Buffer | string) => {
+        const match = String(chunk).match(/https:\/\/[a-zA-Z0-9.-]+\.trycloudflare\.com/);
+        if (!match) return;
+        cleanup();
+        resolve(match[0]);
+      };
+
+      const onExit = (code: number | null) => {
+        cleanup();
+        reject(new Error(`cloudflared exited before URL was ready (code ${code ?? 'unknown'})`));
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        child.stdout?.off('data', onData);
+        child.stderr?.off('data', onData);
+        child.off('exit', onExit);
+      };
+
+      child.stdout?.on('data', onData);
+      child.stderr?.on('data', onData);
+      child.on('exit', onExit);
+    });
+
+    this.deps.logInfo(`[GitHubWebhookRuntime] Tunnel ready at ${publicUrl}`);
+    return publicUrl;
+  }
+
+  private async reconcileHooks(): Promise<void> {
+    if (!this.publicBaseUrl || !this.secret) return;
+
+    const features = await this.featureRepo.list({ lifecycle: SdlcLifecycle.Review });
+    const repoPaths = [
+      ...new Set(features.map((feature) => feature.repositoryPath).filter(Boolean)),
+    ];
+
+    for (const repoPath of repoPaths) {
+      try {
+        const result = await this.webhookService.ensureRepositoryWebhook(repoPath, {
+          callbackUrl: `${this.publicBaseUrl}${GITHUB_WEBHOOK_CALLBACK_PATH}`,
+          secret: this.secret,
+          events: ['pull_request', 'check_suite'],
+        });
+
+        if (result.action !== 'unchanged' && result.action !== 'skipped') {
+          this.deps.logInfo(
+            `[GitHubWebhookRuntime] ${result.action} webhook for ${repoPath} -> ${result.callbackUrl ?? 'n/a'}`
+          );
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        this.deps.logWarn(`[GitHubWebhookRuntime] Failed to reconcile ${repoPath}: ${msg}`);
+      }
+    }
+  }
+}

--- a/packages/core/src/infrastructure/services/webhooks/github-webhook.service.ts
+++ b/packages/core/src/infrastructure/services/webhooks/github-webhook.service.ts
@@ -1,0 +1,151 @@
+import type { ExecFunction } from '../git/worktree.service';
+import type { IGitPrService } from '../../../application/ports/output/services/git-pr-service.interface';
+
+export interface GitHubWebhookConfig {
+  callbackUrl: string;
+  secret: string;
+  events: string[];
+}
+
+export interface GitHubWebhookSyncResult {
+  action: 'created' | 'updated' | 'unchanged' | 'skipped';
+  hookId?: number;
+  callbackUrl?: string;
+}
+
+interface GitHubRepoHook {
+  id: number;
+  active: boolean;
+  events?: string[];
+  config?: {
+    url?: string;
+    content_type?: string;
+  };
+}
+
+const SHEP_WEBHOOK_MARKER = 'source=shep';
+
+function parseGitHubOwnerRepo(remoteUrl: string | null): { owner: string; repo: string } | null {
+  if (!remoteUrl) return null;
+
+  const httpsMatch = remoteUrl.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (httpsMatch) {
+    return { owner: httpsMatch[1], repo: httpsMatch[2] };
+  }
+
+  const sshMatch = remoteUrl.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (sshMatch) {
+    return { owner: sshMatch[1], repo: sshMatch[2] };
+  }
+
+  return null;
+}
+
+export class GitHubWebhookService {
+  constructor(
+    private readonly execFile: ExecFunction,
+    private readonly gitPrService: Pick<IGitPrService, 'getRemoteUrl'>
+  ) {}
+
+  async ensureRepositoryWebhook(
+    cwd: string,
+    config: GitHubWebhookConfig
+  ): Promise<GitHubWebhookSyncResult> {
+    const remoteUrl = await this.gitPrService.getRemoteUrl(cwd);
+    const repo = parseGitHubOwnerRepo(remoteUrl);
+    if (!repo) {
+      return { action: 'skipped' };
+    }
+
+    const hooksPath = `repos/${repo.owner}/${repo.repo}/hooks`;
+    const hooks = await this.listHooks(cwd, hooksPath);
+    const existing = hooks.find((hook) => hook.config?.url?.includes(SHEP_WEBHOOK_MARKER));
+
+    if (!existing) {
+      const created = await this.execFile(
+        'gh',
+        ['api', hooksPath, '--method', 'POST', ...this.buildMutationArgs(config)],
+        { cwd }
+      );
+      const payload = this.parseHookPayload(created.stdout);
+      return {
+        action: 'created',
+        hookId: payload?.id,
+        callbackUrl: config.callbackUrl,
+      };
+    }
+
+    if (this.isHookUpToDate(existing, config)) {
+      return {
+        action: 'unchanged',
+        hookId: existing.id,
+        callbackUrl: config.callbackUrl,
+      };
+    }
+
+    await this.execFile(
+      'gh',
+      [
+        'api',
+        `${hooksPath}/${existing.id}`,
+        '--method',
+        'PATCH',
+        ...this.buildMutationArgs(config),
+      ],
+      { cwd }
+    );
+    return {
+      action: 'updated',
+      hookId: existing.id,
+      callbackUrl: config.callbackUrl,
+    };
+  }
+
+  private async listHooks(cwd: string, hooksPath: string): Promise<GitHubRepoHook[]> {
+    const result = await this.execFile('gh', ['api', hooksPath], { cwd });
+    return (JSON.parse(result.stdout) as GitHubRepoHook[]) ?? [];
+  }
+
+  private buildMutationArgs(config: GitHubWebhookConfig): string[] {
+    const args = [
+      '-f',
+      'name=web',
+      '-f',
+      'active=true',
+      '-f',
+      `config[url]=${config.callbackUrl}`,
+      '-f',
+      'config[content_type]=json',
+      '-f',
+      `config[secret]=${config.secret}`,
+      '-f',
+      'config[insecure_ssl]=0',
+    ];
+
+    for (const event of config.events) {
+      args.push('-f', `events[]=${event}`);
+    }
+
+    return args;
+  }
+
+  private isHookUpToDate(hook: GitHubRepoHook, config: GitHubWebhookConfig): boolean {
+    const actualEvents = [...(hook.events ?? [])].sort();
+    const desiredEvents = [...config.events].sort();
+
+    return (
+      hook.active === true &&
+      hook.config?.url === config.callbackUrl &&
+      hook.config?.content_type === 'json' &&
+      actualEvents.length === desiredEvents.length &&
+      actualEvents.every((event, index) => event === desiredEvents[index])
+    );
+  }
+
+  private parseHookPayload(stdout: string): GitHubRepoHook | null {
+    if (!stdout.trim()) return null;
+    return JSON.parse(stdout) as GitHubRepoHook;
+  }
+}
+
+export { SHEP_WEBHOOK_MARKER };

--- a/packages/core/src/infrastructure/services/webhooks/webhook-secret.service.ts
+++ b/packages/core/src/infrastructure/services/webhooks/webhook-secret.service.ts
@@ -1,0 +1,23 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { getShepHomeDir } from '../filesystem/shep-directory.service';
+
+const WEBHOOK_SECRET_DIR = 'webhooks';
+const GITHUB_SECRET_FILE = 'github.secret';
+
+export function getGitHubWebhookSecretPath(): string {
+  return join(getShepHomeDir(), WEBHOOK_SECRET_DIR, GITHUB_SECRET_FILE);
+}
+
+export function getOrCreateGitHubWebhookSecret(): string {
+  const secretPath = getGitHubWebhookSecretPath();
+  if (existsSync(secretPath)) {
+    return readFileSync(secretPath, 'utf8').trim();
+  }
+
+  mkdirSync(join(getShepHomeDir(), WEBHOOK_SECRET_DIR), { recursive: true });
+  const secret = randomBytes(32).toString('hex');
+  writeFileSync(secretPath, `${secret}\n`, { mode: 0o600 });
+  return secret;
+}

--- a/specs/066-github-webhook-tunnel/feature.yaml
+++ b/specs/066-github-webhook-tunnel/feature.yaml
@@ -1,0 +1,36 @@
+feature:
+  id: '066-github-webhook-tunnel'
+  name: 'github-webhook-tunnel'
+  number: 66
+  branch: 'feat/066-github-webhook-tunnel'
+  lifecycle: 'research'
+  createdAt: '2026-03-15T00:00:00Z'
+
+status:
+  phase: 'research'
+  progress:
+    completed: 0
+    total: 6
+    percentage: 0
+  currentTask: null
+  lastUpdated: '2026-03-15T00:00:00Z'
+  lastUpdatedBy: 'codex'
+
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+
+tasks:
+  current: null
+  blocked: []
+  failed: []
+
+checkpoints:
+  - phase: 'feature-created'
+    completedAt: '2026-03-15T00:00:00Z'
+    completedBy: 'codex'
+
+errors:
+  current: null
+  history: []

--- a/specs/066-github-webhook-tunnel/plan.yaml
+++ b/specs/066-github-webhook-tunnel/plan.yaml
@@ -1,0 +1,106 @@
+name: github-webhook-tunnel
+summary: >
+  Implementation plan for opt-in GitHub webhook support with a webhook-only Cloudflare tunnel.
+  The work is split into four phases: (1) spec and contract updates, (2) GitHub service and PR
+  watcher extensions, (3) webhook runtime and route implementation, and (4) startup wiring and
+  verification. All feature behavior follows RED-GREEN-REFACTOR cycles.
+relatedFeatures:
+  - 039-github-pr-sync
+  - 064-pr-sync-rate-limit
+technologies:
+  - GitHub CLI (gh api)
+  - cloudflared
+  - Node.js http server
+  - Next.js route handlers
+relatedLinks: []
+phases:
+  - id: phase-1
+    name: Spec and contracts
+    description: >
+      Create the feature spec artifacts, then extend the GitHub service and PR sync watcher
+      contracts needed for webhook reconciliation and targeted refresh.
+    parallel: false
+  - id: phase-2
+    name: GitHub service and watcher behavior
+    description: >
+      Add repo webhook reconciliation to GitPrService and add a public targeted-refresh entry point
+      to PrSyncWatcherService that reuses the existing repository processing path.
+    parallel: false
+  - id: phase-3
+    name: Webhook runtime and route
+    description: >
+      Build the local gateway, Cloudflare quick tunnel manager, persistent secret handling, and the
+      GitHub route handler with signature verification.
+    parallel: false
+  - id: phase-4
+    name: Startup wiring and hardening
+    description: >
+      Wire the webhook runtime into foreground and daemon startup flows, keep shutdown clean, and
+      run targeted tests.
+    parallel: false
+filesToCreate:
+  - packages/core/src/infrastructure/services/webhooks/github-webhook-runtime.service.ts
+  - packages/core/src/infrastructure/services/webhooks/webhook-secret.service.ts
+  - src/presentation/web/app/api/webhooks/github/route.ts
+  - tests/unit/infrastructure/services/webhooks/github-webhook-runtime.service.test.ts
+  - tests/unit/presentation/web/api/github-webhook.test.ts
+filesToModify:
+  - packages/core/src/application/ports/output/services/git-pr-service.interface.ts
+  - packages/core/src/infrastructure/services/git/git-pr.service.ts
+  - packages/core/src/infrastructure/services/pr-sync/pr-sync-watcher.service.ts
+  - src/presentation/cli/commands/_serve.command.ts
+  - src/presentation/cli/commands/ui.command.ts
+  - src/presentation/web/dev-server.ts
+openQuestions: []
+content: |
+  ## TDD Strategy
+
+  Each phase follows RED → GREEN → REFACTOR.
+
+  ### Phase 1
+
+  RED:
+  - Add tests that fail because webhook reconciliation and targeted watcher refresh APIs do not exist.
+
+  GREEN:
+  - Add the new GitHub service interface types and watcher method signatures.
+
+  REFACTOR:
+  - Keep naming aligned with the existing PR sync terminology.
+
+  ### Phase 2
+
+  RED:
+  - Add unit tests for repo webhook reconciliation behavior in `GitPrService`.
+  - Add unit tests for webhook-triggered repository refresh in `PrSyncWatcherService`.
+
+  GREEN:
+  - Implement webhook list/create/update behavior through `gh api`.
+  - Implement `syncRepositoryByGitHubFullName()` on the watcher by reusing its existing
+    repository processing flow.
+
+  REFACTOR:
+  - Extract helper functions for GitHub remote parsing and hook comparison if needed.
+
+  ### Phase 3
+
+  RED:
+  - Add unit tests for gateway path restriction, tunnel URL parsing, secret persistence, and
+    webhook signature validation.
+
+  GREEN:
+  - Implement the runtime service and the GitHub route.
+
+  REFACTOR:
+  - Keep failure handling centralized and best-effort.
+
+  ### Phase 4
+
+  RED:
+  - Add startup tests for opt-in runtime activation.
+
+  GREEN:
+  - Start and stop the runtime from the daemon/foreground flows.
+
+  REFACTOR:
+  - Ensure shutdown order stays predictable: runtime stop, watchers stop, web server stop.

--- a/specs/066-github-webhook-tunnel/research.yaml
+++ b/specs/066-github-webhook-tunnel/research.yaml
@@ -1,0 +1,98 @@
+name: github-webhook-tunnel
+summary: >
+  Technical research for adding GitHub webhooks to the existing PR sync poller using a webhook-only
+  local gateway plus a Cloudflare quick tunnel. The chosen design keeps the PR poller as fallback,
+  validates GitHub signatures with a persistent local secret, and uses repo webhook reconciliation to
+  handle ephemeral tunnel URLs.
+relatedFeatures:
+  - 039-github-pr-sync
+  - 064-pr-sync-rate-limit
+technologies:
+  - GitHub CLI (gh api)
+  - cloudflared quick tunnels
+  - Node.js http server and proxying
+  - Next.js route handlers
+  - HMAC SHA-256
+relatedLinks: []
+decisions:
+  - title: Webhook ingress boundary
+    chosen: Dedicated local webhook gateway server in front of the app
+    rejected:
+      - >
+        Expose the main Next.js server directly through the tunnel and depend on tunnel path routing.
+        This is simpler on paper, but it weakens the guarantee that only webhook endpoints are public.
+    rationale: >
+      A dedicated local gateway gives a hard boundary: only `/api/webhooks/*` is forwarded and all
+      other paths return 404. This directly satisfies the user request to avoid exposing the whole app.
+  - title: Tunnel URL volatility handling
+    chosen: Reconcile GitHub repo webhooks against the current tunnel URL on startup and on a periodic interval
+    rejected:
+      - >
+        Persist the last URL locally and skip remote inspection. This misses out-of-band edits and
+        does not help if GitHub webhook state drifts.
+    rationale: >
+      Quick tunnel URLs are ephemeral. The source of truth is GitHub's current webhook configuration,
+      so the implementation should inspect and update remote hooks instead of trusting local state.
+  - title: Event processing model
+    chosen: Treat webhook events as a targeted refresh signal for the existing PR sync watcher
+    rejected:
+      - >
+        Fully map webhook payloads to direct feature database updates. Faster in theory, but it
+        duplicates PR sync logic and creates two sources of truth for status transitions.
+    rationale: >
+      The existing watcher already knows how to resolve PR status, CI status, mergeability, lifecycle
+      transitions, agent run completion, deduplication, and notifications. Webhooks should wake it up,
+      not replace its logic.
+  - title: Secret management
+    chosen: Generate or reuse a persistent secret file under SHEP_HOME
+    rejected:
+      - >
+        Generate a new in-memory secret every run. That would require updating every webhook on every
+        startup and break delivery for any event arriving before reconciliation finishes.
+      - >
+        Require the user to provide a secret env var manually. Secure, but too much friction for the
+        first implementation.
+    rationale: >
+      A persistent local secret gives stable signature verification semantics and keeps setup automatic
+      once the feature is enabled.
+  - title: Enablement model
+    chosen: Opt-in via environment variable
+    rejected:
+      - >
+        Always-on startup whenever cloudflared exists. Public ingress should not happen implicitly.
+    rationale: >
+      This feature creates an internet-reachable endpoint. Opt-in is the safest default and does not
+      disrupt existing local UI usage.
+openQuestions: []
+content: |
+  ## Architecture Notes
+
+  The implementation layers cleanly on top of the existing PR sync architecture:
+
+  1. `PrSyncWatcherService` remains the authority for PR/CI reconciliation.
+  2. A new webhook route verifies GitHub signatures and extracts `repository.full_name`.
+  3. The route asks the watcher to perform an immediate refresh for the matching repository.
+  4. A new runtime service starts:
+     - a localhost-only webhook gateway
+     - a `cloudflared` quick tunnel to that gateway
+     - periodic GitHub webhook reconciliation for repositories currently in Review
+
+  ## GitHub webhook identification
+
+  Because quick tunnel URLs change, the code needs a deterministic way to find the Shep-managed
+  webhook in GitHub. The simplest robust marker is the callback URL itself:
+
+  - register `.../api/webhooks/github?source=shep`
+  - when listing repo webhooks, match hooks whose URL contains `source=shep`
+
+  This avoids storing GitHub hook IDs locally and still lets us patch the existing hook whenever
+  the public base URL changes.
+
+  ## Failure handling
+
+  Webhook runtime failures must never block the web UI:
+
+  - `cloudflared` missing: log warning, leave polling active
+  - `gh api` failure: log warning, retry on next reconcile interval
+  - invalid webhook signature: return 401, do not trigger sync
+  - watcher unavailable: return 202/503-safe behavior from the route without crashing the app

--- a/specs/066-github-webhook-tunnel/spec.yaml
+++ b/specs/066-github-webhook-tunnel/spec.yaml
@@ -1,0 +1,128 @@
+name: github-webhook-tunnel
+number: 66
+branch: feat/066-github-webhook-tunnel
+oneLiner: Add GitHub webhook acceleration for PR sync using a webhook-only Cloudflare tunnel alongside polling
+userQuery: >
+  I want to add support to webhooks together with polling but because we are running locally
+  we should use something like Cloudflare Tunnel client some nuance each time we would run
+  the cloudflare we can get different url, so we need to update the webhook if the url changes
+  also lets no expose the whole app but just the webhook endpoints
+summary: >
+  Extend the existing GitHub PR sync polling flow with opt-in webhook delivery. When enabled,
+  Shep starts a local webhook-only gateway, opens a Cloudflare quick tunnel to that gateway,
+  ensures repository webhooks point at the current public URL, and keeps polling as a fallback.
+  Incoming GitHub webhook events trigger an immediate targeted PR sync refresh for the matching
+  repository instead of waiting for the next poll interval.
+phase: Requirements
+sizeEstimate: M
+relatedFeatures:
+  - 039-github-pr-sync
+  - 064-pr-sync-rate-limit
+technologies:
+  - GitHub CLI (gh api) - repository webhook create/update
+  - Cloudflare Tunnel client (cloudflared) - public quick tunnel for localhost
+  - Node.js http/https - webhook gateway proxy and route handling
+  - HMAC SHA-256 - GitHub webhook signature verification
+  - Next.js Route Handlers - webhook ingress endpoint
+relatedLinks: []
+openQuestions:
+  - question: How should webhook exposure be enabled safely?
+    resolved: true
+    options:
+      - option: Opt-in via environment flag
+        description: >
+          Only start the tunnel and register repo webhooks when an explicit environment flag is set.
+          This avoids surprising users by exposing a public endpoint automatically.
+        selected: true
+      - option: Always enable when cloudflared exists
+        description: >
+          Automatically expose a public endpoint whenever the UI starts. Simpler UX, but risky and
+          surprising because it publishes a network entry point without explicit consent.
+        selected: false
+    selectionRationale: >
+      Public webhook exposure has non-obvious security and privacy consequences. An opt-in environment
+      flag keeps the initial implementation safe while still providing a complete working path.
+    answer: Opt-in via environment flag
+  - question: How should we avoid exposing the whole local app through the tunnel?
+    resolved: true
+    options:
+      - option: Tunnel the main Next.js server directly and rely on path-based routing
+        description: >
+          Simpler setup, but risks exposing the whole app if the tunnel configuration is wrong or
+          path filtering changes.
+        selected: false
+      - option: Start a dedicated local webhook gateway and tunnel only that gateway
+        description: >
+          The gateway only forwards /api/webhooks/* requests to the local app and returns 404 for
+          everything else, guaranteeing that the public tunnel cannot reach the rest of the UI.
+        selected: true
+    selectionRationale: >
+      A dedicated gateway gives us the strongest local boundary with minimal complexity and does not
+      depend on Cloudflare path-routing behavior.
+    answer: Start a dedicated local webhook gateway and tunnel only that gateway
+  - question: How should webhook events integrate with the existing poller?
+    resolved: true
+    options:
+      - option: Replace polling entirely
+        description: >
+          Lower steady-state API usage, but webhook delivery is not guaranteed and local tunnels can
+          disappear. Losing polling would make the system brittle.
+        selected: false
+      - option: Keep polling and use webhooks to trigger immediate repository refreshes
+        description: >
+          Webhooks reduce latency when available, while the existing poller remains the safety net
+          for missed events, tunnel downtime, and startup/bootstrap states.
+        selected: true
+    selectionRationale: >
+      The user explicitly asked for webhooks together with polling. Keeping the poller preserves the
+      reliability characteristics of the existing feature.
+    answer: Keep polling and use webhooks to trigger immediate repository refreshes
+content: |
+  ## Problem Statement
+
+  The current GitHub PR sync flow is polling-only. That works, but it introduces avoidable delay
+  between a GitHub change and Shep reflecting that change locally. Because Shep runs on localhost,
+  GitHub cannot send webhooks directly to the machine without a public ingress point.
+
+  We want to add webhook support without removing polling:
+
+  - use a local tunnel client such as `cloudflared`
+  - accept that the public URL may change every run
+  - update GitHub webhook configuration whenever the public URL changes
+  - expose only webhook endpoints, never the entire local web app
+
+  ## Success Criteria
+
+  - [ ] GitHub webhook support is available alongside the existing PR sync poller
+  - [ ] Webhook mode is opt-in and does not change default startup behavior
+  - [ ] When enabled, Shep starts a local webhook-only gateway and a Cloudflare quick tunnel
+  - [ ] The public tunnel only forwards `/api/webhooks/*` requests to the local app
+  - [ ] A stable local secret is generated/reused for GitHub webhook signature verification
+  - [ ] Repository webhooks are created or updated to the current tunnel URL when it changes
+  - [ ] Incoming GitHub webhook events trigger an immediate targeted PR sync for the matching repo
+  - [ ] Polling remains active as a fallback and source of eventual consistency
+  - [ ] Startup degrades gracefully if `cloudflared` or GitHub webhook setup fails
+  - [ ] Unit tests cover tunnel URL parsing, gateway path restriction, webhook signature validation,
+    webhook registration update logic, and webhook-triggered PR sync refresh
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `packages/core/src/infrastructure/services/git/` | High | Extend GitHub service with repo webhook create/update support |
+  | `packages/core/src/infrastructure/services/pr-sync/` | High | Add webhook-triggered targeted refresh entry point |
+  | `packages/core/src/infrastructure/services/webhooks/` | High | New tunnel runtime and gateway services |
+  | `src/presentation/web/app/api/webhooks/` | High | New verified GitHub webhook ingress route |
+  | `src/presentation/cli/commands/` | Medium | Start/stop webhook runtime alongside web server lifecycle |
+
+  ## Dependencies
+
+  - Existing PR sync watcher from `039-github-pr-sync`
+  - `cloudflared` available on PATH when webhook mode is enabled
+  - `gh` authenticated for repository webhook create/update
+
+  ## Non-Goals
+
+  - A UI for configuring webhook mode in this iteration
+  - Replacing polling entirely
+  - Supporting non-GitHub webhook providers in this iteration

--- a/specs/066-github-webhook-tunnel/tasks.yaml
+++ b/specs/066-github-webhook-tunnel/tasks.yaml
@@ -1,0 +1,147 @@
+name: github-webhook-tunnel
+summary: >
+  Task breakdown for GitHub webhook acceleration over PR sync polling. The work covers service
+  contracts, GitHub webhook reconciliation, webhook-triggered watcher refresh, local tunnel runtime,
+  verified route handling, and startup wiring.
+relatedFeatures:
+  - 039-github-pr-sync
+  - 064-pr-sync-rate-limit
+technologies:
+  - GitHub CLI (gh api)
+  - cloudflared
+  - Node.js http
+  - Next.js route handlers
+relatedLinks: []
+tasks:
+  - id: task-1
+    phaseId: phase-1
+    title: Add GitHub webhook reconciliation types to the git PR service contract
+    description: >
+      Extend the git PR service interface with typed repo webhook reconcile inputs/results so the
+      implementation and tests can work against a stable contract.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - IGitPrService exposes a typed method for ensuring a Shep-managed GitHub webhook
+      - TypeScript typecheck passes after the contract update
+    tdd:
+      red:
+        - Add failing type-level/unit tests referencing the new contract
+      green:
+        - Add the new interface types and method signature
+      refactor:
+        - Keep naming aligned with existing GitHub service conventions
+    estimatedEffort: 20min
+
+  - id: task-2
+    phaseId: phase-2
+    title: Implement repository webhook create/update logic in GitPrService
+    description: >
+      Use `gh api` to list repo webhooks, identify the Shep-managed one via the callback marker,
+      and create or patch it when the URL or events differ.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - Existing Shep webhook is updated when the tunnel URL changes
+      - Missing Shep webhook is created
+      - Matching webhook configuration returns unchanged
+      - Non-GitHub remotes are skipped safely
+    tdd:
+      red:
+        - Add unit tests for create, update, unchanged, and skip paths
+      green:
+        - Implement the `gh api` calls and hook comparison logic
+      refactor:
+        - Extract helper(s) for comparison and remote parsing if helpful
+    estimatedEffort: 1h
+
+  - id: task-3
+    phaseId: phase-2
+    title: Add webhook-triggered targeted refresh to PrSyncWatcherService
+    description: >
+      Expose a watcher method that accepts a GitHub `owner/repo` name and immediately refreshes
+      the matching local repository using the existing PR sync processing path.
+    state: Todo
+    dependencies:
+      - task-2
+    acceptanceCriteria:
+      - Webhook route can trigger an immediate repository refresh without waiting for the poll interval
+      - The watcher reuses existing processing logic instead of duplicating transition handling
+    tdd:
+      red:
+        - Add failing watcher tests for matching and non-matching GitHub repositories
+      green:
+        - Implement the public targeted refresh method
+      refactor:
+        - Keep repository matching logic small and isolated
+    estimatedEffort: 45min
+
+  - id: task-4
+    phaseId: phase-3
+    title: Build the webhook runtime service
+    description: >
+      Implement persistent secret management, a local webhook-only gateway, cloudflared quick
+      tunnel startup, public URL parsing, and periodic repo webhook reconciliation.
+    state: Todo
+    dependencies:
+      - task-2
+    acceptanceCriteria:
+      - Runtime starts only when the opt-in env flag is enabled
+      - Gateway forwards only `/api/webhooks/*` and rejects other paths
+      - Tunnel output parsing extracts the public URL
+      - Repo webhook reconciliation runs on startup and interval
+    tdd:
+      red:
+        - Add failing tests for secret persistence, gateway restriction, tunnel URL parsing, and reconcile scheduling
+      green:
+        - Implement the runtime service
+      refactor:
+        - Keep cleanup/shutdown idempotent
+    estimatedEffort: 2h
+
+  - id: task-5
+    phaseId: phase-3
+    title: Add the verified GitHub webhook route
+    description: >
+      Create `/api/webhooks/github` that validates the GitHub HMAC signature, parses the repository
+      name from the payload, and triggers the targeted watcher refresh.
+    state: Todo
+    dependencies:
+      - task-3
+      - task-4
+    acceptanceCriteria:
+      - Invalid signatures return 401
+      - Valid webhook payloads trigger watcher refresh for the matching repo
+      - Route is force-dynamic and handles malformed payloads safely
+    tdd:
+      red:
+        - Add failing route tests for invalid signature, valid signature, and malformed payload
+      green:
+        - Implement the route handler
+      refactor:
+        - Extract signature verification helper if it improves clarity
+    estimatedEffort: 1h
+
+  - id: task-6
+    phaseId: phase-4
+    title: Wire webhook runtime into daemon and foreground startup
+    description: >
+      Start and stop the runtime from `_serve`, `ui`, and the web dev server so the feature works in
+      both real-user and development flows.
+    state: Todo
+    dependencies:
+      - task-4
+      - task-5
+    acceptanceCriteria:
+      - Runtime starts after the web server is ready
+      - Runtime stops cleanly on shutdown
+      - Existing startup paths still work when webhook mode is disabled
+    tdd:
+      red:
+        - Add failing startup tests for opt-in runtime activation
+      green:
+        - Wire runtime start/stop into the startup commands
+      refactor:
+        - Keep shutdown sequencing consistent across entry points
+    estimatedEffort: 45min

--- a/src/presentation/cli/commands/_serve.command.ts
+++ b/src/presentation/cli/commands/_serve.command.ts
@@ -33,6 +33,16 @@ import {
   initializeNotificationWatcher,
   getNotificationWatcher,
 } from '@/infrastructure/services/notifications/notification-watcher.service.js';
+import {
+  initializePrSyncWatcher,
+  getPrSyncWatcher,
+} from '@/infrastructure/services/pr-sync/pr-sync-watcher.service.js';
+import { getExistingConnection } from '@/infrastructure/persistence/sqlite/connection.js';
+import {
+  GitHubWebhookRuntimeService,
+  isGitHubWebhookRuntimeEnabled,
+} from '@/infrastructure/services/webhooks/github-webhook-runtime.service.js';
+import { GitHubWebhookService } from '@/infrastructure/services/webhooks/github-webhook.service.js';
 import type { IVersionService } from '@/application/ports/output/services/version-service.interface.js';
 import type { IWebServerService } from '@/application/ports/output/services/web-server-service.interface.js';
 import type { IAgentRunRepository } from '@/application/ports/output/agents/agent-run-repository.interface.js';
@@ -40,6 +50,8 @@ import type { IPhaseTimingRepository } from '@/application/ports/output/agents/p
 import type { INotificationService } from '@/application/ports/output/services/notification-service.interface.js';
 import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
 import type { IDeploymentService } from '@/application/ports/output/services/deployment-service.interface.js';
+import type { IGitPrService } from '@/application/ports/output/services/git-pr-service.interface.js';
+import type { ExecFunction } from '@shepai/core/infrastructure/services/git/worktree.service';
 
 function parsePort(value: string): number {
   const port = parseInt(value, 10);
@@ -79,6 +91,31 @@ export function createServeCommand(): Command {
         initializeNotificationWatcher(runRepo, phaseTimingRepo, featureRepo, notificationService);
         getNotificationWatcher().start();
 
+        const gitPrService = container.resolve<IGitPrService>('IGitPrService');
+        const db = getExistingConnection();
+        initializePrSyncWatcher(
+          featureRepo,
+          runRepo,
+          gitPrService,
+          notificationService,
+          undefined,
+          db
+        );
+        getPrSyncWatcher().start();
+
+        let webhookRuntime: GitHubWebhookRuntimeService | null = null;
+        if (isGitHubWebhookRuntimeEnabled()) {
+          try {
+            const execFile = container.resolve<ExecFunction>('ExecFunction');
+            const webhookService = new GitHubWebhookService(execFile, gitPrService);
+            webhookRuntime = new GitHubWebhookRuntimeService(featureRepo, webhookService, port);
+            await webhookRuntime.start();
+          } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            process.stderr.write(`[_serve] GitHub webhook runtime disabled: ${err.message}\n`);
+          }
+        }
+
         // Graceful shutdown handler — identical pattern to ui.command.ts
         let isShuttingDown = false;
         const shutdown = async () => {
@@ -89,6 +126,8 @@ export function createServeCommand(): Command {
           const forceExit = setTimeout(() => process.exit(0), 5000);
           forceExit.unref();
 
+          await webhookRuntime?.stop();
+          getPrSyncWatcher().stop();
           getNotificationWatcher().stop();
           const deploymentService = container.resolve<IDeploymentService>('IDeploymentService');
           deploymentService.stopAll();

--- a/src/presentation/cli/commands/ui.command.ts
+++ b/src/presentation/cli/commands/ui.command.ts
@@ -37,6 +37,12 @@ import {
 } from '@/infrastructure/services/pr-sync/pr-sync-watcher.service.js';
 import { getExistingConnection } from '@/infrastructure/persistence/sqlite/connection.js';
 import { BrowserOpenerService } from '@/infrastructure/services/browser-opener.service.js';
+import {
+  GitHubWebhookRuntimeService,
+  isGitHubWebhookRuntimeEnabled,
+} from '@/infrastructure/services/webhooks/github-webhook-runtime.service.js';
+import { GitHubWebhookService } from '@/infrastructure/services/webhooks/github-webhook.service.js';
+import type { ExecFunction } from '@shepai/core/infrastructure/services/git/worktree.service';
 import { colors, fmt, messages } from '../ui/index.js';
 
 function parsePort(value: string): number {
@@ -102,6 +108,19 @@ Examples:
         );
         getPrSyncWatcher().start();
 
+        let webhookRuntime: GitHubWebhookRuntimeService | null = null;
+        if (isGitHubWebhookRuntimeEnabled()) {
+          try {
+            const execFile = container.resolve<ExecFunction>('ExecFunction');
+            const webhookService = new GitHubWebhookService(execFile, gitPrService);
+            webhookRuntime = new GitHubWebhookRuntimeService(featureRepo, webhookService, port);
+            await webhookRuntime.start();
+          } catch (error) {
+            const err = error instanceof Error ? error : new Error(String(error));
+            messages.warning(`GitHub webhook runtime disabled: ${err.message}`);
+          }
+        }
+
         const url = `http://localhost:${port}`;
         messages.success(`Server ready at ${fmt.code(url)}`);
         messages.info('Press Ctrl+C to stop');
@@ -126,6 +145,7 @@ Examples:
           const forceExit = setTimeout(() => process.exit(0), 5000);
           forceExit.unref();
 
+          await webhookRuntime?.stop();
           getPrSyncWatcher().stop();
           getNotificationWatcher().stop();
           await service.stop();

--- a/src/presentation/web/app/api/webhooks/github/route.ts
+++ b/src/presentation/web/app/api/webhooks/github/route.ts
@@ -1,0 +1,52 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  getPrSyncWatcher,
+  hasPrSyncWatcher,
+} from '@shepai/core/infrastructure/services/pr-sync/pr-sync-watcher.service';
+import { getOrCreateGitHubWebhookSecret } from '@shepai/core/infrastructure/services/webhooks/webhook-secret.service';
+
+export const dynamic = 'force-dynamic';
+
+function isValidSignature(
+  rawBody: string,
+  signatureHeader: string | null,
+  secret: string
+): boolean {
+  if (!signatureHeader?.startsWith('sha256=')) return false;
+
+  const digest = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const expected = Buffer.from(`sha256=${digest}`);
+  const received = Buffer.from(signatureHeader);
+
+  if (expected.length !== received.length) return false;
+  return timingSafeEqual(expected, received);
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const rawBody = await request.text();
+  const secret = getOrCreateGitHubWebhookSecret();
+  const signature = request.headers.get('x-hub-signature-256');
+
+  if (!isValidSignature(rawBody, signature, secret)) {
+    return Response.json({ error: 'Invalid GitHub webhook signature' }, { status: 401 });
+  }
+
+  let payload: { repository?: { full_name?: string } };
+  try {
+    payload = JSON.parse(rawBody) as { repository?: { full_name?: string } };
+  } catch {
+    return Response.json({ error: 'Invalid JSON payload' }, { status: 400 });
+  }
+
+  const fullName = payload.repository?.full_name;
+  if (!fullName) {
+    return Response.json({ error: 'Missing repository.full_name' }, { status: 400 });
+  }
+
+  if (!hasPrSyncWatcher()) {
+    return Response.json({ accepted: true, refreshed: false }, { status: 202 });
+  }
+
+  const refreshed = await getPrSyncWatcher().syncRepositoryByGitHubFullName(fullName);
+  return Response.json({ accepted: true, refreshed }, { status: 202 });
+}

--- a/src/presentation/web/dev-server.ts
+++ b/src/presentation/web/dev-server.ts
@@ -34,6 +34,12 @@ import {
   getPrSyncWatcher,
 } from '@/infrastructure/services/pr-sync/pr-sync-watcher.service.js';
 import { getExistingConnection } from '@/infrastructure/persistence/sqlite/connection.js';
+import {
+  GitHubWebhookRuntimeService,
+  isGitHubWebhookRuntimeEnabled,
+} from '@/infrastructure/services/webhooks/github-webhook-runtime.service.js';
+import { GitHubWebhookService } from '@/infrastructure/services/webhooks/github-webhook.service.js';
+import type { ExecFunction } from '@shepai/core/infrastructure/services/git/worktree.service';
 
 const DEFAULT_PORT = 3000;
 
@@ -90,6 +96,20 @@ async function main() {
     const db = getExistingConnection();
     initializePrSyncWatcher(featureRepo, runRepo, gitPrService, notificationService, undefined, db);
     getPrSyncWatcher().start();
+
+    let webhookRuntime: GitHubWebhookRuntimeService | null = null;
+    if (isGitHubWebhookRuntimeEnabled()) {
+      try {
+        const execFile = container.resolve<ExecFunction>('ExecFunction');
+        const webhookService = new GitHubWebhookService(execFile, gitPrService);
+        webhookRuntime = new GitHubWebhookRuntimeService(featureRepo, webhookService, port);
+        await webhookRuntime.start();
+      } catch (error) {
+        console.warn('[dev-server] GitHub webhook runtime disabled:', error);
+      }
+    }
+
+    (globalThis as Record<string, unknown>).__shepGithubWebhookRuntime = webhookRuntime;
   } catch (error) {
     console.warn('[dev-server] DI initialization failed — features will be empty:', error);
   }
@@ -132,6 +152,13 @@ async function main() {
     console.log('\n[dev-server] Shutting down...');
     const forceExit = setTimeout(() => process.exit(0), 2000);
     try {
+      try {
+        const webhookRuntime = (globalThis as Record<string, unknown>)
+          .__shepGithubWebhookRuntime as GitHubWebhookRuntimeService | undefined;
+        await webhookRuntime?.stop();
+      } catch {
+        /* runtime not initialized */
+      }
       try {
         getNotificationWatcher().stop();
       } catch {

--- a/tests/unit/commands/_serve.command.test.ts
+++ b/tests/unit/commands/_serve.command.test.ts
@@ -37,7 +37,8 @@ vi.mock('@/infrastructure/di/container.js', () => ({
         token === 'IAgentRunRepository' ||
         token === 'IPhaseTimingRepository' ||
         token === 'IFeatureRepository' ||
-        token === 'INotificationService'
+        token === 'INotificationService' ||
+        token === 'IGitPrService'
       ) {
         return {};
       }
@@ -63,6 +64,18 @@ vi.mock('@/infrastructure/services/notifications/notification-watcher.service.js
     start: vi.fn(),
     stop: vi.fn(),
   }),
+}));
+
+vi.mock('@/infrastructure/services/pr-sync/pr-sync-watcher.service.js', () => ({
+  initializePrSyncWatcher: vi.fn(),
+  getPrSyncWatcher: vi.fn().mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+vi.mock('@/infrastructure/persistence/sqlite/connection.js', () => ({
+  getExistingConnection: vi.fn().mockReturnValue(null),
 }));
 
 const mockWebServerService = {

--- a/tests/unit/infrastructure/services/pr-sync/pr-sync-watcher.service.test.ts
+++ b/tests/unit/infrastructure/services/pr-sync/pr-sync-watcher.service.test.ts
@@ -1437,4 +1437,29 @@ describe('PrSyncWatcherService', () => {
       expect(hasPrSyncWatcher()).toBe(false);
     });
   });
+
+  describe('webhook-triggered refresh', () => {
+    it('refreshes the matching GitHub repository immediately', async () => {
+      const feature = createMockFeature();
+      vi.mocked(featureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(gitPrService.getRemoteUrl).mockResolvedValue('https://github.com/org/repo');
+      vi.mocked(gitPrService.listPrStatuses).mockResolvedValue([]);
+
+      const refreshed = await watcher.syncRepositoryByGitHubFullName('org/repo');
+
+      expect(refreshed).toBe(true);
+      expect(gitPrService.listPrStatuses).toHaveBeenCalledWith('/repo/path');
+    });
+
+    it('returns false when no tracked repository matches the webhook repo name', async () => {
+      const feature = createMockFeature();
+      vi.mocked(featureRepo.list).mockResolvedValue([feature]);
+      vi.mocked(gitPrService.getRemoteUrl).mockResolvedValue('https://github.com/other/repo');
+
+      const refreshed = await watcher.syncRepositoryByGitHubFullName('org/repo');
+
+      expect(refreshed).toBe(false);
+      expect(gitPrService.listPrStatuses).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/unit/infrastructure/services/webhooks/github-webhook-runtime.service.test.ts
+++ b/tests/unit/infrastructure/services/webhooks/github-webhook-runtime.service.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { GitHubWebhookRuntimeService } from '@/infrastructure/services/webhooks/github-webhook-runtime.service.js';
+import { SdlcLifecycle } from '@/domain/generated/output.js';
+
+type GatewayHandler = (
+  req: PassThrough & { url?: string; method?: string; headers: Record<string, string> },
+  res: any
+) => void;
+
+function createFeature(repositoryPath: string) {
+  return {
+    id: `feat-${repositoryPath}`,
+    name: 'Feature',
+    userQuery: 'query',
+    slug: 'feature',
+    description: 'desc',
+    repositoryPath,
+    branch: 'feat/test',
+    lifecycle: SdlcLifecycle.Review,
+    messages: [],
+    relatedArtifacts: [],
+    fast: false,
+    push: true,
+    openPr: true,
+    approvalGates: { allowPrd: false, allowPlan: false, allowMerge: false },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+function createTunnelProcess(url: string) {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const handlers = new Map<string, (...args: unknown[]) => void>();
+
+  const proc = {
+    stdout,
+    stderr,
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.set(event, handler);
+      return proc;
+    }),
+    off: vi.fn((event: string) => {
+      handlers.delete(event);
+      return proc;
+    }),
+    kill: vi.fn(() => {
+      const handler = handlers.get('exit');
+      handler?.(0);
+      return true;
+    }),
+  };
+
+  setTimeout(() => {
+    stderr.write(`INF Quick Tunnel ready: ${url}\n`);
+  }, 0);
+
+  return proc;
+}
+
+describe('GitHubWebhookRuntimeService', () => {
+  const originalEnv = process.env.SHEP_ENABLE_GITHUB_WEBHOOKS;
+
+  beforeEach(() => {
+    delete process.env.SHEP_ENABLE_GITHUB_WEBHOOKS;
+  });
+
+  afterEach(async () => {
+    if (originalEnv === undefined) {
+      delete process.env.SHEP_ENABLE_GITHUB_WEBHOOKS;
+    } else {
+      process.env.SHEP_ENABLE_GITHUB_WEBHOOKS = originalEnv;
+    }
+  });
+
+  it('does nothing when webhook mode is disabled', async () => {
+    const featureRepo = { list: vi.fn() };
+    const webhookService = { ensureRepositoryWebhook: vi.fn() };
+    const runtime = new GitHubWebhookRuntimeService(
+      featureRepo as any,
+      webhookService as any,
+      4050
+    );
+
+    const result = await runtime.start();
+
+    expect(result).toBeNull();
+    expect(featureRepo.list).not.toHaveBeenCalled();
+    expect(runtime.getGatewayPort()).toBeNull();
+  });
+
+  it('forwards only webhook paths through the local gateway', async () => {
+    process.env.SHEP_ENABLE_GITHUB_WEBHOOKS = '1';
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    let gatewayHandler: GatewayHandler | null = null;
+
+    const mockServer = {
+      once: vi.fn(),
+      listen: vi.fn((_port: number, _host: string, cb: () => void) => cb()),
+      close: vi.fn((cb: () => void) => cb()),
+    };
+
+    const runtime = new GitHubWebhookRuntimeService(
+      { list: vi.fn().mockResolvedValue([]) } as any,
+      { ensureRepositoryWebhook: vi.fn() } as any,
+      4050,
+      60_000,
+      {
+        createServer: vi.fn((handler) => {
+          gatewayHandler = handler as any;
+          return mockServer as any;
+        }),
+        findAvailablePort: vi.fn().mockResolvedValue(4591),
+        spawnProcess: vi.fn(() => createTunnelProcess('https://demo.trycloudflare.com')) as any,
+        getSecret: vi.fn().mockReturnValue('secret'),
+        fetchImpl: fetchImpl as any,
+      }
+    );
+
+    await runtime.start();
+    if (!gatewayHandler) {
+      throw new Error('Expected gateway handler to be registered');
+    }
+    const activeGatewayHandler = gatewayHandler as GatewayHandler;
+
+    const blockedReq = new PassThrough() as PassThrough & {
+      url?: string;
+      method?: string;
+      headers: Record<string, string>;
+    };
+    blockedReq.url = '/';
+    blockedReq.method = 'POST';
+    blockedReq.headers = {};
+    blockedReq.end();
+    const blockedRes = {
+      statusCode: 200,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    };
+    await activeGatewayHandler(blockedReq, blockedRes);
+    expect(blockedRes.statusCode).toBe(404);
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    const webhookReq = new PassThrough() as PassThrough & {
+      url?: string;
+      method?: string;
+      headers: Record<string, string>;
+    };
+    webhookReq.url = '/api/webhooks/github';
+    webhookReq.method = 'POST';
+    webhookReq.headers = { 'x-test': '1' };
+    webhookReq.end('payload');
+    const webhookRes = {
+      statusCode: 0,
+      setHeader: vi.fn(),
+      end: vi.fn(),
+    };
+    activeGatewayHandler(webhookReq, webhookRes);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [forwardedUrl, forwardedInit] = fetchImpl.mock.calls[0];
+    expect(forwardedUrl).toBe('http://127.0.0.1:4050/api/webhooks/github');
+    expect(forwardedInit).toMatchObject({
+      method: 'POST',
+      headers: expect.any(Headers),
+    });
+    expect(forwardedInit?.body).toBeInstanceOf(Uint8Array);
+    expect(Buffer.from(forwardedInit.body as Uint8Array)).toEqual(Buffer.from('payload'));
+    expect(webhookRes.statusCode).toBe(200);
+    expect(webhookRes.end).toHaveBeenCalledWith(Buffer.from('ok'));
+
+    await runtime.stop();
+  });
+
+  it('reconciles unique review repositories against the current tunnel URL', async () => {
+    process.env.SHEP_ENABLE_GITHUB_WEBHOOKS = '1';
+
+    const featureRepo = {
+      list: vi
+        .fn()
+        .mockResolvedValue([
+          createFeature('/repo/a'),
+          createFeature('/repo/a'),
+          createFeature('/repo/b'),
+        ]),
+    };
+    const webhookService = {
+      ensureRepositoryWebhook: vi.fn().mockResolvedValue({ action: 'created' }),
+    };
+
+    const runtime = new GitHubWebhookRuntimeService(
+      featureRepo as any,
+      webhookService as any,
+      4050,
+      60_000,
+      {
+        createServer: vi.fn(
+          () =>
+            ({
+              once: vi.fn(),
+              listen: vi.fn((_port: number, _host: string, cb: () => void) => cb()),
+              close: vi.fn((cb: () => void) => cb()),
+            }) as any
+        ),
+        findAvailablePort: vi.fn().mockResolvedValue(4592),
+        spawnProcess: vi.fn(() => createTunnelProcess('https://demo.trycloudflare.com')) as any,
+        getSecret: vi.fn().mockReturnValue('secret'),
+      }
+    );
+
+    const publicUrl = await runtime.start();
+
+    expect(publicUrl).toBe('https://demo.trycloudflare.com');
+    expect(webhookService.ensureRepositoryWebhook).toHaveBeenCalledTimes(2);
+    expect(webhookService.ensureRepositoryWebhook).toHaveBeenCalledWith('/repo/a', {
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+      secret: 'secret',
+      events: ['pull_request', 'check_suite'],
+    });
+    expect(webhookService.ensureRepositoryWebhook).toHaveBeenCalledWith('/repo/b', {
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+      secret: 'secret',
+      events: ['pull_request', 'check_suite'],
+    });
+
+    await runtime.stop();
+  });
+});

--- a/tests/unit/infrastructure/services/webhooks/github-webhook.service.test.ts
+++ b/tests/unit/infrastructure/services/webhooks/github-webhook.service.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitHubWebhookService } from '@/infrastructure/services/webhooks/github-webhook.service.js';
+import type { ExecFunction } from '@/infrastructure/services/git/worktree.service.js';
+import type { IGitPrService } from '@/application/ports/output/services/git-pr-service.interface.js';
+
+describe('GitHubWebhookService', () => {
+  let execFile: ExecFunction;
+  let gitPrService: Pick<IGitPrService, 'getRemoteUrl'>;
+  let service: GitHubWebhookService;
+
+  beforeEach(() => {
+    execFile = vi.fn();
+    gitPrService = {
+      getRemoteUrl: vi.fn(async (_cwd: string) => null),
+    };
+    service = new GitHubWebhookService(execFile, gitPrService);
+  });
+
+  it('skips non-GitHub remotes', async () => {
+    vi.mocked(gitPrService.getRemoteUrl).mockResolvedValue('https://gitlab.com/org/repo');
+
+    const result = await service.ensureRepositoryWebhook('/repo', {
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+      secret: 'secret',
+      events: ['pull_request', 'check_suite'],
+    });
+
+    expect(result).toEqual({ action: 'skipped' });
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('creates a webhook when no Shep-managed hook exists', async () => {
+    vi.mocked(gitPrService.getRemoteUrl).mockResolvedValue('https://github.com/org/repo');
+    vi.mocked(execFile)
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            id: 1,
+            active: true,
+            config: { url: 'https://example.com/other' },
+            events: ['push'],
+          },
+        ]),
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ id: 99 }),
+        stderr: '',
+      });
+
+    const result = await service.ensureRepositoryWebhook('/repo', {
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+      secret: 'secret',
+      events: ['pull_request', 'check_suite'],
+    });
+
+    expect(result).toEqual({
+      action: 'created',
+      hookId: 99,
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+    });
+    expect(execFile).toHaveBeenNthCalledWith(1, 'gh', ['api', 'repos/org/repo/hooks'], {
+      cwd: '/repo',
+    });
+    expect(execFile).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      expect.arrayContaining([
+        'api',
+        'repos/org/repo/hooks',
+        '--method',
+        'POST',
+        '-f',
+        'name=web',
+        '-f',
+        'active=true',
+        '-f',
+        'config[content_type]=json',
+      ]),
+      { cwd: '/repo' }
+    );
+  });
+
+  it('updates the existing Shep hook when the callback URL changes', async () => {
+    vi.mocked(gitPrService.getRemoteUrl).mockResolvedValue('https://github.com/org/repo');
+    vi.mocked(execFile)
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            id: 12,
+            active: true,
+            config: { url: 'https://old.trycloudflare.com/api/webhooks/github?source=shep' },
+            events: ['pull_request'],
+          },
+        ]),
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        stdout: '',
+        stderr: '',
+      });
+
+    const result = await service.ensureRepositoryWebhook('/repo', {
+      callbackUrl: 'https://new.trycloudflare.com/api/webhooks/github?source=shep',
+      secret: 'secret',
+      events: ['pull_request', 'check_suite'],
+    });
+
+    expect(result).toEqual({
+      action: 'updated',
+      hookId: 12,
+      callbackUrl: 'https://new.trycloudflare.com/api/webhooks/github?source=shep',
+    });
+    expect(execFile).toHaveBeenNthCalledWith(
+      2,
+      'gh',
+      expect.arrayContaining(['api', 'repos/org/repo/hooks/12', '--method', 'PATCH']),
+      { cwd: '/repo' }
+    );
+  });
+
+  it('returns unchanged when the Shep hook already matches', async () => {
+    vi.mocked(gitPrService.getRemoteUrl).mockResolvedValue('git@github.com:org/repo.git');
+    vi.mocked(execFile).mockResolvedValueOnce({
+      stdout: JSON.stringify([
+        {
+          id: 12,
+          active: true,
+          config: {
+            url: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+            content_type: 'json',
+          },
+          events: ['check_suite', 'pull_request'],
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await service.ensureRepositoryWebhook('/repo', {
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+      secret: 'secret',
+      events: ['pull_request', 'check_suite'],
+    });
+
+    expect(result).toEqual({
+      action: 'unchanged',
+      hookId: 12,
+      callbackUrl: 'https://demo.trycloudflare.com/api/webhooks/github?source=shep',
+    });
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/infrastructure/services/webhooks/webhook-secret.service.test.ts
+++ b/tests/unit/infrastructure/services/webhooks/webhook-secret.service.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  getGitHubWebhookSecretPath,
+  getOrCreateGitHubWebhookSecret,
+} from '@/infrastructure/services/webhooks/webhook-secret.service.js';
+
+describe('webhook secret service', () => {
+  const originalShepHome = process.env.SHEP_HOME;
+  let shepHome: string;
+
+  beforeEach(() => {
+    shepHome = mkdtempSync(join(tmpdir(), 'shep-webhook-secret-'));
+    process.env.SHEP_HOME = shepHome;
+  });
+
+  afterEach(() => {
+    rmSync(shepHome, { recursive: true, force: true });
+    if (originalShepHome === undefined) {
+      delete process.env.SHEP_HOME;
+    } else {
+      process.env.SHEP_HOME = originalShepHome;
+    }
+  });
+
+  it('creates the GitHub secret inside SHEP_HOME/webhooks', () => {
+    const secret = getOrCreateGitHubWebhookSecret();
+
+    expect(secret).toHaveLength(64);
+    expect(getGitHubWebhookSecretPath()).toBe(join(shepHome, 'webhooks', 'github.secret'));
+  });
+
+  it('reuses the same secret across repeated calls', () => {
+    const first = getOrCreateGitHubWebhookSecret();
+    const second = getOrCreateGitHubWebhookSecret();
+
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/presentation/web/api/github-webhook.test.ts
+++ b/tests/unit/presentation/web/api/github-webhook.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+
+import { createHmac } from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  syncRepositoryByGitHubFullName: vi.fn(),
+  hasPrSyncWatcher: vi.fn(() => true),
+}));
+
+vi.mock('@shepai/core/infrastructure/services/webhooks/webhook-secret.service', () => ({
+  getOrCreateGitHubWebhookSecret: vi.fn(() => 'secret'),
+}));
+
+vi.mock('@shepai/core/infrastructure/services/pr-sync/pr-sync-watcher.service', () => ({
+  hasPrSyncWatcher: mocks.hasPrSyncWatcher,
+  getPrSyncWatcher: vi.fn(() => ({
+    syncRepositoryByGitHubFullName: mocks.syncRepositoryByGitHubFullName,
+  })),
+}));
+
+import { POST, dynamic } from '@/app/api/webhooks/github/route';
+
+function sign(body: string): string {
+  return `sha256=${createHmac('sha256', 'secret').update(body).digest('hex')}`;
+}
+
+describe('POST /api/webhooks/github', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasPrSyncWatcher.mockReturnValue(true);
+    mocks.syncRepositoryByGitHubFullName.mockResolvedValue(true);
+  });
+
+  it('exports dynamic = force-dynamic', () => {
+    expect(dynamic).toBe('force-dynamic');
+  });
+
+  it('rejects invalid signatures', async () => {
+    const body = JSON.stringify({ repository: { full_name: 'org/repo' } });
+    const response = await POST(
+      new Request('http://localhost:3000/api/webhooks/github', {
+        method: 'POST',
+        headers: {
+          'x-hub-signature-256': 'sha256=bad',
+        },
+        body,
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.syncRepositoryByGitHubFullName).not.toHaveBeenCalled();
+  });
+
+  it('triggers a targeted repository refresh for valid webhook payloads', async () => {
+    const body = JSON.stringify({ repository: { full_name: 'org/repo' } });
+    const response = await POST(
+      new Request('http://localhost:3000/api/webhooks/github', {
+        method: 'POST',
+        headers: {
+          'x-hub-signature-256': sign(body),
+        },
+        body,
+      })
+    );
+
+    expect(response.status).toBe(202);
+    expect(mocks.syncRepositoryByGitHubFullName).toHaveBeenCalledWith('org/repo');
+    await expect(response.json()).resolves.toEqual({ accepted: true, refreshed: true });
+  });
+
+  it('returns 400 for validly signed payloads missing repository.full_name', async () => {
+    const body = JSON.stringify({ repository: {} });
+    const response = await POST(
+      new Request('http://localhost:3000/api/webhooks/github', {
+        method: 'POST',
+        headers: {
+          'x-hub-signature-256': sign(body),
+        },
+        body,
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.syncRepositoryByGitHubFullName).not.toHaveBeenCalled();
+  });
+
+  it('accepts the event without refresh when the watcher is unavailable', async () => {
+    mocks.hasPrSyncWatcher.mockReturnValue(false);
+    const body = JSON.stringify({ repository: { full_name: 'org/repo' } });
+    const response = await POST(
+      new Request('http://localhost:3000/api/webhooks/github', {
+        method: 'POST',
+        headers: {
+          'x-hub-signature-256': sign(body),
+        },
+        body,
+      })
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ accepted: true, refreshed: false });
+    expect(mocks.syncRepositoryByGitHubFullName).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a spec-driven github webhook integration path alongside the existing polling flow
- run a local webhook-only gateway behind cloudflared and reconcile repo webhooks when the tunnel url changes
- verify signed github webhook deliveries and trigger targeted PR sync refreshes for matching repositories

## Testing
- pnpm run typecheck
- pnpm exec vitest run tests/unit/infrastructure/services/webhooks/webhook-secret.service.test.ts tests/unit/infrastructure/services/webhooks/github-webhook.service.test.ts tests/unit/infrastructure/services/webhooks/github-webhook-runtime.service.test.ts tests/unit/infrastructure/services/pr-sync/pr-sync-watcher.service.test.ts tests/unit/presentation/web/api/github-webhook.test.ts tests/unit/commands/_serve.command.test.ts