### PR TITLE
fix(agents): use structured relatedLinks format in spec prompts

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/analyze.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/analyze.prompt.ts
@@ -54,7 +54,9 @@ You MUST write the COMPLETE file (not a partial update). Preserve the existing n
   technologies:
     - (list each technology relevant to implementing this feature)
 
-  relatedLinks: []
+  relatedLinks:
+    - title: '(Human-readable title for the resource)'
+      url: '(URL to external documentation or reference)'
 
   openQuestions: []
 

--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/plan.prompt.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/plan.prompt.ts
@@ -99,7 +99,9 @@ You MUST write TWO files:
   relatedFeatures: []
   technologies:
     - (technologies needed)
-  relatedLinks: []
+  relatedLinks:
+    - title: '(Human-readable title for the resource)'
+      url: '(URL to external documentation or reference)'
 
   phases:
     - id: phase-1
@@ -148,7 +150,9 @@ You MUST write TWO files:
 
   relatedFeatures: []
   technologies: []
-  relatedLinks: []
+  relatedLinks:
+    - title: '(Human-readable title for the resource)'
+      url: '(URL to external documentation or reference)'
 
   tasks:
     - id: task-1


### PR DESCRIPTION
## Summary

- The analyze and plan phase prompts showed `relatedLinks` as `[]` with no structural example, causing the AI to output plain URL strings instead of the required `{ title, url }` objects
- Updated YAML templates in `analyze.prompt.ts` and `plan.prompt.ts` to show the correct object structure, matching the existing `research.prompt.ts` format
- The `RelatedLink` TypeSpec model and JSON Schema already enforce `title` + `url` as required fields — this fix aligns the prompts with that contract

## Root Cause

The `relatedLinks` field is defined as `RelatedLink[]` in TypeSpec ([spec-metadata.tsp](tsp/domain/value-objects/spec-metadata.tsp)) with required `title` and `url` properties. The JSON Schema validator enforces this at parse time. However, the analyze and plan prompts only showed `relatedLinks: []` — giving the AI no example of the expected object structure. The research prompt was the only one with the correct format.

## Test plan

- [x] All 4512 unit tests pass
- [x] Verified analyze.prompt.ts shows `{ title, url }` structure
- [x] Verified plan.prompt.ts shows `{ title, url }` structure in both plan.yaml and tasks.yaml templates
- [x] research.prompt.ts already had the correct format (unchanged)
- [x] requirements.prompt.ts uses `(keep)` — inherits from previous phase (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)