### PR TITLE
fix(api): stash uncommitted changes before merge-pr delete-branch

### DIFF
--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -206,6 +206,14 @@ export class GitPrService implements IGitPrService {
   }
 
   async mergePr(cwd: string, prNumber: number, strategy: MergeStrategy = 'squash'): Promise<void> {
+    // Stash uncommitted changes to prevent --delete-branch from failing
+    const { stdout: status } = await this.execFile('git', ['status', '--porcelain'], { cwd });
+    const hasChanges = status.trim().length > 0;
+
+    if (hasChanges) {
+      await this.execFile('git', ['stash', 'push', '-m', 'shep: auto-stash before merge'], { cwd });
+    }
+
     try {
       await this.execFile(
         'gh',
@@ -216,6 +224,14 @@ export class GitPrService implements IGitPrService {
       const message = error instanceof Error ? error.message : String(error);
       const cause = error instanceof Error ? error : undefined;
       throw new GitPrError(message, GitPrErrorCode.MERGE_FAILED, cause);
+    } finally {
+      if (hasChanges) {
+        try {
+          await this.execFile('git', ['stash', 'pop'], { cwd });
+        } catch {
+          // Stash pop failure is non-fatal — changes remain in stash
+        }
+      }
     }
   }
 

--- a/tests/unit/infrastructure/services/git/git-pr.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.test.ts
@@ -284,32 +284,85 @@ describe('GitPrService', () => {
   });
 
   describe('mergePr', () => {
-    it('should call gh pr merge with prNumber and default squash strategy', async () => {
-      vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
+    it('should stash changes before merge and pop after when there are uncommitted changes', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: ' M dirty-file.ts\n', stderr: '' }) // git status --porcelain
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git stash push
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr merge
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git stash pop
 
       await service.mergePr('/repo', 42);
 
-      expect(mockExec).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenNthCalledWith(1, 'git', ['status', '--porcelain'], {
+        cwd: '/repo',
+      });
+      expect(mockExec).toHaveBeenNthCalledWith(
+        2,
+        'git',
+        ['stash', 'push', '-m', 'shep: auto-stash before merge'],
+        { cwd: '/repo' }
+      );
+      expect(mockExec).toHaveBeenNthCalledWith(
+        3,
         'gh',
         ['pr', 'merge', '42', '--squash', '--auto', '--delete-branch'],
         { cwd: '/repo' }
       );
+      expect(mockExec).toHaveBeenNthCalledWith(4, 'git', ['stash', 'pop'], { cwd: '/repo' });
+    });
+
+    it('should skip stash when working tree is clean', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git status --porcelain (clean)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // gh pr merge
+
+      await service.mergePr('/repo', 42);
+
+      expect(mockExec).toHaveBeenNthCalledWith(1, 'git', ['status', '--porcelain'], {
+        cwd: '/repo',
+      });
+      expect(mockExec).toHaveBeenNthCalledWith(
+        2,
+        'gh',
+        ['pr', 'merge', '42', '--squash', '--auto', '--delete-branch'],
+        { cwd: '/repo' }
+      );
+      expect(mockExec).toHaveBeenCalledTimes(2);
     });
 
     it('should call gh pr merge with specified strategy', async () => {
-      vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git status --porcelain (clean)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // gh pr merge
 
       await service.mergePr('/repo', 42, 'rebase');
 
-      expect(mockExec).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenNthCalledWith(
+        2,
         'gh',
         ['pr', 'merge', '42', '--rebase', '--auto', '--delete-branch'],
         { cwd: '/repo' }
       );
     });
 
+    it('should pop stash even when merge fails', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: ' M file.ts\n', stderr: '' }) // git status --porcelain
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git stash push
+        .mockRejectedValueOnce(new Error('merge failed: not mergeable')) // gh pr merge
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // git stash pop
+
+      await expect(service.mergePr('/repo', 42)).rejects.toMatchObject({
+        code: GitPrErrorCode.MERGE_FAILED,
+      });
+
+      expect(mockExec).toHaveBeenNthCalledWith(4, 'git', ['stash', 'pop'], { cwd: '/repo' });
+    });
+
     it('should throw GitPrError with MERGE_FAILED on merge failure', async () => {
-      vi.mocked(mockExec).mockRejectedValue(new Error('merge failed: not mergeable'));
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // git status --porcelain (clean)
+        .mockRejectedValueOnce(new Error('merge failed: not mergeable'));
 
       await expect(service.mergePr('/repo', 42)).rejects.toMatchObject({
         code: GitPrErrorCode.MERGE_FAILED,


### PR DESCRIPTION
## Summary
- Stashes uncommitted changes before running `gh pr merge --delete-branch` to prevent branch deletion from failing when the worktree is dirty
- Uses a `finally` block to restore (pop) stashed changes even if the merge itself fails
- Skips stash entirely when the working tree is clean (no overhead)

## Test plan
- [x] Unit test: stash + merge + pop when worktree is dirty
- [x] Unit test: skip stash when worktree is clean
- [x] Unit test: stash pop runs even when merge fails
- [x] Unit test: merge strategy passthrough still works
- [x] All 62 existing git-pr service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)