### PR TITLE
fix(web): detect default branch for merge review diff

### DIFF
--- a/src/presentation/web/app/actions/get-merge-review-data.ts
+++ b/src/presentation/web/app/actions/get-merge-review-data.ts
@@ -74,13 +74,25 @@ export async function getMergeReviewData(featureId: string): Promise<GetMergeRev
         }
       : undefined;
 
-    const branch = feature.branch ? { source: feature.branch, target: 'main' } : undefined;
-
     const worktreePath =
       feature.worktreePath ??
       (feature.repositoryPath && feature.branch
         ? computeWorktreePath(feature.repositoryPath, feature.branch)
         : null);
+
+    // Detect the actual default branch (main, master, etc.) for diff comparison.
+    const gitPrService = resolve<IGitPrService>('IGitPrService');
+    const diffCwd = worktreePath ?? feature.repositoryPath ?? null;
+    let defaultBranch = 'main';
+    if (diffCwd) {
+      try {
+        defaultBranch = await gitPrService.getDefaultBranch(diffCwd);
+      } catch {
+        // Fall back to 'main' if detection fails
+      }
+    }
+
+    const branch = feature.branch ? { source: feature.branch, target: defaultBranch } : undefined;
 
     // Load evidence manifest (best-effort).
     // Evidence is stored independently of the worktree at:
@@ -116,10 +128,9 @@ export async function getMergeReviewData(featureId: string): Promise<GetMergeRev
     }
 
     try {
-      const gitPrService = resolve<IGitPrService>('IGitPrService');
       const [diffSummary, fileDiffs] = await Promise.all([
-        gitPrService.getPrDiffSummary(worktreePath, 'main'),
-        gitPrService.getFileDiffs(worktreePath, 'main').catch(() => undefined),
+        gitPrService.getPrDiffSummary(worktreePath, defaultBranch),
+        gitPrService.getFileDiffs(worktreePath, defaultBranch).catch(() => undefined),
       ]);
       return { pr, branch, diffSummary, fileDiffs, evidence };
     } catch {

--- a/tests/unit/presentation/web/actions/merge-review/get-merge-review-data.test.ts
+++ b/tests/unit/presentation/web/actions/merge-review/get-merge-review-data.test.ts
@@ -4,6 +4,7 @@ import { PrStatus, CiStatus } from '@shepai/core/domain/generated/output';
 const mockFindById = vi.fn();
 const mockGetPrDiffSummary = vi.fn();
 const mockGetFileDiffs = vi.fn();
+const mockGetDefaultBranch = vi.fn<(cwd: string) => Promise<string>>().mockResolvedValue('main');
 const mockComputeWorktreePath = vi.fn(
   (_repoPath: string, branch: string) => `/computed/wt/${branch.replace(/\//g, '-')}`
 );
@@ -14,7 +15,11 @@ vi.mock('@/lib/server-container', () => ({
   resolve: (token: string) => {
     if (token === 'IFeatureRepository') return { findById: mockFindById };
     if (token === 'IGitPrService')
-      return { getPrDiffSummary: mockGetPrDiffSummary, getFileDiffs: mockGetFileDiffs };
+      return {
+        getPrDiffSummary: mockGetPrDiffSummary,
+        getFileDiffs: mockGetFileDiffs,
+        getDefaultBranch: mockGetDefaultBranch,
+      };
     throw new Error(`Unknown token: ${token}`);
   },
 }));
@@ -220,6 +225,33 @@ describe('getMergeReviewData server action', () => {
     const result = await getMergeReviewData('feat-123');
 
     expect(result).toMatchObject({ branch: undefined });
+  });
+
+  it('uses detected default branch instead of hardcoded main', async () => {
+    mockGetDefaultBranch.mockResolvedValue('master');
+    mockFindById.mockResolvedValue(baseFeature);
+    mockGetPrDiffSummary.mockResolvedValue(baseDiffSummary);
+
+    const result = await getMergeReviewData('feat-123');
+
+    expect(result).toMatchObject({
+      branch: { source: 'feat/test-feature', target: 'master' },
+      diffSummary: baseDiffSummary,
+    });
+    expect(mockGetPrDiffSummary).toHaveBeenCalledWith('/tmp/worktree', 'master');
+  });
+
+  it('falls back to main when getDefaultBranch fails', async () => {
+    mockGetDefaultBranch.mockRejectedValue(new Error('detection failed'));
+    mockFindById.mockResolvedValue(baseFeature);
+    mockGetPrDiffSummary.mockResolvedValue(baseDiffSummary);
+
+    const result = await getMergeReviewData('feat-123');
+
+    expect(result).toMatchObject({
+      branch: { source: 'feat/test-feature', target: 'main' },
+    });
+    expect(mockGetPrDiffSummary).toHaveBeenCalledWith('/tmp/worktree', 'main');
   });
 
   it('returns error when repository throws', async () => {


### PR DESCRIPTION
## Summary
- Merge review panel showed "Diff statistics unavailable" for repos using `master` (or other non-`main` default branches)
- Root cause: `get-merge-review-data.ts` hardcoded `'main'` as the base branch for `git diff --stat main...HEAD`
- Now uses `gitPrService.getDefaultBranch()` to detect the actual default branch, with fallback to `'main'`

## Test plan
- [x] Unit tests pass (22 tests including 2 new ones for dynamic branch detection and fallback)
- [ ] Verify merge review diff shows correctly for repos using `master` as default branch
- [ ] Verify merge review diff still works for repos using `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)