### PR TITLE
fix(agents): remove --delete-branch from gh pr merge for worktree compat

### DIFF
--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -207,16 +207,40 @@ export class GitPrService implements IGitPrService {
 
   async mergePr(cwd: string, prNumber: number, strategy: MergeStrategy = 'squash'): Promise<void> {
     try {
-      await this.execFile(
-        'gh',
-        ['pr', 'merge', String(prNumber), `--${strategy}`, '--auto', '--delete-branch'],
-        { cwd }
-      );
+      await this.execFile('gh', ['pr', 'merge', String(prNumber), `--${strategy}`, '--auto'], {
+        cwd,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       const cause = error instanceof Error ? error : undefined;
       throw new GitPrError(message, GitPrErrorCode.MERGE_FAILED, cause);
     }
+
+    // Try to delete the remote branch gracefully — not fatal if it fails
+    // (e.g. branch already deleted by GitHub auto-delete, or permissions)
+    try {
+      await this.execFile(
+        'gh',
+        [
+          'api',
+          '--method',
+          'DELETE',
+          `repos/{owner}/{repo}/git/refs/heads/${await this.getPrHeadBranch(cwd, prNumber)}`,
+        ],
+        { cwd }
+      );
+    } catch {
+      // Branch deletion is best-effort — log-level concern, not an error
+    }
+  }
+
+  private async getPrHeadBranch(cwd: string, prNumber: number): Promise<string> {
+    const { stdout } = await this.execFile(
+      'gh',
+      ['pr', 'view', String(prNumber), '--json', 'headRefName', '--jq', '.headRefName'],
+      { cwd }
+    );
+    return stdout.trim();
   }
 
   async localMergeSquash(

--- a/tests/unit/infrastructure/services/git/git-pr.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.test.ts
@@ -284,28 +284,38 @@ describe('GitPrService', () => {
   });
 
   describe('mergePr', () => {
-    it('should call gh pr merge with prNumber and default squash strategy', async () => {
-      vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
+    it('should call gh pr merge without --delete-branch and attempt remote branch cleanup', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr merge
+        .mockResolvedValueOnce({ stdout: 'feat/my-branch\n', stderr: '' }) // gh pr view --json headRefName
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // gh api DELETE
 
       await service.mergePr('/repo', 42);
 
-      expect(mockExec).toHaveBeenCalledWith(
-        'gh',
-        ['pr', 'merge', '42', '--squash', '--auto', '--delete-branch'],
-        { cwd: '/repo' }
-      );
+      expect(mockExec).toHaveBeenCalledWith('gh', ['pr', 'merge', '42', '--squash', '--auto'], {
+        cwd: '/repo',
+      });
     });
 
     it('should call gh pr merge with specified strategy', async () => {
-      vi.mocked(mockExec).mockResolvedValue({ stdout: '', stderr: '' });
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr merge
+        .mockResolvedValueOnce({ stdout: 'feat/my-branch\n', stderr: '' }) // gh pr view
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }); // gh api DELETE
 
       await service.mergePr('/repo', 42, 'rebase');
 
-      expect(mockExec).toHaveBeenCalledWith(
-        'gh',
-        ['pr', 'merge', '42', '--rebase', '--auto', '--delete-branch'],
-        { cwd: '/repo' }
-      );
+      expect(mockExec).toHaveBeenCalledWith('gh', ['pr', 'merge', '42', '--rebase', '--auto'], {
+        cwd: '/repo',
+      });
+    });
+
+    it('should not throw when remote branch deletion fails', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '', stderr: '' }) // gh pr merge
+        .mockRejectedValueOnce(new Error('branch delete failed')); // gh pr view fails
+
+      await expect(service.mergePr('/repo', 42)).resolves.toBeUndefined();
     });
 
     it('should throw GitPrError with MERGE_FAILED on merge failure', async () => {


### PR DESCRIPTION
## Summary
- Removed `--delete-branch` flag from `gh pr merge` which caused failures in git worktrees (where `main` is already checked out in the primary working directory)
- After successful merge, attempts to delete the remote branch via GitHub API (`gh api --method DELETE`), failing gracefully if cleanup fails
- Added `getPrHeadBranch` helper to resolve the branch name from PR number

## Test plan
- [x] Updated unit tests to verify `--delete-branch` is no longer passed
- [x] Added test confirming merge succeeds even when branch deletion fails
- [x] All 61 git-pr service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)