### PR TITLE
fix(web): use di container for terminal list in settings page

### DIFF
--- a/packages/core/src/application/ports/output/services/index.ts
+++ b/packages/core/src/application/ports/output/services/index.ts
@@ -19,7 +19,7 @@ export type { IVersionService } from './version-service.interface.js';
 export type { IWebServerService } from './web-server-service.interface.js';
 export type { IWorktreeService, WorktreeInfo } from './worktree-service.interface.js';
 export { WorktreeError, WorktreeErrorCode } from './worktree-service.interface.js';
-export type { IToolInstallerService } from './tool-installer.service.js';
+export type { IToolInstallerService, AvailableTerminalEntry } from './tool-installer.service.js';
 export type { INotificationService } from './notification-service.interface.js';
 export type {
   IGitPrService,

--- a/packages/core/src/application/ports/output/services/tool-installer.service.ts
+++ b/packages/core/src/application/ports/output/services/tool-installer.service.ts
@@ -10,6 +10,12 @@ import type {
   ToolInstallCommand,
 } from '../../../../domain/generated/output.js';
 
+export interface AvailableTerminalEntry {
+  id: string;
+  name: string;
+  available: boolean;
+}
+
 /**
  * Service interface for tool installation management.
  */
@@ -41,4 +47,13 @@ export interface IToolInstallerService {
     toolName: string,
     onOutput?: (data: string) => void
   ): Promise<ToolInstallationStatus>;
+
+  /**
+   * List all terminal emulators supported on the current platform with availability status.
+   * Uses tool metadata loaded in the Node.js context (not bundled by Next.js),
+   * so this must be called via the DI container from server actions.
+   *
+   * @returns Array of terminal entries with id, name, and availability
+   */
+  listAvailableTerminals(): Promise<AvailableTerminalEntry[]>;
 }

--- a/packages/core/src/infrastructure/services/tool-installer/tool-installer.service.ts
+++ b/packages/core/src/infrastructure/services/tool-installer/tool-installer.service.ts
@@ -15,7 +15,10 @@
 import { injectable } from 'tsyringe';
 import { exec, spawn } from 'node:child_process';
 import { platform } from 'node:os';
-import type { IToolInstallerService } from '../../../application/ports/output/services/tool-installer.service.js';
+import type {
+  IToolInstallerService,
+  AvailableTerminalEntry,
+} from '../../../application/ports/output/services/tool-installer.service.js';
 import type {
   ToolInstallationStatus,
   ToolInstallCommand,
@@ -26,7 +29,7 @@ import {
   createMissingStatus,
   createErrorStatus,
 } from '../../../domain/value-objects/tool-installation-status.js';
-import { TOOL_METADATA, type ToolMetadata } from './tool-metadata.js';
+import { TOOL_METADATA, getTerminalEntries, type ToolMetadata } from './tool-metadata.js';
 import { checkBinaryExists } from './binary-exists.js';
 
 /**
@@ -199,6 +202,50 @@ export class ToolInstallerServiceImpl implements IToolInstallerService {
         cleanup(`Installation error: ${err.message}`);
       });
     });
+  }
+
+  /**
+   * List all terminal emulators supported on the current platform with availability status.
+   * TOOL_METADATA is loaded in the Node.js CLI context, so this is safe to call from the
+   * DI container even when the Next.js standalone bundle cannot resolve tools/ via import.meta.url.
+   */
+  async listAvailableTerminals(): Promise<AvailableTerminalEntry[]> {
+    const currentPlatform = platform();
+    const entries = getTerminalEntries();
+    const results: AvailableTerminalEntry[] = [];
+
+    for (const [id, meta] of entries) {
+      if (
+        meta.platforms &&
+        !meta.platforms.includes(currentPlatform as 'linux' | 'darwin' | 'win32')
+      ) {
+        continue;
+      }
+
+      if (id === 'system-terminal') {
+        results.unshift({ id: 'system', name: meta.name, available: true });
+        continue;
+      }
+
+      const binary = typeof meta.binary === 'string' ? meta.binary : meta.binary[currentPlatform];
+      if (!binary) continue;
+
+      let available = false;
+      if (meta.verifyCommand.startsWith('test ')) {
+        available = await runVerifyCommand(meta.verifyCommand);
+      } else {
+        const result = await checkBinaryExists(binary);
+        available = result.found;
+      }
+
+      results.push({ id, name: meta.name, available });
+    }
+
+    if (!results.some((r) => r.id === 'system')) {
+      results.unshift({ id: 'system', name: 'System Terminal', available: true });
+    }
+
+    return results;
   }
 
   /**

--- a/src/presentation/web/app/actions/get-available-terminals.ts
+++ b/src/presentation/web/app/actions/get-available-terminals.ts
@@ -1,8 +1,7 @@
 'use server';
 
-import { platform } from 'node:os';
-import { getTerminalEntries } from '@shepai/core/infrastructure/services/tool-installer/tool-metadata';
-import { checkBinaryExists } from '@shepai/core/infrastructure/services/tool-installer/binary-exists';
+import { resolve } from '@/lib/server-container';
+import type { IToolInstallerService } from '@shepai/core/application/ports/output/services/tool-installer.service';
 
 export interface AvailableTerminal {
   id: string;
@@ -11,58 +10,20 @@ export interface AvailableTerminal {
 }
 
 /**
- * Returns the list of terminal entries from tool metadata, filtered to the
- * current platform, with availability checks. The "system-terminal" entry
- * is always marked available and listed first.
+ * Returns the list of terminal entries from the DI container's IToolInstallerService,
+ * filtered to the current platform with availability checks.
+ *
+ * Using the DI container (not a direct import from tool-metadata) ensures that
+ * TOOL_METADATA is read from the correct tools/ directory path — it is loaded once
+ * in the Node.js CLI bootstrap context where import.meta.url resolves correctly.
+ * Direct imports of tool-metadata from Next.js server action bundles break in
+ * standalone production mode because import.meta.url points to the chunk file.
  */
 export async function getAvailableTerminals(): Promise<AvailableTerminal[]> {
-  const currentPlatform = platform();
-  const entries = getTerminalEntries();
-
-  const results: AvailableTerminal[] = [];
-
-  for (const [id, meta] of entries) {
-    // Skip terminals not supported on this platform
-    if (
-      meta.platforms &&
-      !meta.platforms.includes(currentPlatform as 'linux' | 'darwin' | 'win32')
-    ) {
-      continue;
-    }
-
-    // System terminal is always available
-    if (id === 'system-terminal') {
-      results.unshift({ id: 'system', name: meta.name, available: true });
-      continue;
-    }
-
-    // Check binary availability
-    const binary = typeof meta.binary === 'string' ? meta.binary : meta.binary[currentPlatform];
-    if (!binary) continue;
-
-    // For app-bundle terminals (Warp, iTerm2) that use verifyCommand instead of binary check
-    let available = false;
-    if (meta.verifyCommand.startsWith('test ')) {
-      // Use verifyCommand for app-bundle checks (e.g., "test -d /Applications/Warp.app")
-      try {
-        const { execSync } = await import('node:child_process');
-        execSync(meta.verifyCommand, { stdio: 'ignore' });
-        available = true;
-      } catch {
-        available = false;
-      }
-    } else {
-      const result = await checkBinaryExists(binary);
-      available = result.found;
-    }
-
-    results.push({ id, name: meta.name, available });
+  try {
+    const service = resolve<IToolInstallerService>('IToolInstallerService');
+    return await service.listAvailableTerminals();
+  } catch {
+    return [{ id: 'system', name: 'System Terminal', available: true }];
   }
-
-  // Ensure system terminal is always present even if not in tool metadata
-  if (!results.some((r) => r.id === 'system')) {
-    results.unshift({ id: 'system', name: 'System Terminal', available: true });
-  }
-
-  return results;
 }

--- a/tests/unit/application/use-cases/tools/install-tool.use-case.test.ts
+++ b/tests/unit/application/use-cases/tools/install-tool.use-case.test.ts
@@ -29,6 +29,7 @@ describe('InstallToolUseCase', () => {
           status: 'available',
           toolName: 'test-tool',
         }),
+      listAvailableTerminals: vi.fn(),
     };
 
     useCase = new InstallToolUseCase(mockService);

--- a/tests/unit/application/use-cases/tools/list-tools.use-case.test.ts
+++ b/tests/unit/application/use-cases/tools/list-tools.use-case.test.ts
@@ -95,6 +95,7 @@ describe('ListToolsUseCase', () => {
       checkAvailability: vi.fn(),
       getInstallCommand: vi.fn(),
       executeInstall: vi.fn(),
+      listAvailableTerminals: vi.fn(),
     };
 
     useCase = new ListToolsUseCase(mockService);

--- a/tests/unit/application/use-cases/tools/validate-tool-availability.use-case.test.ts
+++ b/tests/unit/application/use-cases/tools/validate-tool-availability.use-case.test.ts
@@ -27,6 +27,7 @@ describe('ValidateToolAvailabilityUseCase', () => {
         }),
       getInstallCommand: vi.fn(),
       executeInstall: vi.fn(),
+      listAvailableTerminals: vi.fn(),
     };
 
     useCase = new ValidateToolAvailabilityUseCase(mockService);

--- a/tests/unit/infrastructure/services/tool-installer/tool-installer.service.test.ts
+++ b/tests/unit/infrastructure/services/tool-installer/tool-installer.service.test.ts
@@ -122,6 +122,48 @@ describe('ToolInstallerServiceImpl', () => {
     });
   });
 
+  describe('listAvailableTerminals', () => {
+    it('should include system terminal as always available', async () => {
+      mockCheckBinaryExists.mockResolvedValue({ found: true });
+
+      const results = await service.listAvailableTerminals();
+
+      const system = results.find((r) => r.id === 'system');
+      expect(system).toBeDefined();
+      expect(system!.available).toBe(true);
+    });
+
+    it('should include warp as available when binary check passes', async () => {
+      // Warp uses a verifyCommand starting with "test " (app bundle check)
+      // We simulate exec returning no error (available)
+      mockExec.mockImplementation((_cmd: string, cb: (err: Error | null) => void) => {
+        cb(null);
+      });
+      mockCheckBinaryExists.mockResolvedValue({ found: true });
+
+      const results = await service.listAvailableTerminals();
+
+      // System terminal must always be present
+      expect(results.some((r) => r.id === 'system')).toBe(true);
+    });
+
+    it('should mark warp as unavailable when app bundle is not found', async () => {
+      mockExec.mockImplementation((_cmd: string, cb: (err: Error | null) => void) => {
+        cb(new Error('not found'));
+      });
+      mockCheckBinaryExists.mockResolvedValue({ found: false, notInPath: true });
+
+      const results = await service.listAvailableTerminals();
+
+      const warp = results.find((r) => r.id === 'warp');
+      if (warp) {
+        expect(warp.available).toBe(false);
+      }
+      // System terminal is always available
+      expect(results.some((r) => r.id === 'system' && r.available)).toBe(true);
+    });
+  });
+
   describe('executeInstall', () => {
     it('should call spawn with shell: true instead of sh -c', async () => {
       const mockProc = createMockProcess(0);


### PR DESCRIPTION
## Summary

- Terminal options like Warp were visible in dev mode but missing when running via `shep ui` (production standalone mode)
- Root cause: `get-available-terminals.ts` directly imported `getTerminalEntries` from `tool-metadata.ts`; in Next.js standalone production bundles, `import.meta.url` resolves to the chunk file path rather than the original source, so the `tools/` directory lookup silently fails and returns an empty list
- Fix: added `listAvailableTerminals()` to `IToolInstallerService` and routed the server action through the DI container, where `TOOL_METADATA` is loaded correctly in the Node.js CLI bootstrap context

## Changes

- `IToolInstallerService` — new `AvailableTerminalEntry` type and `listAvailableTerminals()` method
- `ToolInstallerServiceImpl` — implementation of `listAvailableTerminals()` (logic moved from server action)
- `get-available-terminals.ts` — replaced direct `tool-metadata` import with `resolve<IToolInstallerService>('IToolInstallerService').listAvailableTerminals()`
- Test mocks updated; 3 new unit tests for `listAvailableTerminals()`

## Test plan

- [ ] All 4350 unit tests pass (`pnpm test:unit`)
- [ ] Run `shep ui`, navigate to Settings → Environment — Warp and other installed terminals appear in the Terminal dropdown
- [ ] Dev mode (`pnpm dev:web`) still shows terminals correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)