### PR TITLE
fix(ci): pin trivy-action to immutable release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Trivy filesystem scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.34.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -203,7 +203,7 @@ jobs:
           fi
 
       - name: Trivy filesystem scan (SARIF)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.34.0
         if: always()
         with:
           scan-type: 'fs'


### PR DESCRIPTION
replace mutable @master ref with @0.34.0 to mitigate supply chain
compromise where attackers force-pushed malicious code to trivy-action
tags and branches

https://claude.ai/code/session_01PfkHzpiKkiXXEdkRM83zBM