### PR TITLE
feat(ci): add --compact flag to gh run watch

### DIFF
--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -382,7 +382,15 @@ export class GitPrService implements IGitPrService {
       const runId = String(runs[0].databaseId);
       runUrl = runs[0].url;
       const interval = intervalSeconds ?? 30;
-      const args = ['run', 'watch', runId, '--exit-status', '--interval', String(interval)];
+      const args = [
+        'run',
+        'watch',
+        runId,
+        '--exit-status',
+        '--compact',
+        '--interval',
+        String(interval),
+      ];
       const { stdout } = await this.execFile('gh', args, {
         cwd,
         ...(timeoutMs ? { timeout: timeoutMs } : {}),

--- a/tests/integration/infrastructure/services/git/git-pr-ci-watch.test.ts
+++ b/tests/integration/infrastructure/services/git/git-pr-ci-watch.test.ts
@@ -57,7 +57,7 @@ Run completed: success
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       'gh',
-      ['run', 'watch', String(runId), '--exit-status', '--interval', '30'],
+      ['run', 'watch', String(runId), '--exit-status', '--compact', '--interval', '30'],
       { cwd }
     );
     expect(result.status).toBe('success');
@@ -132,7 +132,7 @@ Run completed: success
     expect(mockExec).toHaveBeenNthCalledWith(
       2,
       'gh',
-      ['run', 'watch', String(runId), '--exit-status', '--interval', '30'],
+      ['run', 'watch', String(runId), '--exit-status', '--compact', '--interval', '30'],
       {
         cwd,
         timeout: timeoutMs,

--- a/tests/unit/infrastructure/services/git/git-pr.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.test.ts
@@ -464,7 +464,7 @@ describe('GitPrService', () => {
       expect(mockExec).toHaveBeenNthCalledWith(
         2,
         'gh',
-        ['run', 'watch', '789', '--exit-status', '--interval', '30'],
+        ['run', 'watch', '789', '--exit-status', '--compact', '--interval', '30'],
         expect.objectContaining({ cwd: '/repo' })
       );
       expect(result.status).toBe('success');
@@ -638,7 +638,7 @@ describe('GitPrService', () => {
       expect(mockExec).toHaveBeenNthCalledWith(
         2,
         'gh',
-        ['run', 'watch', '789', '--exit-status', '--interval', '30'],
+        ['run', 'watch', '789', '--exit-status', '--compact', '--interval', '30'],
         {
           cwd: '/repo',
           timeout: 30000,


### PR DESCRIPTION
## Summary
- Adds `--compact` flag to `gh run watch` command in CI watch service, reducing output to a single line per job instead of the full animated progress display
- Cleaner logs in non-interactive contexts (agent sessions, CI pipelines)
- Interval already defaults to 30s — no change needed

## Test plan
- [x] Unit tests updated and passing (332 files, 4512 tests)
- [x] Integration tests updated and passing (46 files, 521 tests)
- [ ] Verify compact output in a real CI watch run

🤖 Generated with [Claude Code](https://claude.com/claude-code)