### PR TITLE
fix(tsp): change relatedLinks from string[] to RelatedLink object array

### DIFF
--- a/.claude/skills/shep-kit-new-feature/templates/spec.yaml
+++ b/.claude/skills/shep-kit-new-feature/templates/spec.yaml
@@ -22,7 +22,8 @@ technologies:
 
 relatedLinks:
   []
-  # - https://example.com/relevant-doc
+  # - title: Example Docs
+  #   url: https://example.com/relevant-doc
 
 # Open questions (must be resolved before implementation)
 openQuestions:

--- a/apis/json-schema/RelatedLink.yaml
+++ b/apis/json-schema/RelatedLink.yaml
@@ -1,0 +1,14 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: RelatedLink.yaml
+type: object
+properties:
+  title:
+    type: string
+    description: Human-readable title describing the linked resource
+  url:
+    type: string
+    description: URL to the external documentation, reference, or resource
+required:
+  - title
+  - url
+description: External link with title and URL

--- a/apis/json-schema/SpecArtifactBase.yaml
+++ b/apis/json-schema/SpecArtifactBase.yaml
@@ -24,7 +24,7 @@ properties:
   relatedLinks:
     type: array
     items:
-      type: string
+      $ref: RelatedLink.yaml
     description: URLs to external documentation, references, or comparisons
   openQuestions:
     type: array

--- a/packages/core/src/domain/generated/output.ts
+++ b/packages/core/src/domain/generated/output.ts
@@ -969,6 +969,20 @@ export type Feature = SoftDeletableEntity & {
 };
 
 /**
+ * External link with title and URL
+ */
+export type RelatedLink = {
+  /**
+   * Human-readable title describing the linked resource
+   */
+  title: string;
+  /**
+   * URL to the external documentation, reference, or resource
+   */
+  url: string;
+};
+
+/**
  * Option for resolving an open question
  */
 export type QuestionOption = {
@@ -1039,7 +1053,7 @@ export type SpecArtifactBase = BaseEntity & {
   /**
    * URLs to external documentation, references, or comparisons
    */
-  relatedLinks: string[];
+  relatedLinks: RelatedLink[];
   /**
    * Structured open questions for validation gate checks
    */

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/research.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/research.prompt.ts
@@ -56,7 +56,8 @@ Use this YAML structure:
     - (list all technologies evaluated or needed)
 
   relatedLinks:
-    - (relevant documentation URLs discovered during research)
+    - title: '(Human-readable title for the resource)'
+      url: '(URL to external documentation or reference)'
 
   decisions:
     - title: '(Decision Title — e.g., "Database Schema Design")'

--- a/tests/unit/domain/generated/spec-artifact-schema-mapping.test.ts
+++ b/tests/unit/domain/generated/spec-artifact-schema-mapping.test.ts
@@ -57,7 +57,7 @@ function buildSpecArtifactBaseSample(): SpecArtifactBase {
     content: '## Problem\n\nTest content',
     technologies: ['TypeScript', 'Vitest'],
     relatedFeatures: ['008-agent-configuration'],
-    relatedLinks: ['https://example.com'],
+    relatedLinks: [{ title: 'Example Docs', url: 'https://example.com' }],
     openQuestions: [],
   };
 }

--- a/tsp/domain/entities/spec-artifact-base.tsp
+++ b/tsp/domain/entities/spec-artifact-base.tsp
@@ -81,7 +81,7 @@ model SpecArtifactBase extends BaseEntity {
   relatedFeatures: string[];
 
   @doc("URLs to external documentation, references, or comparisons")
-  relatedLinks: string[];
+  relatedLinks: RelatedLink[];
 
   @doc("Structured open questions for validation gate checks")
   openQuestions: OpenQuestion[];

--- a/tsp/domain/value-objects/spec-metadata.tsp
+++ b/tsp/domain/value-objects/spec-metadata.tsp
@@ -70,6 +70,21 @@ model OpenQuestion {
 }
 
 /**
+ * Represents an external link referenced in a spec artifact.
+ *
+ * RelatedLink captures a URL and a human-readable title for
+ * external documentation, references, or comparisons.
+ */
+@doc("External link with title and URL")
+model RelatedLink {
+  @doc("Human-readable title describing the linked resource")
+  title: string;
+
+  @doc("URL to the external documentation, reference, or resource")
+  url: string;
+}
+
+/**
  * Represents a technology decision documented in research.
  *
  * TechDecision captures structured information about technology choices


### PR DESCRIPTION
## Summary

- Adds `RelatedLink` value object (`title: string`, `url: string`) to `tsp/domain/value-objects/spec-metadata.tsp`
- Changes `relatedLinks: string[]` → `relatedLinks: RelatedLink[]` in `SpecArtifactBase`
- Regenerates JSON schema (`apis/json-schema/RelatedLink.yaml`, `SpecArtifactBase.yaml`) and TypeScript types (`generated/output.ts`) via `tsp:compile`
- Updates the research agent prompt and `spec.yaml` template to use the correct `{ title, url }` object format
- Fixes the test fixture in `spec-artifact-schema-mapping.test.ts` to use the object format

**Root cause:** The TypeSpec model defined `relatedLinks` as `string[]` but agents were consistently generating (and real spec YAMLs already contain) objects with `title` and `url` fields. The model is now aligned with the actual data.

## Test plan

- [x] `pnpm tsp:compile` — compiles cleanly
- [x] `pnpm typecheck` — passes (fixed test fixture)
- [x] Pre-commit hooks pass (lint-staged, commitlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)