### PR TITLE
fix(web): fetch merge review data for maintain lifecycle features

### DIFF
--- a/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
+++ b/src/presentation/web/components/common/control-center-drawer/feature-drawer-client.tsx
@@ -233,8 +233,9 @@ export function FeatureDrawerClient({ view: initialView, urlTab }: FeatureDrawer
   );
 
   const mergeFeatureId =
-    featureNode?.lifecycle === 'review' &&
-    (featureNode?.state === 'action-required' || featureNode?.state === 'error')
+    (featureNode?.lifecycle === 'review' &&
+      (featureNode?.state === 'action-required' || featureNode?.state === 'error')) ||
+    (featureNode?.lifecycle === 'maintain' && featureNode?.pr)
       ? featureNode.featureId
       : null;
   const isLoadingMerge = useArtifactFetch(


### PR DESCRIPTION
## Summary
- Fixed regression where the Merge History tab showed "Merge review data unavailable" for features in the `maintain` lifecycle
- `mergeFeatureId` (which triggers `getMergeReviewData` fetch) only matched `lifecycle=review`, but the tab is also visible for `lifecycle=maintain` with a PR
- Extended the condition to also fetch data when `lifecycle=maintain && pr` exists, matching the `computeVisibleTabs` logic

## Test plan
- [x] All 4520 unit tests pass
- [ ] Open a feature that has been merged (maintain lifecycle with PR) — Merge History tab should show PR details and diff data instead of "Merge review data unavailable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)