### PR TITLE
fix(agents): skip validate nodes on resume using successor phase check

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-graph.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/feature-agent-graph.ts
@@ -12,7 +12,12 @@ import { createRepairNode } from './nodes/repair.node.js';
 import { validateSpecAnalyze, validateSpecRequirements } from './nodes/schemas/spec.schema.js';
 import { validateResearch } from './nodes/schemas/research.schema.js';
 import { validatePlan, validateTasks } from './nodes/schemas/plan.schema.js';
-import { readSpecFile, safeYamlLoad, createNodeLogger } from './nodes/node-helpers.js';
+import {
+  readSpecFile,
+  safeYamlLoad,
+  createNodeLogger,
+  getCompletedPhases,
+} from './nodes/node-helpers.js';
 
 // Re-export state types for consumers
 export { FeatureAgentAnnotation, type FeatureAgentState } from './state.js';
@@ -78,6 +83,20 @@ function createPlanTasksValidator(): (
 
   return async (state: FeatureAgentState): Promise<Partial<FeatureAgentState>> => {
     log.activate();
+
+    // Skip validation when the successor phase (implement) is already completed.
+    // This proves validation already passed and the pipeline progressed beyond it.
+    // Same logic as createValidateNode's successorPhase guard.
+    if (getCompletedPhases(state.specDir).includes('implement')) {
+      log.info("Successor phase 'implement' already completed, skipping validation");
+      return {
+        lastValidationTarget: 'plan.yaml+tasks.yaml',
+        lastValidationErrors: [],
+        validationRetries: 0,
+        messages: ["[validate:plan+tasks] SKIP (successor 'implement' already completed)"],
+      };
+    }
+
     log.info('Validating plan.yaml and tasks.yaml');
     const allErrors: string[] = [];
 
@@ -177,12 +196,20 @@ export function createFeatureAgentGraph(
     .addNode('implement', createImplementNode(executor))
 
     // --- Validate nodes ---
-    .addNode('validate_spec_analyze', createValidateNode('spec.yaml', validateSpecAnalyze))
+    // Each validate node receives its SUCCESSOR phase name (the phase that runs
+    // after validation passes). On resume, validation is skipped only when the
+    // successor is already completed — proving this validation already passed.
+    // Using the successor (not the producer) avoids skipping validation when the
+    // producer ran successfully but validation itself failed.
+    .addNode(
+      'validate_spec_analyze',
+      createValidateNode('spec.yaml', validateSpecAnalyze, 'requirements')
+    )
     .addNode(
       'validate_spec_requirements',
-      createValidateNode('spec.yaml', validateSpecRequirements)
+      createValidateNode('spec.yaml', validateSpecRequirements, 'research')
     )
-    .addNode('validate_research', createValidateNode('research.yaml', validateResearch))
+    .addNode('validate_research', createValidateNode('research.yaml', validateResearch, 'plan'))
     .addNode('validate_plan_tasks', createPlanTasksValidator())
 
     // --- Repair nodes ---

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/validate.node.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/validate.node.ts
@@ -1,6 +1,11 @@
 import type { FeatureAgentState } from '../state.js';
 import type { ValidationResult } from './schemas/validation.js';
-import { readSpecFile, safeYamlLoad, createNodeLogger } from './node-helpers.js';
+import {
+  readSpecFile,
+  safeYamlLoad,
+  createNodeLogger,
+  getCompletedPhases,
+} from './node-helpers.js';
 
 type SchemaValidator = (data: unknown) => ValidationResult;
 
@@ -9,15 +14,40 @@ type SchemaValidator = (data: unknown) => ValidationResult;
  *
  * On success: resets validationRetries to 0, clears errors.
  * On failure: increments validationRetries, sets errors for repair node.
+ *
+ * @param successorPhase - The phase that runs AFTER this validation passes.
+ *   If provided, skip validation when the successor is already completed — this
+ *   proves the validation already passed in a prior run and the pipeline progressed
+ *   beyond it. Checking the successor (not the producer) avoids skipping validation
+ *   when the producer ran but validation itself failed.
  */
 export function createValidateNode(
   filename: string,
-  schema: SchemaValidator
+  schema: SchemaValidator,
+  successorPhase?: string
 ): (state: FeatureAgentState) => Promise<Partial<FeatureAgentState>> {
   const log = createNodeLogger(`validate:${filename}`);
 
   return async (state: FeatureAgentState): Promise<Partial<FeatureAgentState>> => {
     log.activate();
+
+    // Skip validation when the successor phase is already completed.
+    // This means: the validation already passed in a prior run AND the next phase
+    // ran successfully. On resume, LangGraph replays nodes from the last checkpoint.
+    // The producer node skips (via getCompletedPhases), but if we only checked the
+    // producer we'd also skip validation when it previously FAILED (since
+    // markPhaseComplete runs before validation). Checking the successor is safe:
+    // if the successor completed, this validation must have passed to get there.
+    if (successorPhase && getCompletedPhases(state.specDir).includes(successorPhase)) {
+      log.info(`Successor phase '${successorPhase}' already completed, skipping validation`);
+      return {
+        lastValidationTarget: filename,
+        lastValidationErrors: [],
+        validationRetries: 0,
+        messages: [`[validate:${filename}] SKIP (successor '${successorPhase}' already completed)`],
+      };
+    }
+
     log.info(`Validating ${filename}`);
 
     const content = readSpecFile(state.specDir, filename);

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/validate.node.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/validate.node.test.ts
@@ -10,6 +10,20 @@ vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
 import { createValidateNode } from '@/infrastructure/services/agents/feature-agent/nodes/validate.node.js';
 import type { FeatureAgentState } from '@/infrastructure/services/agents/feature-agent/state.js';
 
+// Mock getCompletedPhases from node-helpers
+vi.mock(
+  '@/infrastructure/services/agents/feature-agent/nodes/node-helpers.js',
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...(actual as Record<string, unknown>),
+      getCompletedPhases: vi.fn(() => []),
+    };
+  }
+);
+
+import { getCompletedPhases } from '@/infrastructure/services/agents/feature-agent/nodes/node-helpers.js';
+
 describe('createValidateNode', () => {
   let tempDir: string;
   let specDir: string;
@@ -84,5 +98,73 @@ describe('createValidateNode', () => {
 
     const result = await node(makeState({ validationRetries: 2 }));
     expect(result.validationRetries).toBe(3);
+  });
+
+  it('skips validation when successor phase is already completed', async () => {
+    writeFileSync(join(specDir, 'test.yaml'), 'name: hello\n');
+    const schema = vi.fn().mockReturnValue({
+      valid: false,
+      errors: ['would fail'],
+    });
+
+    // validate_spec_analyze has successor 'requirements'.
+    // If requirements is completed, this validation already passed.
+    vi.mocked(getCompletedPhases).mockReturnValue(['analyze', 'requirements']);
+
+    const node = createValidateNode('test.yaml', schema, 'requirements');
+    const result = await node(makeState({ validationRetries: 2 }));
+
+    // Should skip validation entirely — pass through with clean state
+    expect(result.lastValidationErrors).toEqual([]);
+    expect(result.validationRetries).toBe(0);
+    expect(schema).not.toHaveBeenCalled();
+  });
+
+  it('still validates when successor phase is NOT completed', async () => {
+    writeFileSync(join(specDir, 'test.yaml'), 'name: hello\n');
+    const schema = vi.fn().mockReturnValue({ valid: true, errors: [] });
+
+    // Producer (analyze) is completed but successor (requirements) is not.
+    // Validation must still run because we can't prove it passed before.
+    vi.mocked(getCompletedPhases).mockReturnValue(['analyze']);
+
+    const node = createValidateNode('test.yaml', schema, 'requirements');
+    const result = await node(makeState());
+
+    expect(schema).toHaveBeenCalled();
+    expect(result.lastValidationErrors).toEqual([]);
+  });
+
+  it('validates normally when no successor phase is specified (backwards compat)', async () => {
+    writeFileSync(join(specDir, 'test.yaml'), 'name: hello\n');
+    const schema = vi.fn().mockReturnValue({ valid: true, errors: [] });
+
+    vi.mocked(getCompletedPhases).mockReturnValue(['analyze']);
+
+    const node = createValidateNode('test.yaml', schema);
+    const result = await node(makeState());
+
+    expect(schema).toHaveBeenCalled();
+    expect(result.lastValidationErrors).toEqual([]);
+  });
+
+  it('does NOT skip when producer completed but successor has not (validation failed before)', async () => {
+    writeFileSync(join(specDir, 'research.yaml'), 'name: hello\n');
+    const schema = vi.fn().mockReturnValue({
+      valid: false,
+      errors: ['still broken'],
+    });
+
+    // Research agent ran (markPhaseComplete called) but validate_research failed.
+    // Successor 'plan' is NOT in completedPhases, so validation must re-run.
+    vi.mocked(getCompletedPhases).mockReturnValue(['analyze', 'requirements', 'research']);
+
+    const node = createValidateNode('research.yaml', schema, 'plan');
+    const result = await node(makeState());
+
+    // Must NOT skip — validation needs to run
+    expect(schema).toHaveBeenCalled();
+    expect(result.lastValidationErrors).toEqual(['still broken']);
+    expect(result.validationRetries).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Validate nodes now accept an optional `successorPhase` parameter and skip on resume when that successor is already completed — proving the validation already passed in a prior run
- Uses the **successor** phase (not the producer) to avoid incorrectly skipping validation when the producer ran but validation itself failed
- Applies the same guard to `createPlanTasksValidator` (checks `implement` phase)

**Root cause:** On resume from error, LangGraph replays the graph from the first node. Producer nodes correctly skip via `getCompletedPhases()`, but validate nodes always re-ran — applying stale validators against YAML modified by later phases (e.g. `validateSpecAnalyze` failing because `requirements` already populated `openQuestions`). The initial fix of checking the producer phase was too aggressive: it also skipped validation when the producer succeeded but validation itself had failed (since `markPhaseComplete` runs before validation).

**Successor mapping:**
| Validate node | Successor | Skip when |
|---|---|---|
| `validate_spec_analyze` | `requirements` | requirements completed |
| `validate_spec_requirements` | `research` | research completed |
| `validate_research` | `plan` | plan completed |
| `validate_plan_tasks` | `implement` | implement completed |

## Test plan

- [x] Added 4 new test cases covering: skip when successor completed, validate when successor not completed, backwards compat (no successor), and the critical case where producer completed but successor didn't (validation previously failed)
- [x] All 341 feature-agent tests pass
- [x] Build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)