### PR TITLE
refactor(domain): split interactive session service into clean-arch collaborators

### DIFF
--- a/docs/plans/2026-04-14-interactive-session-service-refactor.md
+++ b/docs/plans/2026-04-14-interactive-session-service-refactor.md
@@ -1,0 +1,270 @@
+# Interactive Session Service — Refactor Findings & Plan
+
+**Date:** 2026-04-14
+**Target:** [packages/core/src/infrastructure/services/interactive/interactive-session.service.ts](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts)
+**Current size:** 1576 lines, one class, ~10 mixed responsibilities
+
+---
+
+## 1. Post-pull review — what changed on main
+
+Pulled `main` fast-forward from `3349156b` → `29342f80d` (one commit: `feat: one-click cloud deploy for applications (spec 089) (#554)`).
+
+### 1.1 Changes inside the target file
+
+Only one self-contained change touched this file — a correctness fix, not a structural one. 43 lines added, 12 removed:
+
+1. **New private field `lastMessageTs` + helper `nextMessageDate()`** ([interactive-session.service.ts:146-157](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L146-L157), [interactive-session.service.ts:1461-1476](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1461-L1476))
+   - Monotonic clock: `max(Date.now(), lastMessageTs + 1)`.
+   - Reason stated in-file: `Date.now()` has millisecond resolution, and the Claude SDK fires `tool_use` + `tool_result` in the same millisecond. Two rows with identical `created_at` break `ORDER BY created_at ASC` in `interactiveMessageRepo.findByFeatureId`, which breaks the tool→Output pairing in `StepTracker.classifyMessages` on the frontend.
+   - The counter is **process-wide** (one per `InteractiveSessionService` instance), not per session — deliberately, because it guards message ordering within the shared `messages` table regardless of which session wrote the row.
+
+2. **`persistToolEvent` and `flushAssistantBuffer` now consume `this.nextMessageDate()`** instead of `new Date()` ([interactive-session.service.ts:1415-1424](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1415-L1424), [interactive-session.service.ts:1445-1456](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1445-L1456)).
+
+3. **Five `void this.persistToolEvent(...)` calls rewritten as `await this.persistToolEvent(...)`** inside both the boot stream loop and the turn stream loop:
+   - `thinking` event ([interactive-session.service.ts:431](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L431), [interactive-session.service.ts:694](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L694))
+   - `tool_use` event ([interactive-session.service.ts:445](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L445), [interactive-session.service.ts:708](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L708))
+   - `tool_result` event ([interactive-session.service.ts:459](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L459), [interactive-session.service.ts:722](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L722))
+   - `task_started` event ([interactive-session.service.ts:811](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L811))
+   - `task_done` event ([interactive-session.service.ts:830](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L830))
+   - Together with the monotonic clock, this guarantees that each tool-event row is fully persisted before the next call observes `lastMessageTs`. Firing them in parallel via `void` could race against the counter and silently re-introduce duplicates.
+
+### 1.2 Relevant changes elsewhere on main
+
+- **[application/ports/output/services/logger.interface.ts](../../packages/core/src/application/ports/output/services/logger.interface.ts)** is NEW on main. It's the `ILogger` port I had previously recommended adding as step 6 of the original plan. The port already exists — so the refactor can just inject it; no new port to create.
+- **[application/ports/output/services/interactive-session-service.interface.ts](../../packages/core/src/application/ports/output/services/interactive-session-service.interface.ts)** is UNCHANGED by the pull. The refactor stays internal to `infrastructure/`.
+- **No `ISettingsProvider` port exists yet.** The file still imports `getSettings` / `hasSettings` singletons from [settings.service.ts](../../packages/core/src/infrastructure/services/settings.service.ts) at lines [44](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L44), [1395](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1395), [1403](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1403), [1572](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1572) — that port still needs to be added as part of this refactor.
+- **Many other new ports** were added alongside the cloud-deploy feature (cloud provider registry, event bus, operation log, worktree path provider, etc.) — none relevant to this refactor. They do demonstrate that the team is already splitting services via per-concern port interfaces, so the approach below fits the repo style.
+
+### 1.3 Impact on the original refactor plan
+
+| Original plan item | Impact |
+|---|---|
+| **Action 3 — `SessionPersistence`** | Must now also own `lastMessageTs` + `nextMessageDate()`. The monotonic counter is a persistence concern, not session state. It stays **process-singleton inside the persistence module**, NOT per-session. |
+| **Action 7 — `AgentStreamConsumer`** | MUST preserve the `await this.persistToolEvent(...)` sequencing. This is no longer a cosmetic choice — it is an **ordering invariant** the frontend depends on. Any extraction that reintroduces `void`-fire-and-forget will regress tool→Output pairing in `StepTracker.classifyMessages` and must fail review. Document this in the stream consumer's doc comment. |
+| **Action 19 — drop `console.*`** | `ILogger` port already exists on main — no port to create, just inject it. Removes one step. |
+| **Actions 1, 2, 4, 5, 6, 8–18, 20** | Unchanged. |
+
+The line count went from 1545 to 1576 — the file grew, not shrank. The refactor is MORE justified post-pull, not less.
+
+---
+
+## 2. Repository conventions that shape the plan
+
+Two conventions govern file placement:
+
+- **Tests live in a separate mirrored tree** at [tests/unit/infrastructure/services/interactive/](../../tests/unit/infrastructure/services/interactive/) — **not colocated**. Current tests already live there: [interactive-session.service.test.ts](../../tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts), [feature-context.builder.test.ts](../../tests/unit/infrastructure/services/interactive/feature-context.builder.test.ts). Every new collaborator gets its test at `tests/unit/<mirror-of-src-path>.test.ts`.
+- **Complex service folders are subgrouped.** [packages/core/src/infrastructure/services/agents/](../../packages/core/src/infrastructure/services/agents/) — the other large service in the repo — already uses semantic subfolders (`sessions/`, `streaming/`, `common/`, `application-creation/`, `analyze-repo/`, `feature-agent/`, `conflict-resolution/`). With ~15 production files the interactive service qualifies for the same treatment.
+
+---
+
+## 3. Refactoring plan (single-row action items)
+
+Target: a thin `InteractiveSessionService` facade (~200 lines) at the root of [packages/core/src/infrastructure/services/interactive/](../../packages/core/src/infrastructure/services/interactive/), composing small single-responsibility collaborators organised into four semantic subfolders (`core/`, `lifecycle/`, `runtime/`, `api/`). All collaborators stay inside the `infrastructure/` layer — no new application ports except `ISettingsProvider` (action 4a).
+
+1. **Extract `SessionState` + `SessionRegistry`** → new `interactive/core/session-registry.ts`. Move `SessionState` interface ([62-99](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L62-L99)), `sessions` map, `stoppedAgentSessionIds`, `activeStepByFeature`, and `findActiveStateForFeature` ([1378-1384](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1378-L1384)). Expose typed getters/setters only — no business logic.
+
+2. **Extract `StreamEventDispatcher`** → new `interactive/core/stream-event-dispatcher.ts`. Owns `featureSubscribers`, `globalSubscribers`, session subscribers, plus `subscribe` / `subscribeByFeature` / `subscribeAll` ([939-947](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L939-L947), [1180-1203](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1180-L1203)) and `notify` / `notifyByFeatureId` ([1486-1506](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1486-L1506)). Pure pub/sub — no DB, no state.
+
+3. **Extract `SessionPersistence`** → new `interactive/core/session-persistence.ts`. Consolidates `persistMessage` ([1518-1528](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1518-L1528)), `updateSessionStatusAndNotify` ([1533-1549](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1533-L1549)), `updateTurnStatusAndNotify` ([1552-1563](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1552-L1563)), `flushAssistantBuffer` ([1445-1459](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1445-L1459)), `persistToolEvent` ([1407-1430](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1407-L1430)), **AND the new monotonic clock** (`lastMessageTs` field at [146-157](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L146-L157) + `nextMessageDate()` at [1461-1476](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1461-L1476)). The counter is module-private state of this collaborator — registered as a **singleton inside the DI container** so one instance guards the whole process. Deps: `IInteractiveMessageRepository`, `IInteractiveSessionRepository`, `SessionRegistry` (for `activeStepByFeature` read), `StreamEventDispatcher`.
+
+4. **Extract `AgentConfigResolver`** → new `interactive/lifecycle/agent-config.resolver.ts`. Moves `resolveAgentType` ([1391-1399](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1391-L1399)), `resolveAuthConfig` ([1402-1411](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1402-L1411)), and `getCap` ([1571-1575](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1571-L1575)). Takes an injected `ISettingsProvider` (see 4a) so this file stops importing `getSettings` / `hasSettings` from [settings.service.ts](../../packages/core/src/infrastructure/services/settings.service.ts) at [44](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L44).
+
+4a. **Add application port `ISettingsProvider`** → new [settings-provider.interface.ts](../../packages/core/src/application/ports/output/services/settings-provider.interface.ts). Minimal shape `{ has(): boolean; get(): ShepSettings }`. Adapter `interactive/lifecycle/settings-provider.adapter.ts` wraps the existing [settings.service.ts](../../packages/core/src/infrastructure/services/settings.service.ts) singleton. This is the one real clean-arch fix — removes the singleton violation flagged by [.claude/rules/code-quality.md](../../.claude/rules/code-quality.md) "No Singletons or Global State Outside Infrastructure Bootstrapping".
+
+5. **Extract `UserInteractionCoordinator`** → new `interactive/runtime/user-interaction.coordinator.ts`. Moves `buildOnUserQuestionCallback` ([1329-1376](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1329-L1376)) and `respondToInteraction` ([1233-1274](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1233-L1274)). Owns `pendingInteraction` / `pendingInteractionResolver` lifecycle on `SessionState`.
+
+6. **Extract `BootPromptResolver`** → new `interactive/lifecycle/boot-prompt.resolver.ts`. Pure function computing `(context, bootPrompt)` from `SessionState` + `IFeatureRepository` + `FeatureContextBuilder` — the three-case branch at [280-321](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L280-L321). Unit-testable without handles or streams.
+
+7. **Extract `AgentStreamConsumer`** → new `interactive/runtime/agent-stream.consumer.ts`. Single method `consume(handle, state, { mode: 'boot' | 'turn', abortSignal })` owning the event switch shared between `completeBootAsync` ([410-517](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L410-L517)) and `executeAndPersistTurn` ([683-850](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L683-L850)) — kills the ~200-line duplication. **CRITICAL**: preserves the `await this.persistToolEvent(...)` sequencing from the recent fix — this is an ordering invariant, not cosmetic. Document it in the consumer's header comment.
+
+8. **Extract `BootWatchdog`** → new `interactive/lifecycle/boot-watchdog.ts`. Moves `BOOT_IDLE_TIMEOUT_MS` + the idle-timer dance ([386-394](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L386-L394)). Exposes `start() / bump() / stop()` — trivial to unit-test with fake timers.
+
+9. **Extract `SessionBootstrapper`** → new `interactive/lifecycle/session-bootstrapper.ts`. Owns `startSession` ([159-260](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L159-L260)) and `completeBootAsync` ([268-558](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L268-L558)). Depends on: `AgentConfigResolver`, `BootPromptResolver`, `AgentStreamConsumer`, `BootWatchdog`, `SessionRegistry`, `SessionPersistence`, `IAgentExecutorFactory`, `IInteractiveSessionRepository`.
+
+10. **Extract `TurnExecutor`** → new `interactive/runtime/turn.executor.ts`. Owns `executeAndPersistTurn` ([646-892](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L646-L892)) + the per-session turn queue lock ([633-638](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L633-L638), [998-1003](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L998-L1003), [902-909](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L902-L909)). Delegates the stream event loop to `AgentStreamConsumer`. Exposes `enqueueTurn(state, prompt)`.
+
+11. **Extract `SessionTerminator`** → new `interactive/lifecycle/session-terminator.ts`. Moves `stopSession` ([560-604](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L560-L604)) and `stopByFeature` ([1205-1209](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1205-L1209)). Replace the diagnostic `console.log(new Error().stack)` at [568-571](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L568-L571) with an injected `ILogger.debug` call.
+
+12. **Extract `ChatStateAssembler`** → new `interactive/api/chat-state.assembler.ts`. Moves the 113-line `getChatState` ([1066-1178](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1066-L1178)) — read-only orchestration, no mutation.
+
+13. **Extract `MessageDispatcher`** → new `interactive/api/message-dispatcher.ts`. Owns `sendMessage` ([606-641](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L606-L641)) and `sendUserMessage` ([960-1064](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L960-L1064)) — the model-change-restart logic and cold-boot-vs-hot-turn routing. Depends on: `SessionBootstrapper`, `TurnExecutor`, `SessionRegistry`, `SessionPersistence`.
+
+14. **Extract `WorkflowOrchestratorHooks`** → new `interactive/api/workflow-hooks.ts`. Moves `setActiveStep` / `clearActiveStep` / `notifyWorkflowStep` / `waitForTurnDone` ([1280-1322](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L1280-L1322)). Small but a distinct audience (the orchestrator, not the chat UI).
+
+15. **Re-shape `InteractiveSessionService` as a thin facade** ([interactive-session.service.ts](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts)) implementing `IInteractiveSessionService` by delegating to collaborators above. Lives at the root of `interactive/` (not in a subfolder). Target ≤200 lines, no private state, no direct repo access. Preserves the application port contract so nothing above `application/` has to change.
+
+16. **Wire new collaborators in the DI container** — add constructions at the existing `new InteractiveSessionService(...)` site. Compose in dependency order: `core/*` → settings-provider adapter → `lifecycle/*` → `runtime/*` → `api/*` → facade. The facade is registered as the singleton binding for `IInteractiveSessionService`. `SessionPersistence` is the only collaborator registered as a process-singleton in its own right (so the monotonic clock is shared).
+
+17. **Enforce subfolder layering with ESLint `no-restricted-imports`** — `core/*` MUST NOT import from `lifecycle/` / `runtime/` / `api/`; `lifecycle/*` MUST NOT import from `runtime/` / `api/`; `runtime/*` MUST NOT import from `api/`; `api/*` may import from all of the above. Add the rule to [eslint.config.mjs](../../eslint.config.mjs) so the layering is load-bearing, not aspirational.
+
+18. **Strangler migration, one collaborator per commit**, per [.claude/rules/code-quality.md](../../.claude/rules/code-quality.md) "Refactor Before Extending". Order: (a) create `core/` subfolder + move registry + dispatcher (pure move) → (b) persistence with monotonic clock → (c) settings-provider port + lifecycle/ config resolver + adapter → (d) runtime/ stream consumer + lifecycle/ watchdog (kills duplication; carries ordering invariant) → (e) lifecycle/ bootstrapper + terminator + runtime/ turn executor + user-interaction coordinator + boot-prompt resolver → (f) api/ message dispatcher + chat-state assembler + workflow hooks → (g) facade reshape + delete dead code + add ESLint layering rule. Each commit runs full test suite green before moving on.
+
+19. **Per-collaborator TDD tests in the mirrored test tree** — every new production file at `packages/core/src/infrastructure/services/interactive/<subfolder>/<file>.ts` gets a test at `tests/unit/infrastructure/services/interactive/<subfolder>/<file>.test.ts`. The existing [tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts](../../tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts) becomes a thin facade test; the meat moves into per-collaborator specs. **Must-have test for `SessionPersistence`** at [tests/unit/infrastructure/services/interactive/core/session-persistence.test.ts](../../tests/unit/infrastructure/services/interactive/core/session-persistence.test.ts): persisting 100 messages in a tight loop produces 100 strictly-increasing `createdAt` values even when `Date.now()` returns the same value for all calls (use `vi.useFakeTimers()` + `vi.setSystemTime()`). This codifies the recent fix so the refactor cannot regress it.
+
+20. **Drop `/* eslint-disable no-console */` and `console.*` calls** scattered through the file ([482-488](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L482-L488), [542-543](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L542-L543), [568-571](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L568-L571), [770-774](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L770-L774), [866-869](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L866-L869), [893-894](../../packages/core/src/infrastructure/services/interactive/interactive-session.service.ts#L893-L894)) — each collaborator takes an injected `ILogger` from [logger.interface.ts](../../packages/core/src/application/ports/output/services/logger.interface.ts) (already on main, no port to create).
+
+21. **Verify `IInteractiveSessionService` is unchanged** at [interactive-session-service.interface.ts](../../packages/core/src/application/ports/output/services/interactive-session-service.interface.ts). Run `pnpm typecheck && pnpm vitest run tests/unit/infrastructure/services/interactive` after each step per [.claude/rules/cicd.md](../../.claude/rules/cicd.md) pre-push sequence.
+
+---
+
+## 4. Clean-arch posture
+
+- **No new application ports for the collaborators themselves** — they're infrastructure-private composition details. Creating `ITurnExecutor` / `IBootstrapper` / `IStreamConsumer` ports would be ceremony, not architecture.
+- **One new port needed: `ISettingsProvider`** (action 4a) — removes the singleton violation.
+- **Zero new exported domain models.** `SessionState` is infrastructure-private. All domain types already live in [domain/generated/output.ts](../../packages/core/src/domain/generated/output.ts) via TypeSpec — do NOT touch.
+- **`ILogger` port already exists on main** — just inject it.
+- **The `IInteractiveSessionService` port contract is unchanged** — the entire refactor is internal to `infrastructure/services/interactive/`.
+- **Subfolder layering enforced via ESLint** (action 17) — `core/` ← `lifecycle/` ← `runtime/` ← `api/` ← facade. No upward imports; siblings don't cross-import. This matches the [agents/](../../packages/core/src/infrastructure/services/agents/) convention already in the repo.
+
+---
+
+## 5. Estimated sizes & final structure
+
+### 5.1 Per-file size estimates
+
+| Group | File | Est. lines |
+|---|---|---:|
+| root | `interactive-session.service.ts` (facade) | ~200 |
+| root | `feature-context.builder.ts` *(existing, unchanged)* | — |
+| `core/` | `session-registry.ts` | ~90 |
+| `core/` | `stream-event-dispatcher.ts` | ~100 |
+| `core/` | `session-persistence.ts` ★ monotonic clock | ~170 |
+| `lifecycle/` | `agent-config.resolver.ts` | ~55 |
+| `lifecycle/` | `settings-provider.adapter.ts` | ~25 |
+| `lifecycle/` | `boot-prompt.resolver.ts` | ~75 |
+| `lifecycle/` | `boot-watchdog.ts` | ~55 |
+| `lifecycle/` | `session-bootstrapper.ts` | ~220 |
+| `lifecycle/` | `session-terminator.ts` | ~90 |
+| `runtime/` | `agent-stream.consumer.ts` ⭐ single event switch | ~230 |
+| `runtime/` | `turn.executor.ts` | ~125 |
+| `runtime/` | `user-interaction.coordinator.ts` | ~135 |
+| `api/` | `message-dispatcher.ts` | ~165 |
+| `api/` | `chat-state.assembler.ts` | ~145 |
+| `api/` | `workflow-hooks.ts` | ~85 |
+| *application* | `settings-provider.interface.ts` *(new port)* | ~20 |
+
+### 5.2 Before vs after
+
+| | Before | After |
+|---|---:|---:|
+| Production lines | **1576** (1 file) | **~1885** (15 files + 1 port) |
+| Largest file | **1576** | **~230** (`agent-stream.consumer.ts`) |
+| Largest class | **1 × 1576-line class** | **15 classes, each ≤230 lines** |
+| Files over 300 lines | 1 | **0** ✅ ([code-quality.md](../../.claude/rules/code-quality.md) "File Length & Focus") |
+| Hidden `getSettings()` singleton calls | 4 | **0** |
+| Duplicated stream event switch | 2× (~280 lines) | **1×** (~230 lines) |
+
+Growth: **~+19%** (309 lines). Normal cost of splitting (file headers, class decls, constructor signatures, imports, jsdoc). Each individual unit shrinks dramatically — biggest file drops 85% (1576 → 230), which is the real win.
+
+### 5.3 Final production tree
+
+```
+packages/core/src/
+│
+├── application/ports/output/services/
+│   ├── interactive-session-service.interface.ts     (unchanged)
+│   ├── logger.interface.ts                           (already on main)
+│   └── settings-provider.interface.ts                ★ NEW port (action 4a)
+│
+└── infrastructure/services/interactive/
+    │
+    ├── interactive-session.service.ts                ~200   ★ facade (was 1576)
+    ├── feature-context.builder.ts                             (existing, unchanged)
+    │
+    ├── core/                                          ← shared plumbing, no business logic
+    │   ├── session-registry.ts                       ~90
+    │   ├── stream-event-dispatcher.ts                ~100
+    │   └── session-persistence.ts                    ~170   ← owns monotonic clock
+    │
+    ├── lifecycle/                                     ← start / boot / stop a session
+    │   ├── agent-config.resolver.ts                  ~55
+    │   ├── settings-provider.adapter.ts              ~25
+    │   ├── boot-prompt.resolver.ts                   ~75
+    │   ├── boot-watchdog.ts                          ~55
+    │   ├── session-bootstrapper.ts                   ~220
+    │   └── session-terminator.ts                     ~90
+    │
+    ├── runtime/                                       ← what happens during a live session
+    │   ├── agent-stream.consumer.ts                  ~230   ⭐ single event-switch source of truth
+    │   ├── turn.executor.ts                          ~125
+    │   └── user-interaction.coordinator.ts           ~135
+    │
+    └── api/                                           ← request-shaped entry & read operations
+        ├── message-dispatcher.ts                     ~165
+        ├── chat-state.assembler.ts                   ~145
+        └── workflow-hooks.ts                         ~85
+```
+
+### 5.4 Final test tree (mirrored at `tests/unit/`)
+
+Tests live in a **separate tree mirroring the production structure** — **not colocated** — per the repo convention ([tests/unit/infrastructure/services/interactive/](../../tests/unit/infrastructure/services/interactive/) already follows this pattern).
+
+```
+tests/unit/infrastructure/services/interactive/
+│
+├── interactive-session.service.test.ts                 (existing — reshape into facade test)
+├── feature-context.builder.test.ts                     (existing, unchanged)
+│
+├── core/
+│   ├── session-registry.test.ts
+│   ├── stream-event-dispatcher.test.ts
+│   └── session-persistence.test.ts                     ★ MUST HAVE: monotonic-clock regression test
+│                                                         (100 msgs under vi.setSystemTime() → 100 unique createdAt)
+│
+├── lifecycle/
+│   ├── agent-config.resolver.test.ts
+│   ├── boot-prompt.resolver.test.ts                    ← pure fn, easiest TDD cycle
+│   ├── boot-watchdog.test.ts                           ← fake-timers
+│   ├── session-bootstrapper.test.ts
+│   └── session-terminator.test.ts
+│
+├── runtime/
+│   ├── agent-stream.consumer.test.ts                   ★ critical: preserves await sequencing invariant
+│   ├── turn.executor.test.ts
+│   └── user-interaction.coordinator.test.ts
+│
+└── api/
+    ├── message-dispatcher.test.ts
+    ├── chat-state.assembler.test.ts
+    └── workflow-hooks.test.ts
+```
+
+Thirteen new test files. `settings-provider.adapter.ts` is a five-line passthrough and doesn't need its own spec — it's covered transitively by `agent-config.resolver.test.ts` which injects a fake `ISettingsProvider`.
+
+### 5.5 Composition (DI wiring order)
+
+```
+ISettingsProvider (new port)
+         │
+         ▼
+ settings-provider.adapter (lifecycle/)
+         │
+         ▼
+ AgentConfigResolver (lifecycle/)
+         │
+         ▼
+ SessionBootstrapper (lifecycle/) ──► needs BootPromptResolver, BootWatchdog,
+         │                             AgentStreamConsumer (runtime/)
+         ▼
+ InteractiveSessionService (facade, root)
+         ▲
+         │ composes:
+ ┌───────┴────────┬─────────────────┬────────────────────┐
+ │                │                 │                    │
+SessionRegistry   StreamEventDispatcher   SessionPersistence (singleton — owns the monotonic clock)
+         ▲
+         │
+ ┌───────┴───────┬──────────────┬─────────────────┬──────────────┬────────────┐
+ │               │              │                 │              │            │
+MessageDispatcher TurnExecutor  SessionTerminator ChatStateAssembler UserInteractionCoordinator WorkflowHooks
+ (api/)         (runtime/)      (lifecycle/)      (api/)         (runtime/)    (api/)
+```
+
+Only `InteractiveSessionService` (the facade) is registered as the singleton binding for `IInteractiveSessionService`. Every collaborator is constructed by hand at the existing `new InteractiveSessionService(...)` site — no DI-framework magic, just `new Foo(bar, baz)` calls in dependency order.
+
+---
+
+## 6. Outcome
+
+One ~200-line facade + 14 focused collaborators organised into four enforceable subfolders (`core/`, `lifecycle/`, `runtime/`, `api/`), each ≤230 lines, each independently testable against a mirrored test tree. The SDK stream event switch (biggest duplication source) exists in exactly one place. The monotonic-clock ordering invariant from the recent fix is preserved and codified by a targeted regression test. No component calls `getSettings` / `hasSettings` directly. Layering is enforced by ESLint, not by convention alone. Ready to ship incrementally behind the existing application port.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -325,6 +325,82 @@ export default tseslint.config(
   },
 
   // =============================================================================
+  // Interactive service subfolder layering
+  //
+  // Dependency direction: core/ ← lifecycle/ ← runtime/ ← api/ ← facade
+  // Inner layers must NOT import from outer layers.
+  // =============================================================================
+  {
+    files: ['packages/core/src/infrastructure/services/interactive/core/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '**/services/interactive/lifecycle/**',
+                '**/services/interactive/lifecycle/*',
+              ],
+              message:
+                'core/ must not import from lifecycle/. Dependency direction: core ← lifecycle ← runtime ← api.',
+            },
+            {
+              group: ['**/services/interactive/runtime/**', '**/services/interactive/runtime/*'],
+              message:
+                'core/ must not import from runtime/. Dependency direction: core ← lifecycle ← runtime ← api.',
+            },
+            {
+              group: ['**/services/interactive/api/**', '**/services/interactive/api/*'],
+              message:
+                'core/ must not import from api/. Dependency direction: core ← lifecycle ← runtime ← api.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['packages/core/src/infrastructure/services/interactive/lifecycle/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/services/interactive/runtime/**', '**/services/interactive/runtime/*'],
+              message:
+                'lifecycle/ must not import from runtime/. Dependency direction: core ← lifecycle ← runtime ← api.',
+            },
+            {
+              group: ['**/services/interactive/api/**', '**/services/interactive/api/*'],
+              message:
+                'lifecycle/ must not import from api/. Dependency direction: core ← lifecycle ← runtime ← api.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: ['packages/core/src/infrastructure/services/interactive/runtime/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/services/interactive/api/**', '**/services/interactive/api/*'],
+              message:
+                'runtime/ must not import from api/. Dependency direction: core ← lifecycle ← runtime ← api.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // =============================================================================
   // Prettier compatibility (must be last)
   // =============================================================================
   prettierConfig

--- a/packages/core/src/application/ports/output/services/index.ts
+++ b/packages/core/src/application/ports/output/services/index.ts
@@ -80,6 +80,7 @@ export type {
   ScaffoldProjectResult,
 } from './project-scaffold-service.interface.js';
 export type { IAgentAuthDetectorService } from './agent-auth-detector.interface.js';
+export type { ISettingsProvider } from './settings-provider.interface.js';
 export type { IDesktopNotifier } from './i-desktop-notifier.js';
 export type { IBrowserOpener } from './i-browser-opener.js';
 export type {

--- a/packages/core/src/application/ports/output/services/settings-provider.interface.ts
+++ b/packages/core/src/application/ports/output/services/settings-provider.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * Settings Provider (port)
+ *
+ * Read-only access to the global Shep settings for infrastructure
+ * services that need to resolve agent config, auth method, or
+ * concurrent-session caps without reaching into the singleton
+ * directly. Replaces the `getSettings()` / `hasSettings()` module-level
+ * accessors previously imported from infrastructure.
+ */
+
+import type { Settings } from '../../../../domain/generated/output.js';
+
+export interface ISettingsProvider {
+  /** Whether settings have been initialized (loaded from disk / DB). */
+  has(): boolean;
+  /** Returns the full resolved settings. Throws if `has()` is false. */
+  get(): Settings;
+}

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -30,6 +30,8 @@ import type { IAgentExecutorFactory } from '../../application/ports/output/agent
 import type { IFeatureRepository } from '../../application/ports/output/repositories/feature-repository.interface.js';
 import { InteractiveSessionService } from '../services/interactive/interactive-session.service.js';
 import { FeatureContextBuilder } from '../services/interactive/feature-context.builder.js';
+import { SessionRegistry } from '../services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '../services/interactive/core/stream-event-dispatcher.js';
 
 // Topic-grouped registration modules
 import { registerRepositories } from './modules/register-repositories.js';
@@ -106,13 +108,17 @@ export async function initializeContainer(): Promise<typeof container> {
   const interactiveMessageRepo = container.resolve<IInteractiveMessageRepository>(
     'IInteractiveMessageRepository'
   );
+  const sessionRegistry = new SessionRegistry();
+  const streamEventDispatcher = new StreamEventDispatcher(sessionRegistry);
   const interactiveSessionService = new InteractiveSessionService(
     interactiveSessionRepo,
     interactiveMessageRepo,
     container.resolve<IAgentExecutorFactory>('IAgentExecutorFactory'),
     container.resolve<IFeatureRepository>('IFeatureRepository'),
     new FeatureContextBuilder(),
-    workflowStepRepoBoot
+    workflowStepRepoBoot,
+    sessionRegistry,
+    streamEventDispatcher
   );
   container.registerInstance<IInteractiveSessionService>(
     'IInteractiveSessionService',

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -157,7 +157,8 @@ export async function initializeContainer(): Promise<typeof container> {
   const interactionCoordinator = new UserInteractionCoordinator(
     sessionPersistence,
     streamEventDispatcher,
-    logger
+    logger,
+    sessionRegistry
   );
   const bootstrapper = new SessionBootstrapper(
     interactiveSessionRepo,
@@ -175,7 +176,9 @@ export async function initializeContainer(): Promise<typeof container> {
     sessionRegistry,
     sessionPersistence,
     streamEventDispatcher,
-    logger
+    logger,
+    interactiveMessageRepo,
+    workflowStepRepoBoot
   );
   const turnExecutor = new TurnExecutor(
     interactiveSessionRepo,

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -32,6 +32,7 @@ import { InteractiveSessionService } from '../services/interactive/interactive-s
 import { FeatureContextBuilder } from '../services/interactive/feature-context.builder.js';
 import { SessionRegistry } from '../services/interactive/core/session-registry.js';
 import { StreamEventDispatcher } from '../services/interactive/core/stream-event-dispatcher.js';
+import { SessionPersistence } from '../services/interactive/core/session-persistence.js';
 
 // Topic-grouped registration modules
 import { registerRepositories } from './modules/register-repositories.js';
@@ -110,6 +111,16 @@ export async function initializeContainer(): Promise<typeof container> {
   );
   const sessionRegistry = new SessionRegistry();
   const streamEventDispatcher = new StreamEventDispatcher(sessionRegistry);
+  // SessionPersistence is a process-wide singleton so its monotonic
+  // `createdAt` counter is shared across every write. See
+  // `core/session-persistence.ts` for why strictly-increasing timestamps
+  // matter (tool_use / tool_result collisions).
+  const sessionPersistence = new SessionPersistence(
+    interactiveMessageRepo,
+    interactiveSessionRepo,
+    sessionRegistry,
+    streamEventDispatcher
+  );
   const interactiveSessionService = new InteractiveSessionService(
     interactiveSessionRepo,
     interactiveMessageRepo,
@@ -118,7 +129,8 @@ export async function initializeContainer(): Promise<typeof container> {
     new FeatureContextBuilder(),
     workflowStepRepoBoot,
     sessionRegistry,
-    streamEventDispatcher
+    streamEventDispatcher,
+    sessionPersistence
   );
   container.registerInstance<IInteractiveSessionService>(
     'IInteractiveSessionService',

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -33,6 +33,8 @@ import { FeatureContextBuilder } from '../services/interactive/feature-context.b
 import { SessionRegistry } from '../services/interactive/core/session-registry.js';
 import { StreamEventDispatcher } from '../services/interactive/core/stream-event-dispatcher.js';
 import { SessionPersistence } from '../services/interactive/core/session-persistence.js';
+import { SettingsProviderAdapter } from '../services/interactive/lifecycle/settings-provider.adapter.js';
+import { AgentConfigResolver } from '../services/interactive/lifecycle/agent-config.resolver.js';
 
 // Topic-grouped registration modules
 import { registerRepositories } from './modules/register-repositories.js';
@@ -121,6 +123,11 @@ export async function initializeContainer(): Promise<typeof container> {
     sessionRegistry,
     streamEventDispatcher
   );
+  // Settings-provider port + agent-config resolver. The adapter is the
+  // one legitimate place the `settings.service` singleton is called —
+  // everywhere else consults it through the injected port.
+  const settingsProvider = new SettingsProviderAdapter();
+  const agentConfigResolver = new AgentConfigResolver(settingsProvider);
   const interactiveSessionService = new InteractiveSessionService(
     interactiveSessionRepo,
     interactiveMessageRepo,
@@ -130,7 +137,8 @@ export async function initializeContainer(): Promise<typeof container> {
     workflowStepRepoBoot,
     sessionRegistry,
     streamEventDispatcher,
-    sessionPersistence
+    sessionPersistence,
+    agentConfigResolver
   );
   container.registerInstance<IInteractiveSessionService>(
     'IInteractiveSessionService',

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -36,6 +36,11 @@ import { SessionPersistence } from '../services/interactive/core/session-persist
 import { SettingsProviderAdapter } from '../services/interactive/lifecycle/settings-provider.adapter.js';
 import { AgentConfigResolver } from '../services/interactive/lifecycle/agent-config.resolver.js';
 import { AgentStreamConsumer } from '../services/interactive/runtime/agent-stream.consumer.js';
+import { BootPromptResolver } from '../services/interactive/lifecycle/boot-prompt.resolver.js';
+import { SessionBootstrapper } from '../services/interactive/lifecycle/session-bootstrapper.js';
+import { SessionTerminator } from '../services/interactive/lifecycle/session-terminator.js';
+import { TurnExecutor } from '../services/interactive/runtime/turn.executor.js';
+import { UserInteractionCoordinator } from '../services/interactive/runtime/user-interaction.coordinator.js';
 import type { ILogger } from '../../application/ports/output/services/logger.interface.js';
 
 // Topic-grouped registration modules
@@ -142,19 +147,55 @@ export async function initializeContainer(): Promise<typeof container> {
     error: (msg, meta) => console.error(`[shep] ${msg}`, meta ?? ''),
   };
   const streamConsumer = new AgentStreamConsumer(sessionPersistence, streamEventDispatcher, logger);
+  const featureRepository = container.resolve<IFeatureRepository>('IFeatureRepository');
+  const agentExecutorFactory = container.resolve<IAgentExecutorFactory>('IAgentExecutorFactory');
+  const featureContextBuilder = new FeatureContextBuilder();
+  const bootPromptResolver = new BootPromptResolver(featureRepository, featureContextBuilder);
+  const interactionCoordinator = new UserInteractionCoordinator(
+    sessionPersistence,
+    streamEventDispatcher,
+    logger
+  );
+  const bootstrapper = new SessionBootstrapper(
+    interactiveSessionRepo,
+    sessionRegistry,
+    sessionPersistence,
+    streamEventDispatcher,
+    bootPromptResolver,
+    streamConsumer,
+    agentExecutorFactory,
+    agentConfigResolver,
+    interactionCoordinator,
+    logger
+  );
+  const terminator = new SessionTerminator(
+    sessionRegistry,
+    sessionPersistence,
+    streamEventDispatcher,
+    logger
+  );
+  const turnExecutor = new TurnExecutor(
+    interactiveSessionRepo,
+    sessionRegistry,
+    sessionPersistence,
+    streamConsumer,
+    logger,
+    streamEventDispatcher
+  );
   const interactiveSessionService = new InteractiveSessionService(
     interactiveSessionRepo,
     interactiveMessageRepo,
-    container.resolve<IAgentExecutorFactory>('IAgentExecutorFactory'),
-    container.resolve<IFeatureRepository>('IFeatureRepository'),
-    new FeatureContextBuilder(),
+    featureRepository,
+    featureContextBuilder,
     workflowStepRepoBoot,
     sessionRegistry,
     streamEventDispatcher,
     sessionPersistence,
-    agentConfigResolver,
-    streamConsumer,
-    logger
+    logger,
+    bootstrapper,
+    terminator,
+    turnExecutor,
+    interactionCoordinator
   );
   container.registerInstance<IInteractiveSessionService>(
     'IInteractiveSessionService',

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -41,6 +41,9 @@ import { SessionBootstrapper } from '../services/interactive/lifecycle/session-b
 import { SessionTerminator } from '../services/interactive/lifecycle/session-terminator.js';
 import { TurnExecutor } from '../services/interactive/runtime/turn.executor.js';
 import { UserInteractionCoordinator } from '../services/interactive/runtime/user-interaction.coordinator.js';
+import { MessageDispatcher } from '../services/interactive/api/message-dispatcher.js';
+import { ChatStateAssembler } from '../services/interactive/api/chat-state.assembler.js';
+import { WorkflowHooks } from '../services/interactive/api/workflow-hooks.js';
 import type { ILogger } from '../../application/ports/output/services/logger.interface.js';
 
 // Topic-grouped registration modules
@@ -182,6 +185,22 @@ export async function initializeContainer(): Promise<typeof container> {
     logger,
     streamEventDispatcher
   );
+  const messageDispatcher = new MessageDispatcher(
+    interactiveSessionRepo,
+    interactiveMessageRepo,
+    sessionRegistry,
+    sessionPersistence,
+    bootstrapper,
+    terminator,
+    turnExecutor
+  );
+  const chatStateAssembler = new ChatStateAssembler(
+    interactiveMessageRepo,
+    interactiveSessionRepo,
+    workflowStepRepoBoot,
+    sessionRegistry
+  );
+  const workflowHooks = new WorkflowHooks(sessionRegistry, streamEventDispatcher);
   const interactiveSessionService = new InteractiveSessionService(
     interactiveSessionRepo,
     interactiveMessageRepo,
@@ -195,7 +214,10 @@ export async function initializeContainer(): Promise<typeof container> {
     bootstrapper,
     terminator,
     turnExecutor,
-    interactionCoordinator
+    interactionCoordinator,
+    messageDispatcher,
+    chatStateAssembler,
+    workflowHooks
   );
   container.registerInstance<IInteractiveSessionService>(
     'IInteractiveSessionService',

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -35,6 +35,8 @@ import { StreamEventDispatcher } from '../services/interactive/core/stream-event
 import { SessionPersistence } from '../services/interactive/core/session-persistence.js';
 import { SettingsProviderAdapter } from '../services/interactive/lifecycle/settings-provider.adapter.js';
 import { AgentConfigResolver } from '../services/interactive/lifecycle/agent-config.resolver.js';
+import { AgentStreamConsumer } from '../services/interactive/runtime/agent-stream.consumer.js';
+import type { ILogger } from '../../application/ports/output/services/logger.interface.js';
 
 // Topic-grouped registration modules
 import { registerRepositories } from './modules/register-repositories.js';
@@ -128,6 +130,18 @@ export async function initializeContainer(): Promise<typeof container> {
   // everywhere else consults it through the injected port.
   const settingsProvider = new SettingsProviderAdapter();
   const agentConfigResolver = new AgentConfigResolver(settingsProvider);
+
+  const logger: ILogger = {
+    // eslint-disable-next-line no-console
+    debug: (msg, meta) => console.debug(`[shep] ${msg}`, meta ?? ''),
+    // eslint-disable-next-line no-console
+    info: (msg, meta) => console.info(`[shep] ${msg}`, meta ?? ''),
+    // eslint-disable-next-line no-console
+    warn: (msg, meta) => console.warn(`[shep] ${msg}`, meta ?? ''),
+    // eslint-disable-next-line no-console
+    error: (msg, meta) => console.error(`[shep] ${msg}`, meta ?? ''),
+  };
+  const streamConsumer = new AgentStreamConsumer(sessionPersistence, streamEventDispatcher, logger);
   const interactiveSessionService = new InteractiveSessionService(
     interactiveSessionRepo,
     interactiveMessageRepo,
@@ -138,7 +152,9 @@ export async function initializeContainer(): Promise<typeof container> {
     sessionRegistry,
     streamEventDispatcher,
     sessionPersistence,
-    agentConfigResolver
+    agentConfigResolver,
+    streamConsumer,
+    logger
   );
   container.registerInstance<IInteractiveSessionService>(
     'IInteractiveSessionService',

--- a/packages/core/src/infrastructure/services/interactive/api/chat-state.assembler.ts
+++ b/packages/core/src/infrastructure/services/interactive/api/chat-state.assembler.ts
@@ -1,0 +1,134 @@
+/**
+ * ChatStateAssembler
+ *
+ * Pure read-side DTO assembly. Reads messages, session state, usage,
+ * turn statuses, pending interaction, and workflow steps from their
+ * respective stores and assembles the ChatState DTO.
+ *
+ * No mutations — every method is a pure projection.
+ *
+ * Extracted from `InteractiveSessionService` in Phase 6 of the strangler refactor.
+ * See `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import type { ChatState } from '../../../../application/ports/output/services/interactive-session-service.interface.js';
+import type { IInteractiveMessageRepository } from '../../../../application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { IInteractiveSessionRepository } from '../../../../application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { IWorkflowStepRepository } from '../../../../application/ports/output/repositories/workflow-step-repository.interface.js';
+import {
+  InteractiveSessionStatus,
+  WorkflowStepStatus,
+} from '../../../../domain/generated/output.js';
+import type { SessionRegistry } from '../core/session-registry.js';
+
+export class ChatStateAssembler {
+  constructor(
+    private readonly messageRepo: IInteractiveMessageRepository,
+    private readonly sessionRepo: IInteractiveSessionRepository,
+    private readonly workflowStepRepo: IWorkflowStepRepository,
+    private readonly registry: SessionRegistry
+  ) {}
+
+  async assemble(featureId: string): Promise<ChatState> {
+    // DB messages
+    const messages = await this.messageRepo.findByFeatureId(featureId);
+
+    // Find active in-memory session
+    const state = this.registry.findActiveStateForFeature(featureId);
+    let sessionStatus: string | null = null;
+    let streamingText: string | null = null;
+    let sessionInfo: ChatState['sessionInfo'] = null;
+
+    if (state) {
+      const dbSession = await this.sessionRepo.findById(state.sessionId);
+      sessionStatus = dbSession?.status ?? null;
+      if (state.currentAssistantBuffer) {
+        streamingText = state.currentAssistantBuffer;
+      }
+      // Resolve model display: explicit override > default
+      const displayModel = state.model ?? 'claude-sonnet-4-6';
+
+      const usage = await this.sessionRepo.getUsage(state.sessionId);
+      sessionInfo = {
+        pid: null, // SDK manages process internally
+        sessionId: state.agentSessionId ?? state.sessionId,
+        model: displayModel,
+        startedAt: dbSession?.startedAt
+          ? new Date(dbSession.startedAt as unknown as string).toISOString()
+          : new Date().toISOString(),
+        lastActivityAt: dbSession?.lastActivityAt
+          ? new Date(dbSession.lastActivityAt as unknown as string).toISOString()
+          : new Date().toISOString(),
+        totalCostUsd: usage?.totalCostUsd ?? null,
+        totalInputTokens: usage?.totalInputTokens ?? null,
+        totalOutputTokens: usage?.totalOutputTokens ?? null,
+      };
+    } else {
+      // No in-memory state — check DB for last session (e.g. after server restart)
+      const latest = await this.sessionRepo.findByFeatureId(featureId);
+      if (latest) {
+        sessionStatus = latest.status as string;
+        if (
+          latest.status !== InteractiveSessionStatus.stopped &&
+          latest.status !== InteractiveSessionStatus.error
+        ) {
+          const latestUsage = await this.sessionRepo.getUsage(latest.id);
+          sessionInfo = {
+            pid: null,
+            sessionId: latest.id,
+            model: null,
+            startedAt: latest.startedAt
+              ? new Date(latest.startedAt as unknown as string).toISOString()
+              : new Date().toISOString(),
+            lastActivityAt: latest.lastActivityAt
+              ? new Date(latest.lastActivityAt as unknown as string).toISOString()
+              : new Date().toISOString(),
+            totalCostUsd: latestUsage?.totalCostUsd ?? null,
+            totalInputTokens: latestUsage?.totalInputTokens ?? null,
+            totalOutputTokens: latestUsage?.totalOutputTokens ?? null,
+          };
+        }
+      }
+    }
+
+    // Resolve turn status from DB
+    let turnStatus = 'idle';
+    const activeState = state;
+    if (activeState) {
+      const statuses = await this.sessionRepo.getTurnStatuses([featureId]);
+      turnStatus = statuses.get(featureId) ?? 'idle';
+    } else {
+      const latest = await this.sessionRepo.findByFeatureId(featureId);
+      if (latest) {
+        const statuses = await this.sessionRepo.getTurnStatuses([featureId]);
+        turnStatus = statuses.get(featureId) ?? 'idle';
+      }
+    }
+
+    // Include pending interaction if one exists
+    const pendingInteraction = state?.pendingInteraction ?? null;
+
+    // Workflow view — derived entirely from the DB
+    const workflowSteps = await this.workflowStepRepo.listByFeature(featureId);
+    let workflow: ChatState['workflow'] = null;
+    if (workflowSteps.length > 0) {
+      const running = workflowSteps.find((s) => s.status === WorkflowStepStatus.running);
+      workflow = {
+        workflowId: workflowSteps[0].workflowId,
+        steps: workflowSteps,
+        currentStepId: running?.id ?? null,
+      };
+      if (running) turnStatus = 'processing';
+    }
+
+    return {
+      messages,
+      sessionStatus,
+      streamingText,
+      sessionInfo,
+      turnStatus,
+      pendingInteraction,
+      workflow,
+    };
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/api/message-dispatcher.ts
+++ b/packages/core/src/infrastructure/services/interactive/api/message-dispatcher.ts
@@ -1,0 +1,162 @@
+/**
+ * MessageDispatcher
+ *
+ * Handles incoming user messages — the routing logic that decides whether to
+ * start a new session, queue to an existing one, or restart on model/agent change.
+ *
+ * Extracted from `InteractiveSessionService` in Phase 6 of the strangler refactor.
+ * See `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import * as crypto from 'node:crypto';
+import type { IInteractiveSessionRepository } from '../../../../application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { IInteractiveMessageRepository } from '../../../../application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { InteractiveMessage } from '../../../../domain/generated/output.js';
+import {
+  InteractiveSessionStatus,
+  InteractiveMessageRole,
+} from '../../../../domain/generated/output.js';
+import type { SessionRegistry } from '../core/session-registry.js';
+import type { SessionPersistence } from '../core/session-persistence.js';
+import type { SessionBootstrapper } from '../lifecycle/session-bootstrapper.js';
+import type { SessionTerminator } from '../lifecycle/session-terminator.js';
+import type { TurnExecutor } from '../runtime/turn.executor.js';
+
+export class MessageDispatcher {
+  constructor(
+    private readonly sessionRepo: IInteractiveSessionRepository,
+    private readonly messageRepo: IInteractiveMessageRepository,
+    private readonly registry: SessionRegistry,
+    private readonly persistence: SessionPersistence,
+    private readonly bootstrapper: SessionBootstrapper,
+    private readonly terminator: SessionTerminator,
+    private readonly turnExecutor: TurnExecutor
+  ) {}
+
+  /**
+   * Send a message to an already-identified session (by session ID).
+   * Validates session is ready, persists user message, enqueues turn.
+   */
+  async sendMessage(sessionId: string, content: string): Promise<InteractiveMessage> {
+    const dbSession = await this.sessionRepo.findById(sessionId);
+    if (!dbSession || dbSession.status !== InteractiveSessionStatus.ready) {
+      throw new Error(`Session ${sessionId} is not ready — cannot send message`);
+    }
+
+    const state = this.registry.get(sessionId);
+    if (!state) {
+      throw new Error(`Session ${sessionId} is not ready — cannot send message`);
+    }
+
+    // Persist user message
+    const now = new Date();
+    const message: InteractiveMessage = {
+      id: crypto.randomUUID(),
+      featureId: state.featureId,
+      sessionId,
+      role: InteractiveMessageRole.user,
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.persistence.persistMessage(message);
+
+    await this.sessionRepo.updateLastActivity(sessionId, now);
+
+    // Delegate turn execution to TurnExecutor (guarded: one turn at a time)
+    void this.turnExecutor.enqueueTurn(state, content);
+
+    return message;
+  }
+
+  /**
+   * Feature-scoped send — the primary entry point used by the UI.
+   * Routes to the appropriate action: boot new session, enqueue to ready session,
+   * queue to booting session, or restart on model/agent change.
+   */
+  async sendUserMessage(
+    featureId: string,
+    content: string,
+    worktreePath: string,
+    model?: string,
+    agentType?: string,
+    systemPrompt?: string,
+    agentKickoffOverride?: string,
+    persistUserMessage = true
+  ): Promise<InteractiveMessage> {
+    // 1. Persist user message to DB immediately — this is the source
+    //    of truth. SKIPPED when `persistUserMessage === false`, which
+    //    the application-creation flow uses to boot the session on top
+    //    of a user message it already wrote in the foreground.
+    const now = new Date();
+    const userMsg: InteractiveMessage = {
+      id: crypto.randomUUID(),
+      featureId,
+      role: InteractiveMessageRole.user,
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (persistUserMessage) {
+      await this.persistence.persistMessage(userMsg);
+    }
+
+    // 2. Find active session for this feature
+    let state = this.registry.findActiveStateForFeature(featureId);
+
+    // If the caller requested a different model/agent than the running session,
+    // silently stop the current session so a new one boots with the new config.
+    if (state && model && state.model !== model) {
+      await this.terminator.stop(state.sessionId);
+      this.registry.deleteStoppedAgentSessionId(featureId);
+      state = undefined;
+    } else if (state && agentType && state.agentType !== agentType) {
+      await this.terminator.stop(state.sessionId);
+      this.registry.deleteStoppedAgentSessionId(featureId);
+      state = undefined;
+    }
+
+    if (state) {
+      const dbSession = await this.sessionRepo.findById(state.sessionId);
+      if (dbSession?.status === InteractiveSessionStatus.ready) {
+        // Session ready — send to agent (guarded: one turn at a time)
+        await this.sessionRepo.updateLastActivity(state.sessionId, now);
+        void this.turnExecutor.enqueueTurn(state, content);
+      } else if (dbSession?.status === InteractiveSessionStatus.booting) {
+        // Session booting — queue the message
+        state.pendingUserContent = content;
+      }
+    } else {
+      // No in-memory session — check DB for an orphaned active session (e.g. after
+      // service restart / hot-reload) and mark it stopped before booting a new one.
+      const dbSession = await this.sessionRepo.findByFeatureId(featureId);
+      if (
+        dbSession &&
+        (dbSession.status === InteractiveSessionStatus.ready ||
+          dbSession.status === InteractiveSessionStatus.booting)
+      ) {
+        await this.persistence.updateSessionStatusAndNotify(
+          dbSession.id,
+          featureId,
+          InteractiveSessionStatus.stopped,
+          new Date()
+        );
+      }
+
+      // Boot a new session. Pass the first-turn content as `initialUserMessage`
+      // so it's written to the session state atomically BEFORE completeBootAsync
+      // is dispatched.
+      const firstTurnContent = agentKickoffOverride ?? content;
+      await this.bootstrapper.startSession(
+        featureId,
+        worktreePath,
+        model,
+        agentType,
+        systemPrompt,
+        firstTurnContent
+      );
+    }
+
+    return userMsg;
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/api/workflow-hooks.ts
+++ b/packages/core/src/infrastructure/services/interactive/api/workflow-hooks.ts
@@ -1,0 +1,62 @@
+/**
+ * WorkflowHooks
+ *
+ * Orchestrator-facing hooks for workflow step coordination.
+ * Exposes setActiveStep, clearActiveStep, notifyWorkflowStep, and waitForTurnDone.
+ *
+ * Extracted from `InteractiveSessionService` in Phase 6 of the strangler refactor.
+ * See `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import type { WorkflowStep } from '../../../../domain/generated/output.js';
+import type { SessionRegistry } from '../core/session-registry.js';
+import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
+
+export class WorkflowHooks {
+  constructor(
+    private readonly registry: SessionRegistry,
+    private readonly dispatcher: StreamEventDispatcher
+  ) {}
+
+  setActiveStep(featureId: string, stepId: string): void {
+    this.registry.setActiveStep(featureId, stepId);
+  }
+
+  clearActiveStep(featureId: string): void {
+    this.registry.clearActiveStep(featureId);
+  }
+
+  notifyWorkflowStep(featureId: string, step: WorkflowStep): void {
+    this.dispatcher.notifyByFeatureId(featureId, {
+      delta: '',
+      done: false,
+      workflowStep: step,
+    });
+  }
+
+  /**
+   * Resolves the next time any subscriber receives a `done: true`
+   * chunk for the given feature.
+   */
+  async waitForTurnDone(featureId: string, signal?: AbortSignal): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(new Error('waitForTurnDone aborted'));
+        return;
+      }
+      const unsubscribe = this.dispatcher.subscribeByFeature(featureId, (chunk) => {
+        if (chunk.done) {
+          unsubscribe();
+          signal?.removeEventListener('abort', onAbort);
+          resolve();
+        }
+      });
+      const onAbort = () => {
+        unsubscribe();
+        signal?.removeEventListener('abort', onAbort);
+        reject(new Error('waitForTurnDone aborted'));
+      };
+      signal?.addEventListener('abort', onAbort);
+    });
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/core/session-persistence.ts
+++ b/packages/core/src/infrastructure/services/interactive/core/session-persistence.ts
@@ -167,4 +167,21 @@ export class SessionPersistence {
       turnStatus,
     });
   }
+
+  /**
+   * Mark a feature scope as read (turn status → idle).
+   * Uses the active in-memory session when available; falls back to the
+   * most recent DB session for already-stopped scopes.
+   */
+  async markRead(featureId: string): Promise<void> {
+    const state = this.registry.findActiveStateForFeature(featureId);
+    if (state) {
+      void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+      return;
+    }
+    const latest = await this.sessionRepo.findByFeatureId(featureId);
+    if (latest) {
+      void this.updateTurnStatusAndNotify(latest.id, featureId, 'idle');
+    }
+  }
 }

--- a/packages/core/src/infrastructure/services/interactive/core/session-persistence.ts
+++ b/packages/core/src/infrastructure/services/interactive/core/session-persistence.ts
@@ -1,0 +1,170 @@
+/**
+ * Session Persistence
+ *
+ * Every DB mutation that must also notify SSE subscribers flows through
+ * this collaborator. Owns the monotonic message clock — the one piece
+ * of process-wide state that guarantees `createdAt` strictly increases
+ * across consecutive persists, even when `Date.now()` returns the same
+ * millisecond for two rapid writes.
+ *
+ * ## Why the monotonic clock matters
+ *
+ * `Date.now()` has millisecond precision. The Claude SDK routinely
+ * fires `tool_use` + `tool_result` (and their paired `persistToolEvent`
+ * calls) inside the same millisecond, which leaves the DB with two
+ * rows whose `created_at` are identical. `ORDER BY created_at ASC` then
+ * returns them in insert-race order and breaks the tool -> Output
+ * pairing in `StepTracker.classifyMessages` on the frontend. By pinning
+ * each subsequent timestamp to `max(Date.now(), lastTs + 1)` we get a
+ * strictly-increasing sequence under burst writes.
+ *
+ * Because the counter is process-wide (NOT per-session), this class
+ * MUST be registered as a singleton in the DI container so one
+ * instance guards every write.
+ */
+
+import * as crypto from 'node:crypto';
+
+import type { IInteractiveMessageRepository } from '../../../../application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { IInteractiveSessionRepository } from '../../../../application/ports/output/repositories/interactive-session-repository.interface.js';
+import type {
+  InteractiveMessage,
+  InteractiveSessionStatus,
+} from '../../../../domain/generated/output.js';
+import { InteractiveMessageRole } from '../../../../domain/generated/output.js';
+import type { SessionRegistry, SessionState } from './session-registry.js';
+import type { StreamEventDispatcher } from './stream-event-dispatcher.js';
+
+export class SessionPersistence {
+  /**
+   * Process-wide monotonic counter. See file header for the invariant.
+   * Kept private so only `nextMessageDate` can mutate it.
+   */
+  private lastMessageTs = 0;
+
+  constructor(
+    private readonly messageRepo: IInteractiveMessageRepository,
+    private readonly sessionRepo: IInteractiveSessionRepository,
+    private readonly registry: SessionRegistry,
+    private readonly dispatcher: StreamEventDispatcher
+  ) {}
+
+  /**
+   * Produce the next monotonic timestamp for a persisted interactive
+   * message. Guarantees a strictly-increasing sequence even when two
+   * calls happen in the same millisecond.
+   */
+  private nextMessageDate(): Date {
+    const wallclock = Date.now();
+    const next = wallclock > this.lastMessageTs ? wallclock : this.lastMessageTs + 1;
+    this.lastMessageTs = next;
+    return new Date(next);
+  }
+
+  /**
+   * Persist a message AND notify subscribers. Use everywhere instead of
+   * calling `messageRepo.create` directly. The current active workflow
+   * step for the feature (if any) is stamped onto the row so every
+   * message is grouped under the right step card in the UI.
+   */
+  async persistMessage(message: InteractiveMessage): Promise<void> {
+    const activeStepId = this.registry.getActiveStep(message.featureId);
+    const tagged: InteractiveMessage =
+      message.stepId || !activeStepId ? message : { ...message, stepId: activeStepId };
+    await this.messageRepo.create(tagged);
+    this.dispatcher.notifyByFeatureId(tagged.featureId, {
+      delta: '',
+      done: false,
+      message: tagged,
+    });
+  }
+
+  /**
+   * Persist whatever text has accumulated in `state.currentAssistantBuffer`
+   * as its own assistant message, then clear the buffer. Called right
+   * before each tool event so the DB history interleaves agent prose
+   * with tool calls. No-op if the buffer is empty or whitespace-only.
+   */
+  async flushAssistantBuffer(state: SessionState): Promise<void> {
+    const buffered = state.currentAssistantBuffer.trim();
+    if (!buffered) return;
+    state.currentAssistantBuffer = '';
+    const now = this.nextMessageDate();
+    const msg: InteractiveMessage = {
+      id: crypto.randomUUID(),
+      featureId: state.featureId,
+      sessionId: state.sessionId,
+      role: InteractiveMessageRole.assistant,
+      content: buffered,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.persistMessage(msg);
+  }
+
+  /**
+   * Persist a tool/system event as its own assistant message in the DB.
+   * Flushes any pending assistant prose first so the chat thread
+   * interleaves narration with tool calls instead of collapsing all of
+   * a step's narration into one trailing blob.
+   *
+   * Non-critical: errors are swallowed so a transient DB hiccup on a
+   * tool event never fails an in-flight turn.
+   */
+  async persistToolEvent(state: SessionState, label: string, detail?: string): Promise<void> {
+    try {
+      await this.flushAssistantBuffer(state);
+      const content = detail ? `**${label}** \`${detail}\`` : `**${label}**`;
+      const now = this.nextMessageDate();
+      const msg: InteractiveMessage = {
+        id: crypto.randomUUID(),
+        featureId: state.featureId,
+        sessionId: state.sessionId,
+        role: InteractiveMessageRole.assistant,
+        content,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await this.persistMessage(msg);
+    } catch {
+      // Non-critical — don't fail the turn for a tool event
+    }
+  }
+
+  /**
+   * Update session status AND notify subscribers. Passes `endedAt` to
+   * the repo only when supplied so call-arity matches the legacy
+   * two-argument shape (keeps existing test expectations happy).
+   */
+  async updateSessionStatusAndNotify(
+    sessionId: string,
+    featureId: string,
+    status: InteractiveSessionStatus,
+    endedAt?: Date
+  ): Promise<void> {
+    if (endedAt === undefined) {
+      await this.sessionRepo.updateStatus(sessionId, status);
+    } else {
+      await this.sessionRepo.updateStatus(sessionId, status, endedAt);
+    }
+    this.dispatcher.notifyByFeatureId(featureId, {
+      delta: '',
+      done: false,
+      sessionStatus: status,
+    });
+  }
+
+  /** Update turn status AND notify subscribers. */
+  async updateTurnStatusAndNotify(
+    sessionId: string,
+    featureId: string,
+    turnStatus: string
+  ): Promise<void> {
+    await this.sessionRepo.updateTurnStatus(sessionId, turnStatus);
+    this.dispatcher.notifyByFeatureId(featureId, {
+      delta: '',
+      done: false,
+      turnStatus,
+    });
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/core/session-registry.ts
+++ b/packages/core/src/infrastructure/services/interactive/core/session-registry.ts
@@ -1,0 +1,135 @@
+/**
+ * Session Registry
+ *
+ * Pure in-memory state container for the interactive session service.
+ * Owns three maps:
+ *
+ * 1. `sessions`                 — live session state indexed by sessionId.
+ * 2. `stoppedAgentSessionIds`   — agent SDK session ids cached after a
+ *    session stops so the next boot can resume the same SDK conversation.
+ * 3. `activeStepByFeature`      — currently-active workflow step id per
+ *    feature scope, consulted by `persistMessage` so every row is tagged
+ *    with the right `stepId`.
+ *
+ * No business logic. No repo access. No logger. No imports from the
+ * application layer beyond the `StreamChunk` / `UnsubscribeFn` types
+ * that `SessionState` needs (and those are type-only).
+ */
+
+import type {
+  StreamChunk,
+  UnsubscribeFn as _UnsubscribeFn,
+} from '../../../../application/ports/output/services/interactive-session-service.interface.js';
+import type {
+  InteractiveAgentSessionHandle,
+  UserInteractionData,
+} from '../../../../application/ports/output/agents/interactive-agent-executor.interface.js';
+
+/** In-memory state for a single live session. */
+export interface SessionState {
+  sessionId: string;
+  featureId: string;
+  worktreePath: string;
+  /** Agent SDK session handle — null until session is created. */
+  handle: InteractiveAgentSessionHandle | null;
+  /** Agent SDK session ID for resumption across service restarts. */
+  agentSessionId?: string;
+  /** Accumulates assistant text between user turns for persistence. */
+  currentAssistantBuffer: string;
+  /** Accumulates tool events during a turn for rich message persistence. */
+  toolEventsLog: string[];
+  /** Subscriber callbacks for real-time stdout chunk forwarding. */
+  subscribers: Set<(chunk: StreamChunk) => void>;
+  /** User message content queued while session boots. */
+  pendingUserContent?: string;
+  /** Model override for the agent process (e.g. 'claude-sonnet-4-6'). */
+  model?: string;
+  /** Agent type for this session. */
+  agentType?: string;
+  /**
+   * Per-scope system prompt for the agent SDK. When set, it replaces
+   * the default feature-context prompt — lets Feature / Repository /
+   * Application / Global chats each supply their own instructions.
+   * Caller-owned: the session service never infers or modifies this.
+   */
+  systemPrompt?: string;
+  /** AbortController to cancel active stream iteration on stop. */
+  streamAbort?: AbortController;
+  /** Whether a turn is currently executing (prevents concurrent turns). */
+  turnInProgress: boolean;
+  /** Queue of user messages waiting to be sent after the current turn completes. */
+  turnQueue: string[];
+  /** Pending user interaction (AskUserQuestion) — agent stream is paused, waiting for response. */
+  pendingInteraction: UserInteractionData | null;
+  /** Resolver for the pending interaction Promise — call to resume the agent. */
+  pendingInteractionResolver: ((answers: Record<string, string>) => void) | null;
+}
+
+/**
+ * Plain in-memory state container. Methods are typed delegates over
+ * the underlying `Map`s plus a few convenience lookups.
+ */
+export class SessionRegistry {
+  private readonly sessions = new Map<string, SessionState>();
+  private readonly stoppedAgentSessionIds = new Map<string, string>();
+  private readonly activeStepByFeature = new Map<string, string>();
+
+  // ── Session state ──
+
+  get(sessionId: string): SessionState | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  set(sessionId: string, state: SessionState): void {
+    this.sessions.set(sessionId, state);
+  }
+
+  delete(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  has(sessionId: string): boolean {
+    return this.sessions.has(sessionId);
+  }
+
+  values(): IterableIterator<SessionState> {
+    return this.sessions.values();
+  }
+
+  /** First in-memory state whose `featureId` matches, or undefined. */
+  findActiveStateForFeature(featureId: string): SessionState | undefined {
+    for (const state of this.sessions.values()) {
+      if (state.featureId === featureId) return state;
+    }
+    return undefined;
+  }
+
+  // ── Stopped agent session id cache ──
+
+  cacheStoppedAgentSessionId(featureId: string, agentSessionId: string): void {
+    this.stoppedAgentSessionIds.set(featureId, agentSessionId);
+  }
+
+  /** Read-only access — does NOT remove the cached entry. */
+  takeStoppedAgentSessionId(featureId: string): string | undefined {
+    return this.stoppedAgentSessionIds.get(featureId);
+  }
+
+  deleteStoppedAgentSessionId(featureId: string): void {
+    this.stoppedAgentSessionIds.delete(featureId);
+  }
+
+  // ── Active workflow step tracking ──
+
+  setActiveStep(featureId: string, stepId: string): void {
+    this.activeStepByFeature.set(featureId, stepId);
+  }
+
+  clearActiveStep(featureId: string): void {
+    this.activeStepByFeature.delete(featureId);
+  }
+
+  getActiveStep(featureId: string): string | undefined {
+    return this.activeStepByFeature.get(featureId);
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/core/stream-event-dispatcher.ts
+++ b/packages/core/src/infrastructure/services/interactive/core/stream-event-dispatcher.ts
@@ -1,0 +1,112 @@
+/**
+ * Stream Event Dispatcher
+ *
+ * Pure pub/sub fan-out for interactive session stream chunks. Owns two
+ * subscriber maps:
+ *
+ * 1. `featureSubscribers` — per-feature subscribers that survive session
+ *    restarts (SSE connections live here so they keep receiving events
+ *    from a freshly-booted session after the old one died).
+ * 2. `globalSubscribers`  — subscribers that receive every chunk from
+ *    every session tagged with its feature scope key. Used by the
+ *    global turn-status SSE endpoint so the sidebar can track all
+ *    active sessions without polling.
+ *
+ * Session-level subscribers still live on `SessionState.subscribers`
+ * (they're tied to session lifetime), and `notify(state, chunk)` reads
+ * them off the state passed in. The injected `SessionRegistry` dep is
+ * reserved for `subscribeSession` which must resolve the state by id.
+ *
+ * No DB, no persistence, no logging. Just subscriber lists.
+ */
+
+import type {
+  StreamChunk,
+  UnsubscribeFn,
+} from '../../../../application/ports/output/services/interactive-session-service.interface.js';
+import type { SessionRegistry, SessionState } from './session-registry.js';
+
+type SessionChunkHandler = (chunk: StreamChunk) => void;
+type GlobalChunkHandler = (featureId: string, chunk: StreamChunk) => void;
+
+export class StreamEventDispatcher {
+  private readonly featureSubscribers = new Map<string, Set<SessionChunkHandler>>();
+  private readonly globalSubscribers = new Set<GlobalChunkHandler>();
+
+  constructor(private readonly registry: SessionRegistry) {}
+
+  /**
+   * Subscribe to a specific live session by sessionId. The callback is
+   * appended to the `SessionState.subscribers` set and is removed when
+   * the session is deleted from the registry (session-bound lifetime).
+   */
+  subscribeSession(sessionId: string, onChunk: SessionChunkHandler): UnsubscribeFn {
+    const state = this.registry.get(sessionId);
+    if (!state) {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return () => {};
+    }
+    state.subscribers.add(onChunk);
+    return () => state.subscribers.delete(onChunk);
+  }
+
+  /**
+   * Subscribe at the feature level so the callback survives session
+   * restarts. When a session dies (idle timeout, error) and a new one
+   * boots, SSE connections subscribed here keep receiving events from
+   * the new session automatically.
+   */
+  subscribeByFeature(featureId: string, onChunk: SessionChunkHandler): UnsubscribeFn {
+    let subs = this.featureSubscribers.get(featureId);
+    if (!subs) {
+      subs = new Set();
+      this.featureSubscribers.set(featureId, subs);
+    }
+    subs.add(onChunk);
+    return () => {
+      subs!.delete(onChunk);
+      if (subs!.size === 0) {
+        this.featureSubscribers.delete(featureId);
+      }
+    };
+  }
+
+  /**
+   * Subscribe to every chunk emitted by every session, tagged with the
+   * feature scope key so the consumer can multiplex across all active
+   * sessions (global turn-status SSE endpoint).
+   */
+  subscribeAll(onChunk: GlobalChunkHandler): UnsubscribeFn {
+    this.globalSubscribers.add(onChunk);
+    return () => {
+      this.globalSubscribers.delete(onChunk);
+    };
+  }
+
+  /**
+   * Dispatch a chunk to all subscribers for a session — session-level,
+   * feature-level, and global. Use whenever `SessionState` is in scope.
+   */
+  notify(state: SessionState, chunk: StreamChunk): void {
+    state.subscribers.forEach((sub) => sub(chunk));
+    const featureSubs = this.featureSubscribers.get(state.featureId);
+    if (featureSubs) {
+      featureSubs.forEach((sub) => sub(chunk));
+    }
+    this.globalSubscribers.forEach((sub) => sub(state.featureId, chunk));
+  }
+
+  /**
+   * Dispatch a chunk to feature-level subscribers and global subscribers
+   * only, for cases where no in-memory session state is available
+   * (e.g. while persisting the user message before cold-boot — session
+   * subscribers don't exist yet at that point).
+   */
+  notifyByFeatureId(featureId: string, chunk: StreamChunk): void {
+    const featureSubs = this.featureSubscribers.get(featureId);
+    if (featureSubs) {
+      featureSubs.forEach((sub) => sub(chunk));
+    }
+    this.globalSubscribers.forEach((sub) => sub(featureId, chunk));
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -42,18 +42,9 @@ import type { SessionRegistry, SessionState } from './core/session-registry.js';
 import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
 import type { SessionPersistence } from './core/session-persistence.js';
 import type { AgentConfigResolver } from './lifecycle/agent-config.resolver.js';
-
-/**
- * Boot-phase watchdog: how long the agent is allowed to go WITHOUT
- * emitting any stream event (delta / tool_use / tool_result / status)
- * before we consider the boot stuck and abort it.
- *
- * This is an IDLE timer, not a wall-clock budget: each event received
- * resets it. That's essential for application-creation flows where the
- * first turn legitimately takes many minutes (scaffold + install + build
- * a whole project). A fixed wall-clock budget would kill those mid-way.
- */
-const BOOT_IDLE_TIMEOUT_MS = 120_000;
+import type { ILogger } from '../../../application/ports/output/services/logger.interface.js';
+import { BootWatchdog } from './lifecycle/boot-watchdog.js';
+import { type AgentStreamConsumer } from './runtime/agent-stream.consumer.js';
 
 /**
  * Core service managing interactive agent session lifecycles.
@@ -81,7 +72,9 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     private readonly registry: SessionRegistry,
     private readonly dispatcher: StreamEventDispatcher,
     private readonly persistence: SessionPersistence,
-    private readonly agentConfigResolver: AgentConfigResolver
+    private readonly agentConfigResolver: AgentConfigResolver,
+    private readonly streamConsumer: AgentStreamConsumer,
+    private readonly logger: ILogger
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -304,162 +297,65 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       // Send the boot prompt and iterate stream for the greeting
       await handle.send(bootPrompt);
 
-      // No longer needed as a local — delta text is accumulated into
-      // `state.currentAssistantBuffer` and flushed inline alongside
-      // tool events via `flushAssistantBuffer`.
       const bootAbort = new AbortController();
       state.streamAbort = bootAbort;
 
       // Idle watchdog: reset on every event. If the agent goes silent
-      // for longer than BOOT_IDLE_TIMEOUT_MS, abort the boot. This is
-      // NOT a wall-clock budget — long first turns (full project
+      // for longer than BootWatchdog.IDLE_TIMEOUT_MS, abort the boot.
+      // This is NOT a wall-clock budget — long first turns (full project
       // scaffold + install + build) are fine as long as the stream
       // keeps producing events.
-      let bootTimeout: NodeJS.Timeout = setTimeout(() => {
-        bootAbort.abort();
-      }, BOOT_IDLE_TIMEOUT_MS);
-      const bumpBootWatchdog = () => {
-        clearTimeout(bootTimeout);
-        bootTimeout = setTimeout(() => {
-          bootAbort.abort();
-        }, BOOT_IDLE_TIMEOUT_MS);
-      };
+      const watchdog = new BootWatchdog();
+      watchdog.start(() => bootAbort.abort());
 
+      let result;
       try {
-        for await (const event of handle.stream()) {
-          if (bootAbort.signal.aborted) {
-            throw new Error(
-              `Agent boot stalled for ${BOOT_IDLE_TIMEOUT_MS / 1000}s with no stream activity`
-            );
-          }
-
-          // Any event = proof of life. Reset the boot watchdog so a
-          // long-running first turn (full project scaffold) isn't
-          // killed as long as the stream keeps producing events.
-          bumpBootWatchdog();
-
-          switch (event.type) {
-            case 'delta':
-              if (event.content) {
-                state.currentAssistantBuffer += event.content;
-                this.dispatcher.notify(state, { delta: event.content, done: false });
-              }
-              break;
-
-            case 'thinking':
-              if (event.content) {
-                await this.persistence.persistToolEvent(state, 'Thinking', event.content);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: 'Thinking…',
-                  activity: { kind: 'thinking', label: 'Thinking', detail: event.content },
-                });
-              }
-              break;
-
-            case 'tool_use':
-              if (event.label) {
-                const toolLabel = event.label;
-                const toolDetail = event.detail;
-                await this.persistence.persistToolEvent(state, toolLabel, toolDetail);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Using tool: ${toolLabel}`,
-                  activity: { kind: 'tool_use', label: toolLabel, detail: toolDetail },
-                });
-              }
-              break;
-
-            case 'tool_result':
-              if (event.label) {
-                const resultLabel = event.label;
-                const resultDetail = event.detail;
-                await this.persistence.persistToolEvent(state, resultLabel, resultDetail);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Completed: ${resultLabel}`,
-                  activity: { kind: 'tool_result', label: resultLabel, detail: resultDetail },
-                });
-              }
-              break;
-
-            case 'status':
-              if (event.content) {
-                const statusContent = event.content;
-                this.dispatcher.notify(state, { delta: '', done: false, log: statusContent });
-              }
-              break;
-
-            case 'done': {
-              // All delta text is persisted incrementally via
-              // `flushAssistantBuffer` inside `persistToolEvent`, so by
-              // the time `done` fires the buffer only holds the trailing
-              // prose that came after the last tool call (often the
-              // final step confirmation). Flush it here as its own
-              // message — persisting `event.content`/`greetingText`
-              // would duplicate everything we already flushed between
-              // tools.
-              await this.persistence.flushAssistantBuffer(state);
-
-              // Capture the SDK session ID (available after first message exchange)
-              const sdkSessionId = handle.sessionId;
-              if (sdkSessionId) {
-                // Detect CWD mismatch: if we tried to resume but got a different
-                // session ID, the SDK silently created a fresh session (typically
-                // because the cwd changed or session JSONL was lost).
-                if (previousAgentSessionId && sdkSessionId !== previousAgentSessionId) {
-                  // eslint-disable-next-line no-console
-                  console.warn(
-                    `[InteractiveSession] Session resume mismatch for feature ${featureId}: ` +
-                      `expected ${previousAgentSessionId}, got ${sdkSessionId}. ` +
-                      `SDK created a fresh session (likely cwd changed or session expired).`
-                  );
-                }
-                state.agentSessionId = sdkSessionId;
-                // Persist to DB so it survives service restarts
-                void this.sessionRepo.updateAgentSessionId(state.sessionId, sdkSessionId);
-              }
-
-              await this.persistence.updateSessionStatusAndNotify(
-                state.sessionId,
-                state.featureId,
-                InteractiveSessionStatus.ready
-              );
-
-              // If there's a pending user message, the next turn will set 'processing'.
-              // Otherwise boot greeting is expected — mark idle.
-              if (!state.pendingUserContent) {
-                void this.persistence.updateTurnStatusAndNotify(
-                  state.sessionId,
-                  state.featureId,
-                  'idle'
-                );
-              }
-
-              state.currentAssistantBuffer = '';
-              state.toolEventsLog = [];
-
-              // Notify subscribers of end-of-turn
-              this.dispatcher.notify(state, { delta: '', done: true });
-              return; // Boot complete
-            }
-
-            case 'error':
-              throw new Error(`Agent error during boot: ${event.content ?? 'unknown'}`);
-          }
-        }
+        result = await this.streamConsumer.consume(handle, state, 'boot', bootAbort, watchdog);
       } finally {
-        clearTimeout(bootTimeout);
+        watchdog.stop();
         state.streamAbort = undefined;
       }
 
-      // If we get here without a 'done' event, persist whatever
-      // trailing text remains in the buffer (earlier text was already
-      // flushed incrementally alongside tool events).
-      await this.persistence.flushAssistantBuffer(state);
+      if (result.completed === 'done') {
+        // Capture the SDK session ID (available after first message exchange)
+        const sdkSessionId = result.agentSessionIdFromHandle;
+        if (sdkSessionId) {
+          // Detect CWD mismatch: if we tried to resume but got a different
+          // session ID, the SDK silently created a fresh session (typically
+          // because the cwd changed or session JSONL was lost).
+          if (previousAgentSessionId && sdkSessionId !== previousAgentSessionId) {
+            this.logger.warn(
+              `[InteractiveSession] Session resume mismatch for feature ${featureId}: ` +
+                `expected ${previousAgentSessionId}, got ${sdkSessionId}. ` +
+                `SDK created a fresh session (likely cwd changed or session expired).`
+            );
+          }
+          state.agentSessionId = sdkSessionId;
+          // Persist to DB so it survives service restarts
+          void this.sessionRepo.updateAgentSessionId(state.sessionId, sdkSessionId);
+        }
+
+        await this.persistence.updateSessionStatusAndNotify(
+          state.sessionId,
+          state.featureId,
+          InteractiveSessionStatus.ready
+        );
+
+        // If there's a pending user message, the next turn will set 'processing'.
+        // Otherwise boot greeting is expected — mark idle.
+        if (!state.pendingUserContent) {
+          void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+        }
+
+        state.currentAssistantBuffer = '';
+        state.toolEventsLog = [];
+
+        // Notify subscribers of end-of-turn
+        this.dispatcher.notify(state, { delta: '', done: true });
+        return; // Boot complete
+      }
+
+      // ended-without-done: persist trailing text and transition to ready.
       await this.persistence.updateSessionStatusAndNotify(
         state.sessionId,
         state.featureId,

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -44,6 +44,7 @@ import { type FeatureContextBuilder } from './feature-context.builder.js';
 import { getSettings, hasSettings } from '../settings.service.js';
 import type { SessionRegistry, SessionState } from './core/session-registry.js';
 import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
+import type { SessionPersistence } from './core/session-persistence.js';
 
 /** Default concurrent session cap. */
 const DEFAULT_CAP = 3;
@@ -76,18 +77,6 @@ const BOOT_IDLE_TIMEOUT_MS = 120_000;
  * @todo Consider renaming to `scopeId` + adding a `scopeType` discriminator.
  */
 export class InteractiveSessionService implements IInteractiveSessionService {
-  /**
-   * Monotonic clock for message `createdAt` values. `Date.now()` has
-   * millisecond precision, and the SDK can fire `tool_use` + `tool_result`
-   * (and their paired persistToolEvent calls) within the same millisecond
-   * — which leaves the DB with two rows whose `created_at` are identical,
-   * causing `ORDER BY created_at ASC` to return them in insert-race order
-   * and breaking the tool→Output pairing in StepTracker.classifyMessages.
-   * By pinning each subsequent timestamp to `max(Date.now(), lastTs + 1)`
-   * we guarantee monotonically increasing millis even under burst writes.
-   */
-  private lastMessageTs = 0;
-
   constructor(
     private readonly sessionRepo: IInteractiveSessionRepository,
     private readonly messageRepo: IInteractiveMessageRepository,
@@ -96,7 +85,8 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     private readonly contextBuilder: FeatureContextBuilder,
     private readonly workflowStepRepo: IWorkflowStepRepository,
     private readonly registry: SessionRegistry,
-    private readonly dispatcher: StreamEventDispatcher
+    private readonly dispatcher: StreamEventDispatcher,
+    private readonly persistence: SessionPersistence
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -171,7 +161,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     });
 
     // Mark as processing immediately so the FAB shows the spinner during boot
-    void this.updateTurnStatusAndNotify(session.id, featureId, 'processing');
+    void this.persistence.updateTurnStatusAndNotify(session.id, featureId, 'processing');
 
     // Set up in-memory state. CRITICAL: pendingUserContent must be set
     // BEFORE completeBootAsync is dispatched below. Setting it from the
@@ -307,12 +297,12 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       // the session is ready the moment the SDK handle exists. The user
       // will send their first message through the normal turn path.
       if (!bootPrompt) {
-        await this.updateSessionStatusAndNotify(
+        await this.persistence.updateSessionStatusAndNotify(
           state.sessionId,
           state.featureId,
           InteractiveSessionStatus.ready
         );
-        void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+        void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
         return;
       }
 
@@ -363,7 +353,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
             case 'thinking':
               if (event.content) {
-                await this.persistToolEvent(state, 'Thinking', event.content);
+                await this.persistence.persistToolEvent(state, 'Thinking', event.content);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -377,7 +367,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               if (event.label) {
                 const toolLabel = event.label;
                 const toolDetail = event.detail;
-                await this.persistToolEvent(state, toolLabel, toolDetail);
+                await this.persistence.persistToolEvent(state, toolLabel, toolDetail);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -391,7 +381,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               if (event.label) {
                 const resultLabel = event.label;
                 const resultDetail = event.detail;
-                await this.persistToolEvent(state, resultLabel, resultDetail);
+                await this.persistence.persistToolEvent(state, resultLabel, resultDetail);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -417,7 +407,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               // message — persisting `event.content`/`greetingText`
               // would duplicate everything we already flushed between
               // tools.
-              await this.flushAssistantBuffer(state);
+              await this.persistence.flushAssistantBuffer(state);
 
               // Capture the SDK session ID (available after first message exchange)
               const sdkSessionId = handle.sessionId;
@@ -438,7 +428,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
                 void this.sessionRepo.updateAgentSessionId(state.sessionId, sdkSessionId);
               }
 
-              await this.updateSessionStatusAndNotify(
+              await this.persistence.updateSessionStatusAndNotify(
                 state.sessionId,
                 state.featureId,
                 InteractiveSessionStatus.ready
@@ -447,7 +437,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               // If there's a pending user message, the next turn will set 'processing'.
               // Otherwise boot greeting is expected — mark idle.
               if (!state.pendingUserContent) {
-                void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+                void this.persistence.updateTurnStatusAndNotify(
+                  state.sessionId,
+                  state.featureId,
+                  'idle'
+                );
               }
 
               state.currentAssistantBuffer = '';
@@ -470,14 +464,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       // If we get here without a 'done' event, persist whatever
       // trailing text remains in the buffer (earlier text was already
       // flushed incrementally alongside tool events).
-      await this.flushAssistantBuffer(state);
-      await this.updateSessionStatusAndNotify(
+      await this.persistence.flushAssistantBuffer(state);
+      await this.persistence.updateSessionStatusAndNotify(
         state.sessionId,
         state.featureId,
         InteractiveSessionStatus.ready
       );
       if (!state.pendingUserContent) {
-        void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+        void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
       }
       state.currentAssistantBuffer = '';
       state.toolEventsLog = [];
@@ -489,7 +483,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       // eslint-disable-next-line no-console
       console.error(`[InteractiveSession] boot failed for session ${state.sessionId}:`, err);
       try {
-        await this.updateSessionStatusAndNotify(
+        await this.persistence.updateSessionStatusAndNotify(
           state.sessionId,
           state.featureId,
           InteractiveSessionStatus.error
@@ -541,13 +535,13 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       state.handle = null;
     }
 
-    await this.updateSessionStatusAndNotify(
+    await this.persistence.updateSessionStatusAndNotify(
       sessionId,
       state.featureId,
       InteractiveSessionStatus.stopped,
       new Date()
     );
-    void this.updateTurnStatusAndNotify(sessionId, state.featureId, 'idle');
+    void this.persistence.updateTurnStatusAndNotify(sessionId, state.featureId, 'idle');
   }
 
   async sendMessage(sessionId: string, content: string): Promise<InteractiveMessage> {
@@ -572,7 +566,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       createdAt: now,
       updatedAt: now,
     };
-    await this.persistMessage(message);
+    await this.persistence.persistMessage(message);
 
     await this.sessionRepo.updateLastActivity(sessionId, now);
 
@@ -600,7 +594,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       state.toolEventsLog = [];
 
       // Mark turn as processing for dot indicator
-      void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'processing');
+      void this.persistence.updateTurnStatusAndNotify(
+        state.sessionId,
+        state.featureId,
+        'processing'
+      );
 
       // Send the message to the SDK session
       await state.handle.send(prompt);
@@ -626,7 +624,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
             case 'thinking':
               if (event.content) {
-                await this.persistToolEvent(state, 'Thinking', event.content);
+                await this.persistence.persistToolEvent(state, 'Thinking', event.content);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -640,7 +638,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               if (event.label) {
                 const toolLabel = event.label;
                 const toolDetail = event.detail;
-                await this.persistToolEvent(state, toolLabel, toolDetail);
+                await this.persistence.persistToolEvent(state, toolLabel, toolDetail);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -654,7 +652,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               if (event.label) {
                 const resultLabel = event.label;
                 const resultDetail = event.detail;
-                await this.persistToolEvent(state, resultLabel, resultDetail);
+                await this.persistence.persistToolEvent(state, resultLabel, resultDetail);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -679,7 +677,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               // We intentionally do NOT persist `event.content` /
               // `responseText` here — that would duplicate everything
               // we already flushed between tools.
-              await this.flushAssistantBuffer(state);
+              await this.persistence.flushAssistantBuffer(state);
               state.toolEventsLog = [];
 
               // Accumulate usage from this turn
@@ -694,7 +692,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
               // Mark as unread — if user has the chat open, the frontend
               // will immediately call markRead to clear it
-              void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'unread');
+              void this.persistence.updateTurnStatusAndNotify(
+                state.sessionId,
+                state.featureId,
+                'unread'
+              );
 
               // Notify subscribers of end-of-turn
               this.dispatcher.notify(state, { delta: '', done: true });
@@ -747,7 +749,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
             case 'task_started':
               if (event.content) {
-                await this.persistToolEvent(state, 'Subtask started', event.content);
+                await this.persistence.persistToolEvent(state, 'Subtask started', event.content);
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -770,7 +772,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
             case 'task_done':
               if (event.content) {
                 const taskStatus = event.detail ?? 'completed';
-                await this.persistToolEvent(state, `Subtask ${taskStatus}`, event.content);
+                await this.persistence.persistToolEvent(
+                  state,
+                  `Subtask ${taskStatus}`,
+                  event.content
+                );
                 this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
@@ -800,7 +806,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       // persist whatever trailing text remains in the buffer (earlier
       // text was flushed incrementally alongside tool events).
       if (responseText && state.currentAssistantBuffer) {
-        await this.flushAssistantBuffer(state);
+        await this.persistence.flushAssistantBuffer(state);
         state.toolEventsLog = [];
         this.dispatcher.notify(state, { delta: '', done: true });
       } else if (!responseText) {
@@ -820,7 +826,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         }
         this.registry.delete(state.sessionId);
         try {
-          await this.updateSessionStatusAndNotify(
+          await this.persistence.updateSessionStatusAndNotify(
             state.sessionId,
             state.featureId,
             InteractiveSessionStatus.error
@@ -901,7 +907,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       updatedAt: now,
     };
     if (persistUserMessage) {
-      await this.persistMessage(userMsg);
+      await this.persistence.persistMessage(userMsg);
     }
 
     // 2. Find active session for this feature
@@ -947,7 +953,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         (dbSession.status === InteractiveSessionStatus.ready ||
           dbSession.status === InteractiveSessionStatus.booting)
       ) {
-        await this.updateSessionStatusAndNotify(
+        await this.persistence.updateSessionStatusAndNotify(
           dbSession.id,
           featureId,
           InteractiveSessionStatus.stopped,
@@ -1113,13 +1119,13 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     // Find the active session for this feature and clear unread status
     const state = this.registry.findActiveStateForFeature(featureId);
     if (state) {
-      void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+      void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
       return;
     }
     // Fallback: check DB for the latest active session
     const latest = await this.sessionRepo.findByFeatureId(featureId);
     if (latest) {
-      void this.updateTurnStatusAndNotify(latest.id, featureId, 'idle');
+      void this.persistence.updateTurnStatusAndNotify(latest.id, featureId, 'idle');
     }
   }
 
@@ -1157,7 +1163,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       createdAt: now,
       updatedAt: now,
     };
-    await this.persistMessage(userMsg);
+    await this.persistence.persistMessage(userMsg);
 
     // Resolve the Promise that the canUseTool callback is awaiting.
     // This unblocks the SDK stream — the agent resumes with the user's answers.
@@ -1168,7 +1174,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     state.pendingInteractionResolver = null;
 
     // Update turn status back to processing
-    void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'processing');
+    void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'processing');
 
     // Clear the "Waiting for your response..." log
     state.subscribers.forEach((sub) => sub({ delta: '', done: false }));
@@ -1243,7 +1249,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
           createdAt: now,
           updatedAt: now,
         };
-        await this.persistMessage(msg);
+        await this.persistence.persistMessage(msg);
         state.currentAssistantBuffer = '';
         state.toolEventsLog = [];
 
@@ -1257,7 +1263,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       state.pendingInteraction = interaction;
 
       // Update turn status so the dot indicator shows amber
-      void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'awaiting_input');
+      void this.persistence.updateTurnStatusAndNotify(
+        state.sessionId,
+        state.featureId,
+        'awaiting_input'
+      );
 
       // Notify subscribers so SSE pushes the interaction to the frontend
       state.subscribers.forEach((sub) =>
@@ -1303,143 +1313,10 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     };
   }
 
-  // ---------------------------------------------------------------------------
-  // Tool detail extraction
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Persist a tool/system event as its own assistant message in the DB.
-   * Each event gets its own bubble in the chat thread.
-   *
-   * Before writing the tool row, any prose the agent produced since the
-   * last flush is persisted as its own text message so that step cards
-   * interleave agent text with tool calls instead of collapsing every
-   * step's narration into one blob at `done`.
-   */
-  private async persistToolEvent(
-    state: SessionState,
-    label: string,
-    detail?: string
-  ): Promise<void> {
-    try {
-      await this.flushAssistantBuffer(state);
-      const content = detail ? `**${label}** \`${detail}\`` : `**${label}**`;
-      const now = this.nextMessageDate();
-      const msg: InteractiveMessage = {
-        id: crypto.randomUUID(),
-        featureId: state.featureId,
-        sessionId: state.sessionId,
-        role: InteractiveMessageRole.assistant,
-        content,
-        createdAt: now,
-        updatedAt: now,
-      };
-      await this.persistMessage(msg);
-    } catch {
-      // Non-critical — don't fail the turn for a tool event
-    }
-  }
-
-  /**
-   * Persist whatever text has accumulated in `currentAssistantBuffer`
-   * as its own assistant message, then clear the buffer. Called right
-   * before each tool event so the DB history interleaves agent prose
-   * with tool calls — the step tracker groups messages by their
-   * persisted `stepId`, so without the flush everything the agent said
-   * mid-step ends up in one trailing blob (or tagged to no step at all
-   * if the orchestrator has already cleared activeStep by the time
-   * `done` fires).
-   */
-  private async flushAssistantBuffer(state: SessionState): Promise<void> {
-    const buffered = state.currentAssistantBuffer.trim();
-    if (!buffered) return;
-    state.currentAssistantBuffer = '';
-    const now = this.nextMessageDate();
-    const msg: InteractiveMessage = {
-      id: crypto.randomUUID(),
-      featureId: state.featureId,
-      sessionId: state.sessionId,
-      role: InteractiveMessageRole.assistant,
-      content: buffered,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await this.persistMessage(msg);
-  }
-
-  /**
-   * Produce the next monotonic timestamp for a persisted interactive
-   * message. Guarantees a strictly-increasing sequence even when two
-   * calls happen in the same millisecond (which is the norm for rapid
-   * `tool_use` + `tool_result` bursts emitted by the Claude SDK) so
-   * the repository's `ORDER BY created_at ASC` query returns rows in
-   * the exact order they were persisted. Frontend classifyMessages()
-   * depends on that order to pair Write/Edit/Read tool calls with
-   * their adjacent Output bubble.
-   */
-  private nextMessageDate(): Date {
-    const wallclock = Date.now();
-    const next = wallclock > this.lastMessageTs ? wallclock : this.lastMessageTs + 1;
-    this.lastMessageTs = next;
-    return new Date(next);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Mutation helpers — every DB write that changes observable state must go
-  // through one of these so SSE subscribers receive a matching notification.
-  // This is the contract that lets the client drop periodic polling.
-  // ---------------------------------------------------------------------------
-
-  /** Persist a message AND notify subscribers. Use everywhere instead of
-   *  calling `messageRepo.create` directly. The current active workflow
-   *  step for the feature (if any) is stamped onto the row so every
-   *  message is grouped under the right step card in the UI. */
-  private async persistMessage(message: InteractiveMessage): Promise<void> {
-    const activeStepId = this.registry.getActiveStep(message.featureId);
-    const tagged: InteractiveMessage =
-      message.stepId || !activeStepId ? message : { ...message, stepId: activeStepId };
-    await this.messageRepo.create(tagged);
-    this.dispatcher.notifyByFeatureId(tagged.featureId, {
-      delta: '',
-      done: false,
-      message: tagged,
-    });
-  }
-
-  /** Update session status AND notify subscribers. Passes `endedAt` to
-   *  the repo only when supplied so call-arity matches the legacy
-   *  two-argument shape (keeps existing test expectations happy). */
-  private async updateSessionStatusAndNotify(
-    sessionId: string,
-    featureId: string,
-    status: InteractiveSessionStatus,
-    endedAt?: Date
-  ): Promise<void> {
-    if (endedAt === undefined) {
-      await this.sessionRepo.updateStatus(sessionId, status);
-    } else {
-      await this.sessionRepo.updateStatus(sessionId, status, endedAt);
-    }
-    this.dispatcher.notifyByFeatureId(featureId, {
-      delta: '',
-      done: false,
-      sessionStatus: status,
-    });
-  }
-
-  /** Update turn status AND notify subscribers. */
-  private async updateTurnStatusAndNotify(
-    sessionId: string,
-    featureId: string,
-    turnStatus: string
-  ): Promise<void> {
-    await this.sessionRepo.updateTurnStatus(sessionId, turnStatus);
-    this.dispatcher.notifyByFeatureId(featureId, {
-      delta: '',
-      done: false,
-      turnStatus,
-    });
-  }
+  // Persistence + monotonic-clock helpers live on SessionPersistence
+  // (`core/session-persistence.ts`) — this facade delegates via
+  // `this.persistence.*`. The collaborator is a DI singleton so the
+  // monotonic counter is shared process-wide.
 
   // Idle-eviction timer removed. Live agent sessions are preserved
   // indefinitely and only stop on an explicit user action (Stop

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -2,33 +2,34 @@
  * Interactive Session Service
  *
  * Thin facade that implements `IInteractiveSessionService` by delegating
- * to extracted collaborators. Phase 5 of the strangler refactor — see
+ * to extracted collaborators. Phase 6 of the strangler refactor — see
  * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
  *
  * The following collaborators handle the heavy lifting:
- * - `SessionBootstrapper`        — startSession + completeBootAsync
- * - `SessionTerminator`          — stopSession + stopByFeature
- * - `TurnExecutor`               — executeAndPersistTurn + queue drain
- * - `UserInteractionCoordinator` — buildOnUserQuestionCallback + respondToInteraction
- * - `BootPromptResolver`         — three-case boot-prompt logic
- * - `AgentStreamConsumer`        — SDK stream event loop (phase 4)
- * - `AgentConfigResolver`        — agent type/auth/cap resolution (phase 3)
- * - `SessionPersistence`         — monotonic-clock DB writes (phase 2)
- * - `SessionRegistry`            — in-memory state (phase 1)
- * - `StreamEventDispatcher`      — SSE fan-out (phase 1)
+ * - `MessageDispatcher`           — sendMessage + sendUserMessage (phase 6)
+ * - `ChatStateAssembler`          — getChatState read-side DTO (phase 6)
+ * - `WorkflowHooks`               — setActiveStep + clearActiveStep +
+ *                                   notifyWorkflowStep + waitForTurnDone (phase 6)
+ * - `SessionBootstrapper`         — startSession + completeBootAsync (phase 5)
+ * - `SessionTerminator`           — stopSession + stopByFeature (phase 5)
+ * - `TurnExecutor`                — executeAndPersistTurn + queue drain (phase 5)
+ * - `UserInteractionCoordinator`  — buildOnUserQuestionCallback + respondToInteraction (phase 5)
+ * - `BootPromptResolver`          — three-case boot-prompt logic (phase 5)
+ * - `AgentStreamConsumer`         — SDK stream event loop (phase 4)
+ * - `AgentConfigResolver`         — agent type/auth/cap resolution (phase 3)
+ * - `SessionPersistence`          — monotonic-clock DB writes (phase 2)
+ * - `SessionRegistry`             — in-memory state (phase 1)
+ * - `StreamEventDispatcher`       — SSE fan-out (phase 1)
  *
- * Remaining direct logic: sendMessage, sendUserMessage, getChatState,
- * getSession, getMessages, clearMessages, markRead, getTurnStatuses,
- * getAllActiveTurnStatuses, setActiveStep, clearActiveStep,
- * notifyWorkflowStep, waitForTurnDone, subscribe, subscribeByFeature,
- * subscribeAll — these are slated for phases 6+7.
+ * Remaining direct logic: getSession, getMessages, clearMessages, markRead,
+ * getTurnStatuses, getAllActiveTurnStatuses, respondToInteraction,
+ * subscribe, subscribeByFeature, subscribeAll — slated for phase 7.
  *
  * Dependencies are injected via constructor for testability (no real
  * processes are spawned in unit tests — the factory is replaced with a
  * test double).
  */
 
-import * as crypto from 'node:crypto';
 import type {
   IInteractiveSessionService,
   StreamChunk,
@@ -43,11 +44,6 @@ import type {
   InteractiveMessage,
   WorkflowStep,
 } from '../../../domain/generated/output.js';
-import {
-  InteractiveSessionStatus,
-  InteractiveMessageRole,
-  WorkflowStepStatus,
-} from '../../../domain/generated/output.js';
 import type { SessionRegistry } from './core/session-registry.js';
 import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
 import type { SessionPersistence } from './core/session-persistence.js';
@@ -56,6 +52,9 @@ import type { SessionBootstrapper } from './lifecycle/session-bootstrapper.js';
 import type { SessionTerminator } from './lifecycle/session-terminator.js';
 import type { TurnExecutor } from './runtime/turn.executor.js';
 import type { UserInteractionCoordinator } from './runtime/user-interaction.coordinator.js';
+import type { MessageDispatcher } from './api/message-dispatcher.js';
+import type { ChatStateAssembler } from './api/chat-state.assembler.js';
+import type { WorkflowHooks } from './api/workflow-hooks.js';
 
 /**
  * Core service managing interactive agent session lifecycles.
@@ -85,8 +84,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     _logger: ILogger, // owned by collaborators — kept for signature arity
     private readonly bootstrapper: SessionBootstrapper,
     private readonly terminator: SessionTerminator,
-    private readonly turnExecutor: TurnExecutor,
-    private readonly interactionCoordinator: UserInteractionCoordinator
+    _turnExecutor: TurnExecutor, // owned by MessageDispatcher — kept for signature arity
+    private readonly interactionCoordinator: UserInteractionCoordinator,
+    private readonly messageDispatcher: MessageDispatcher,
+    private readonly chatStateAssembler: ChatStateAssembler,
+    private readonly workflowHooks: WorkflowHooks
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -116,35 +118,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   async sendMessage(sessionId: string, content: string): Promise<InteractiveMessage> {
-    const dbSession = await this.sessionRepo.findById(sessionId);
-    if (!dbSession || dbSession.status !== InteractiveSessionStatus.ready) {
-      throw new Error(`Session ${sessionId} is not ready — cannot send message`);
-    }
-
-    const state = this.registry.get(sessionId);
-    if (!state) {
-      throw new Error(`Session ${sessionId} is not ready — cannot send message`);
-    }
-
-    // Persist user message
-    const now = new Date();
-    const message: InteractiveMessage = {
-      id: crypto.randomUUID(),
-      featureId: state.featureId,
-      sessionId,
-      role: InteractiveMessageRole.user,
-      content,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await this.persistence.persistMessage(message);
-
-    await this.sessionRepo.updateLastActivity(sessionId, now);
-
-    // Delegate turn execution to TurnExecutor (guarded: one turn at a time)
-    void this.turnExecutor.enqueueTurn(state, content);
-
-    return message;
+    return this.messageDispatcher.sendMessage(sessionId, content);
   }
 
   async getMessages(featureId: string, limit?: number): Promise<InteractiveMessage[]> {
@@ -186,183 +160,20 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     agentKickoffOverride?: string,
     persistUserMessage = true
   ): Promise<InteractiveMessage> {
-    // 1. Persist user message to DB immediately — this is the source
-    //    of truth. SKIPPED when `persistUserMessage === false`, which
-    //    the application-creation flow uses to boot the session on top
-    //    of a user message it already wrote in the foreground.
-    const now = new Date();
-    const userMsg: InteractiveMessage = {
-      id: crypto.randomUUID(),
+    return this.messageDispatcher.sendUserMessage(
       featureId,
-      role: InteractiveMessageRole.user,
       content,
-      createdAt: now,
-      updatedAt: now,
-    };
-    if (persistUserMessage) {
-      await this.persistence.persistMessage(userMsg);
-    }
-
-    // 2. Find active session for this feature
-    let state = this.registry.findActiveStateForFeature(featureId);
-
-    // If the caller requested a different model/agent than the running session,
-    // silently stop the current session so a new one boots with the new config.
-    if (state && model && state.model !== model) {
-      await this.terminator.stop(state.sessionId);
-      this.registry.deleteStoppedAgentSessionId(featureId);
-      state = undefined;
-    } else if (state && agentType && state.agentType !== agentType) {
-      await this.terminator.stop(state.sessionId);
-      this.registry.deleteStoppedAgentSessionId(featureId);
-      state = undefined;
-    }
-
-    if (state) {
-      const dbSession = await this.sessionRepo.findById(state.sessionId);
-      if (dbSession?.status === InteractiveSessionStatus.ready) {
-        // Session ready — send to agent (guarded: one turn at a time)
-        await this.sessionRepo.updateLastActivity(state.sessionId, now);
-        void this.turnExecutor.enqueueTurn(state, content);
-      } else if (dbSession?.status === InteractiveSessionStatus.booting) {
-        // Session booting — queue the message
-        state.pendingUserContent = content;
-      }
-    } else {
-      // No in-memory session — check DB for an orphaned active session (e.g. after
-      // service restart / hot-reload) and mark it stopped before booting a new one.
-      const dbSession = await this.sessionRepo.findByFeatureId(featureId);
-      if (
-        dbSession &&
-        (dbSession.status === InteractiveSessionStatus.ready ||
-          dbSession.status === InteractiveSessionStatus.booting)
-      ) {
-        await this.persistence.updateSessionStatusAndNotify(
-          dbSession.id,
-          featureId,
-          InteractiveSessionStatus.stopped,
-          new Date()
-        );
-      }
-
-      // Boot a new session. Pass the first-turn content as `initialUserMessage`
-      // so it's written to the session state atomically BEFORE completeBootAsync
-      // is dispatched.
-      const firstTurnContent = agentKickoffOverride ?? content;
-      await this.startSession(
-        featureId,
-        worktreePath,
-        model,
-        agentType,
-        systemPrompt,
-        firstTurnContent
-      );
-    }
-
-    return userMsg;
+      worktreePath,
+      model,
+      agentType,
+      systemPrompt,
+      agentKickoffOverride,
+      persistUserMessage
+    );
   }
 
   async getChatState(featureId: string): Promise<ChatState> {
-    // DB messages
-    const messages = await this.messageRepo.findByFeatureId(featureId);
-
-    // Find active in-memory session
-    const state = this.registry.findActiveStateForFeature(featureId);
-    let sessionStatus: string | null = null;
-    let streamingText: string | null = null;
-    let sessionInfo: ChatState['sessionInfo'] = null;
-
-    if (state) {
-      const dbSession = await this.sessionRepo.findById(state.sessionId);
-      sessionStatus = dbSession?.status ?? null;
-      if (state.currentAssistantBuffer) {
-        streamingText = state.currentAssistantBuffer;
-      }
-      // Resolve model display: explicit override > default
-      const displayModel = state.model ?? 'claude-sonnet-4-6';
-
-      const usage = await this.sessionRepo.getUsage(state.sessionId);
-      sessionInfo = {
-        pid: null, // SDK manages process internally
-        sessionId: state.agentSessionId ?? state.sessionId,
-        model: displayModel,
-        startedAt: dbSession?.startedAt
-          ? new Date(dbSession.startedAt as unknown as string).toISOString()
-          : new Date().toISOString(),
-        lastActivityAt: dbSession?.lastActivityAt
-          ? new Date(dbSession.lastActivityAt as unknown as string).toISOString()
-          : new Date().toISOString(),
-        totalCostUsd: usage?.totalCostUsd ?? null,
-        totalInputTokens: usage?.totalInputTokens ?? null,
-        totalOutputTokens: usage?.totalOutputTokens ?? null,
-      };
-    } else {
-      // No in-memory state — check DB for last session (e.g. after server restart)
-      const latest = await this.sessionRepo.findByFeatureId(featureId);
-      if (latest) {
-        sessionStatus = latest.status as string;
-        if (
-          latest.status !== InteractiveSessionStatus.stopped &&
-          latest.status !== InteractiveSessionStatus.error
-        ) {
-          const latestUsage = await this.sessionRepo.getUsage(latest.id);
-          sessionInfo = {
-            pid: null,
-            sessionId: latest.id,
-            model: null,
-            startedAt: latest.startedAt
-              ? new Date(latest.startedAt as unknown as string).toISOString()
-              : new Date().toISOString(),
-            lastActivityAt: latest.lastActivityAt
-              ? new Date(latest.lastActivityAt as unknown as string).toISOString()
-              : new Date().toISOString(),
-            totalCostUsd: latestUsage?.totalCostUsd ?? null,
-            totalInputTokens: latestUsage?.totalInputTokens ?? null,
-            totalOutputTokens: latestUsage?.totalOutputTokens ?? null,
-          };
-        }
-      }
-    }
-
-    // Resolve turn status from DB
-    let turnStatus = 'idle';
-    const activeState = state;
-    if (activeState) {
-      const statuses = await this.sessionRepo.getTurnStatuses([featureId]);
-      turnStatus = statuses.get(featureId) ?? 'idle';
-    } else {
-      const latest = await this.sessionRepo.findByFeatureId(featureId);
-      if (latest) {
-        const statuses = await this.sessionRepo.getTurnStatuses([featureId]);
-        turnStatus = statuses.get(featureId) ?? 'idle';
-      }
-    }
-
-    // Include pending interaction if one exists
-    const pendingInteraction = state?.pendingInteraction ?? null;
-
-    // Workflow view — derived entirely from the DB
-    const workflowSteps = await this.workflowStepRepo.listByFeature(featureId);
-    let workflow: ChatState['workflow'] = null;
-    if (workflowSteps.length > 0) {
-      const running = workflowSteps.find((s) => s.status === WorkflowStepStatus.running);
-      workflow = {
-        workflowId: workflowSteps[0].workflowId,
-        steps: workflowSteps,
-        currentStepId: running?.id ?? null,
-      };
-      if (running) turnStatus = 'processing';
-    }
-
-    return {
-      messages,
-      sessionStatus,
-      streamingText,
-      sessionInfo,
-      turnStatus,
-      pendingInteraction,
-      workflow,
-    };
+    return this.chatStateAssembler.assemble(featureId);
   }
 
   subscribeByFeature(featureId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
@@ -406,48 +217,22 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   // ---------------------------------------------------------------------------
-  // Workflow orchestrator hooks
+  // Workflow orchestrator hooks — delegated to WorkflowHooks
   // ---------------------------------------------------------------------------
 
   setActiveStep(featureId: string, stepId: string): void {
-    this.registry.setActiveStep(featureId, stepId);
+    this.workflowHooks.setActiveStep(featureId, stepId);
   }
 
   clearActiveStep(featureId: string): void {
-    this.registry.clearActiveStep(featureId);
+    this.workflowHooks.clearActiveStep(featureId);
   }
 
   notifyWorkflowStep(featureId: string, step: WorkflowStep): void {
-    this.dispatcher.notifyByFeatureId(featureId, {
-      delta: '',
-      done: false,
-      workflowStep: step,
-    });
+    this.workflowHooks.notifyWorkflowStep(featureId, step);
   }
 
-  /**
-   * Resolves the next time any subscriber receives a `done: true`
-   * chunk for the given feature.
-   */
   async waitForTurnDone(featureId: string, signal?: AbortSignal): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      if (signal?.aborted) {
-        reject(new Error('waitForTurnDone aborted'));
-        return;
-      }
-      const unsubscribe = this.subscribeByFeature(featureId, (chunk) => {
-        if (chunk.done) {
-          unsubscribe();
-          signal?.removeEventListener('abort', onAbort);
-          resolve();
-        }
-      });
-      const onAbort = () => {
-        unsubscribe();
-        signal?.removeEventListener('abort', onAbort);
-        reject(new Error('waitForTurnDone aborted'));
-      };
-      signal?.addEventListener('abort', onAbort);
-    });
+    return this.workflowHooks.waitForTurnDone(featureId, signal);
   }
 }

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -1,33 +1,23 @@
 /**
- * Interactive Session Service
+ * Interactive Session Service — THIN FACADE (Phase 7 of 7)
  *
- * Thin facade that implements `IInteractiveSessionService` by delegating
- * to extracted collaborators. Phase 6 of the strangler refactor — see
- * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ * Implements `IInteractiveSessionService` by delegating every public method
+ * to the appropriate collaborator. Contains NO business logic of its own.
  *
- * The following collaborators handle the heavy lifting:
- * - `MessageDispatcher`           — sendMessage + sendUserMessage (phase 6)
- * - `ChatStateAssembler`          — getChatState read-side DTO (phase 6)
- * - `WorkflowHooks`               — setActiveStep + clearActiveStep +
- *                                   notifyWorkflowStep + waitForTurnDone (phase 6)
- * - `SessionBootstrapper`         — startSession + completeBootAsync (phase 5)
- * - `SessionTerminator`           — stopSession + stopByFeature (phase 5)
- * - `TurnExecutor`                — executeAndPersistTurn + queue drain (phase 5)
- * - `UserInteractionCoordinator`  — buildOnUserQuestionCallback + respondToInteraction (phase 5)
- * - `BootPromptResolver`          — three-case boot-prompt logic (phase 5)
- * - `AgentStreamConsumer`         — SDK stream event loop (phase 4)
- * - `AgentConfigResolver`         — agent type/auth/cap resolution (phase 3)
- * - `SessionPersistence`          — monotonic-clock DB writes (phase 2)
- * - `SessionRegistry`             — in-memory state (phase 1)
- * - `StreamEventDispatcher`       — SSE fan-out (phase 1)
+ * Collaborator map:
+ * - `SessionBootstrapper`        — startSession
+ * - `SessionTerminator`          — stopSession, stopByFeature, clearMessages
+ * - `MessageDispatcher`          — sendMessage, sendUserMessage
+ * - `IInteractiveMessageRepository` — getMessages
+ * - `IInteractiveSessionRepository` — getSession, getTurnStatuses, getAllActiveTurnStatuses
+ * - `StreamEventDispatcher`      — subscribe, subscribeByFeature, subscribeAll
+ * - `ChatStateAssembler`         — getChatState
+ * - `SessionPersistence`         — markRead
+ * - `UserInteractionCoordinator` — respondToInteraction
+ * - `WorkflowHooks`              — setActiveStep, clearActiveStep, notifyWorkflowStep, waitForTurnDone
  *
- * Remaining direct logic: getSession, getMessages, clearMessages, markRead,
- * getTurnStatuses, getAllActiveTurnStatuses, respondToInteraction,
- * subscribe, subscribeByFeature, subscribeAll — slated for phase 7.
- *
- * Dependencies are injected via constructor for testability (no real
- * processes are spawned in unit tests — the factory is replaced with a
- * test double).
+ * See `docs/plans/2026-04-14-interactive-session-service-refactor.md` for
+ * the full strangler-refactor history (phases 1–7).
  */
 
 import type {
@@ -38,19 +28,15 @@ import type {
 } from '../../../application/ports/output/services/interactive-session-service.interface.js';
 import type { IInteractiveSessionRepository } from '../../../application/ports/output/repositories/interactive-session-repository.interface.js';
 import type { IInteractiveMessageRepository } from '../../../application/ports/output/repositories/interactive-message-repository.interface.js';
-import type { IWorkflowStepRepository } from '../../../application/ports/output/repositories/workflow-step-repository.interface.js';
 import type {
   InteractiveSession,
   InteractiveMessage,
   WorkflowStep,
 } from '../../../domain/generated/output.js';
-import type { SessionRegistry } from './core/session-registry.js';
 import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
 import type { SessionPersistence } from './core/session-persistence.js';
-import type { ILogger } from '../../../application/ports/output/services/logger.interface.js';
 import type { SessionBootstrapper } from './lifecycle/session-bootstrapper.js';
 import type { SessionTerminator } from './lifecycle/session-terminator.js';
-import type { TurnExecutor } from './runtime/turn.executor.js';
 import type { UserInteractionCoordinator } from './runtime/user-interaction.coordinator.js';
 import type { MessageDispatcher } from './api/message-dispatcher.js';
 import type { ChatStateAssembler } from './api/chat-state.assembler.js';
@@ -77,14 +63,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     private readonly messageRepo: IInteractiveMessageRepository,
     _featureRepo: unknown, // owned by SessionBootstrapper — kept for signature arity
     _contextBuilder: unknown, // owned by BootPromptResolver — kept for signature arity
-    private readonly workflowStepRepo: IWorkflowStepRepository,
-    private readonly registry: SessionRegistry,
+    _workflowStepRepo: unknown, // owned by SessionTerminator — kept for signature arity
+    _registry: unknown, // owned by collaborators — kept for signature arity
     private readonly dispatcher: StreamEventDispatcher,
     private readonly persistence: SessionPersistence,
-    _logger: ILogger, // owned by collaborators — kept for signature arity
+    _logger: unknown, // owned by collaborators — kept for signature arity
     private readonly bootstrapper: SessionBootstrapper,
     private readonly terminator: SessionTerminator,
-    _turnExecutor: TurnExecutor, // owned by MessageDispatcher — kept for signature arity
+    _turnExecutor: unknown, // owned by MessageDispatcher — kept for signature arity
     private readonly interactionCoordinator: UserInteractionCoordinator,
     private readonly messageDispatcher: MessageDispatcher,
     private readonly chatStateAssembler: ChatStateAssembler,
@@ -92,7 +78,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   ) {}
 
   // ---------------------------------------------------------------------------
-  // Public API — delegated to collaborators
+  // Session lifecycle
   // ---------------------------------------------------------------------------
 
   async startSession(
@@ -117,38 +103,17 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     return this.terminator.stop(sessionId);
   }
 
+  async stopByFeature(featureId: string): Promise<void> {
+    return this.terminator.stopByFeature(featureId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Messaging
+  // ---------------------------------------------------------------------------
+
   async sendMessage(sessionId: string, content: string): Promise<InteractiveMessage> {
     return this.messageDispatcher.sendMessage(sessionId, content);
   }
-
-  async getMessages(featureId: string, limit?: number): Promise<InteractiveMessage[]> {
-    return this.messageRepo.findByFeatureId(featureId, limit);
-  }
-
-  async clearMessages(featureId: string): Promise<void> {
-    // Stop any active session so the agent doesn't retain old context
-    const state = this.registry.findActiveStateForFeature(featureId);
-    if (state) {
-      await this.terminator.stop(state.sessionId);
-    }
-    // Also clear the cached agentSessionId so next session starts fresh
-    this.registry.deleteStoppedAgentSessionId(featureId);
-    await this.workflowStepRepo.deleteByFeatureId(featureId);
-    this.registry.clearActiveStep(featureId);
-    return this.messageRepo.deleteByFeatureId(featureId);
-  }
-
-  async getSession(sessionId: string): Promise<InteractiveSession | null> {
-    return this.sessionRepo.findById(sessionId);
-  }
-
-  subscribe(sessionId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
-    return this.dispatcher.subscribeSession(sessionId, onChunk);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Feature-scoped API (frontend doesn't manage sessions)
-  // ---------------------------------------------------------------------------
 
   async sendUserMessage(
     featureId: string,
@@ -172,32 +137,20 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     );
   }
 
-  async getChatState(featureId: string): Promise<ChatState> {
-    return this.chatStateAssembler.assemble(featureId);
+  async getMessages(featureId: string, limit?: number): Promise<InteractiveMessage[]> {
+    return this.messageRepo.findByFeatureId(featureId, limit);
   }
 
-  subscribeByFeature(featureId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
-    return this.dispatcher.subscribeByFeature(featureId, onChunk);
+  async clearMessages(featureId: string): Promise<void> {
+    return this.terminator.clearFeatureMessages(featureId);
   }
 
-  subscribeAll(onChunk: (featureId: string, chunk: StreamChunk) => void): UnsubscribeFn {
-    return this.dispatcher.subscribeAll(onChunk);
-  }
+  // ---------------------------------------------------------------------------
+  // Session reads
+  // ---------------------------------------------------------------------------
 
-  async stopByFeature(featureId: string): Promise<void> {
-    return this.terminator.stopByFeature(featureId);
-  }
-
-  async markRead(featureId: string): Promise<void> {
-    const state = this.registry.findActiveStateForFeature(featureId);
-    if (state) {
-      void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
-      return;
-    }
-    const latest = await this.sessionRepo.findByFeatureId(featureId);
-    if (latest) {
-      void this.persistence.updateTurnStatusAndNotify(latest.id, featureId, 'idle');
-    }
+  async getSession(sessionId: string): Promise<InteractiveSession | null> {
+    return this.sessionRepo.findById(sessionId);
   }
 
   async getTurnStatuses(featureIds: string[]): Promise<Map<string, string>> {
@@ -208,12 +161,40 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     return this.sessionRepo.getAllActiveTurnStatuses();
   }
 
+  // ---------------------------------------------------------------------------
+  // Subscriptions
+  // ---------------------------------------------------------------------------
+
+  subscribe(sessionId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
+    return this.dispatcher.subscribeSession(sessionId, onChunk);
+  }
+
+  subscribeByFeature(featureId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
+    return this.dispatcher.subscribeByFeature(featureId, onChunk);
+  }
+
+  subscribeAll(onChunk: (featureId: string, chunk: StreamChunk) => void): UnsubscribeFn {
+    return this.dispatcher.subscribeAll(onChunk);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Chat state & read tracking
+  // ---------------------------------------------------------------------------
+
+  async getChatState(featureId: string): Promise<ChatState> {
+    return this.chatStateAssembler.assemble(featureId);
+  }
+
+  async markRead(featureId: string): Promise<void> {
+    return this.persistence.markRead(featureId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Interaction handling
+  // ---------------------------------------------------------------------------
+
   async respondToInteraction(featureId: string, answers: Record<string, string>): Promise<void> {
-    const state = this.registry.findActiveStateForFeature(featureId);
-    if (!state?.pendingInteraction || !state.pendingInteractionResolver) {
-      throw new Error(`No pending interaction for feature ${featureId}`);
-    }
-    return this.interactionCoordinator.respondToInteraction(state, answers);
+    return this.interactionCoordinator.respondToInteractionByFeature(featureId, answers);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -34,20 +34,14 @@ import type {
 import {
   InteractiveSessionStatus,
   InteractiveMessageRole,
-  AgentType,
-  AgentAuthMethod,
   WorkflowStepStatus,
 } from '../../../domain/generated/output.js';
-import type { AgentConfig } from '../../../domain/generated/output.js';
 import { ConcurrentSessionLimitError } from '../../../domain/errors/concurrent-session-limit.error.js';
 import { type FeatureContextBuilder } from './feature-context.builder.js';
-import { getSettings, hasSettings } from '../settings.service.js';
 import type { SessionRegistry, SessionState } from './core/session-registry.js';
 import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
 import type { SessionPersistence } from './core/session-persistence.js';
-
-/** Default concurrent session cap. */
-const DEFAULT_CAP = 3;
+import type { AgentConfigResolver } from './lifecycle/agent-config.resolver.js';
 
 /**
  * Boot-phase watchdog: how long the agent is allowed to go WITHOUT
@@ -86,7 +80,8 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     private readonly workflowStepRepo: IWorkflowStepRepository,
     private readonly registry: SessionRegistry,
     private readonly dispatcher: StreamEventDispatcher,
-    private readonly persistence: SessionPersistence
+    private readonly persistence: SessionPersistence,
+    private readonly agentConfigResolver: AgentConfigResolver
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -101,7 +96,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     systemPrompt?: string,
     initialUserMessage?: string
   ): Promise<InteractiveSession> {
-    const cap = this.getCap();
+    const cap = this.agentConfigResolver.getCap();
     const activeCount = await this.sessionRepo.countActiveSessions();
     if (activeCount >= cap) {
       throw new ConcurrentSessionLimitError(activeCount, cap);
@@ -258,8 +253,8 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       }
 
       // Resolve agent type and auth config from settings
-      const resolvedAgentType = this.resolveAgentType(state.agentType);
-      const authConfig = this.resolveAuthConfig();
+      const resolvedAgentType = this.agentConfigResolver.resolveAgentType(state.agentType);
+      const authConfig = this.agentConfigResolver.resolveAuthConfig();
 
       // Create the interactive executor and session
       const executor = this.executorFactory.createInteractiveExecutor(
@@ -1286,32 +1281,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     };
   }
 
-  // ---------------------------------------------------------------------------
-  // Agent resolution helpers
-  // ---------------------------------------------------------------------------
-
-  /** Resolve the agent type from an explicit override or settings. */
-  private resolveAgentType(agentTypeOverride?: string): AgentType {
-    if (agentTypeOverride) {
-      return agentTypeOverride as AgentType;
-    }
-    if (hasSettings()) {
-      return getSettings().agent.type;
-    }
-    return AgentType.ClaudeCode;
-  }
-
-  /** Resolve the auth config from settings, with a safe fallback. */
-  private resolveAuthConfig(): AgentConfig {
-    if (hasSettings()) {
-      return getSettings().agent;
-    }
-    // Fallback for when settings haven't been initialized yet
-    return {
-      type: AgentType.ClaudeCode,
-      authMethod: AgentAuthMethod.Session,
-    };
-  }
+  // Agent type / auth / concurrent-session cap resolution lives on
+  // `AgentConfigResolver` (`lifecycle/agent-config.resolver.ts`) — this
+  // facade delegates via `this.agentConfigResolver.*`. The resolver
+  // reads settings through an injected `ISettingsProvider` port so no
+  // component in this file calls the `settings.service` singleton.
 
   // Persistence + monotonic-clock helpers live on SessionPersistence
   // (`core/session-persistence.ts`) — this facade delegates via
@@ -1322,11 +1296,4 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   // indefinitely and only stop on an explicit user action (Stop
   // button, new session reset, server shutdown). See `stopSession`
   // for the only teardown path.
-
-  /** Read the concurrent session cap from settings or fall back to default. */
-  private getCap(): number {
-    if (!hasSettings()) return DEFAULT_CAP;
-    const settings = getSettings();
-    return settings.interactiveAgent?.maxConcurrentSessions ?? DEFAULT_CAP;
-  }
 }

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -42,6 +42,8 @@ import type { AgentConfig } from '../../../domain/generated/output.js';
 import { ConcurrentSessionLimitError } from '../../../domain/errors/concurrent-session-limit.error.js';
 import { type FeatureContextBuilder } from './feature-context.builder.js';
 import { getSettings, hasSettings } from '../settings.service.js';
+import type { SessionRegistry, SessionState } from './core/session-registry.js';
+import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
 
 /** Default concurrent session cap. */
 const DEFAULT_CAP = 3;
@@ -57,46 +59,6 @@ const DEFAULT_CAP = 3;
  * a whole project). A fixed wall-clock budget would kill those mid-way.
  */
 const BOOT_IDLE_TIMEOUT_MS = 120_000;
-
-/** In-memory state for a single live session. */
-interface SessionState {
-  sessionId: string;
-  featureId: string;
-  worktreePath: string;
-  /** Agent SDK session handle — null until session is created. */
-  handle: InteractiveAgentSessionHandle | null;
-  /** Agent SDK session ID for resumption across service restarts. */
-  agentSessionId?: string;
-  /** Accumulates assistant text between user turns for persistence. */
-  currentAssistantBuffer: string;
-  /** Accumulates tool events during a turn for rich message persistence. */
-  toolEventsLog: string[];
-  /** Subscriber callbacks for real-time stdout chunk forwarding. */
-  subscribers: Set<(chunk: StreamChunk) => void>;
-  /** User message content queued while session boots. */
-  pendingUserContent?: string;
-  /** Model override for the agent process (e.g. 'claude-sonnet-4-6'). */
-  model?: string;
-  /** Agent type for this session. */
-  agentType?: string;
-  /**
-   * Per-scope system prompt for the agent SDK. When set, it replaces
-   * the default feature-context prompt — lets Feature / Repository /
-   * Application / Global chats each supply their own instructions.
-   * Caller-owned: the session service never infers or modifies this.
-   */
-  systemPrompt?: string;
-  /** AbortController to cancel active stream iteration on stop. */
-  streamAbort?: AbortController;
-  /** Whether a turn is currently executing (prevents concurrent turns). */
-  turnInProgress: boolean;
-  /** Queue of user messages waiting to be sent after the current turn completes. */
-  turnQueue: string[];
-  /** Pending user interaction (AskUserQuestion) — agent stream is paused, waiting for response. */
-  pendingInteraction: UserInteractionData | null;
-  /** Resolver for the pending interaction Promise — call to resume the agent. */
-  pendingInteractionResolver: ((answers: Record<string, string>) => void) | null;
-}
 
 /**
  * Core service managing interactive agent session lifecycles.
@@ -114,35 +76,6 @@ interface SessionState {
  * @todo Consider renaming to `scopeId` + adding a `scopeType` discriminator.
  */
 export class InteractiveSessionService implements IInteractiveSessionService {
-  /** Live sessions indexed by sessionId. */
-  private sessions = new Map<string, SessionState>();
-  /** Cached agentSessionIds from stopped sessions, keyed by featureId. */
-  private stoppedAgentSessionIds = new Map<string, string>();
-  /**
-   * Feature-level subscribers that survive session restarts.
-   *
-   * Unlike session-level subscribers (in SessionState.subscribers), these
-   * persist when a session dies and a new one boots. SSE connections
-   * subscribe here so they continue receiving events from new sessions.
-   */
-  private featureSubscribers = new Map<string, Set<(chunk: StreamChunk) => void>>();
-  /**
-   * Global subscribers — receive every chunk from every session tagged
-   * with its feature scope key. Used by the global turn-status SSE
-   * endpoint so the sidebar can track all active sessions without
-   * polling.
-   */
-  private globalSubscribers = new Set<(featureId: string, chunk: StreamChunk) => void>();
-
-  /**
-   * Currently-active workflow step id per feature scope. Set by the
-   * orchestrator (`RunWorkflowUseCase`) before each agent turn and
-   * cleared between steps. `persistMessage` reads this so every row
-   * it inserts is tagged with the right `step_id`. In-memory only —
-   * the DB is the source of truth for per-message `stepId`.
-   */
-  private activeStepByFeature = new Map<string, string>();
-
   /**
    * Monotonic clock for message `createdAt` values. `Date.now()` has
    * millisecond precision, and the SDK can fire `tool_use` + `tool_result`
@@ -161,7 +94,9 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     private readonly executorFactory: IAgentExecutorFactory,
     private readonly featureRepo: IFeatureRepository,
     private readonly contextBuilder: FeatureContextBuilder,
-    private readonly workflowStepRepo: IWorkflowStepRepository
+    private readonly workflowStepRepo: IWorkflowStepRepository,
+    private readonly registry: SessionRegistry,
+    private readonly dispatcher: StreamEventDispatcher
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -197,14 +132,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     // to the user's second message. Look it up first.
     // ─────────────────────────────────────────────────────────────
     let previousAgentSessionId: string | undefined;
-    for (const [, s] of this.sessions) {
+    for (const s of this.registry.values()) {
       if (s.featureId === featureId && s.agentSessionId) {
         previousAgentSessionId = s.agentSessionId;
         break;
       }
     }
     // Also check stoppedSessions cache (populated on stop)
-    previousAgentSessionId ??= this.stoppedAgentSessionIds.get(featureId);
+    previousAgentSessionId ??= this.registry.takeStoppedAgentSessionId(featureId);
     // Fall back to DB — the in-memory cache may be empty after
     // service restart, hot reload, or Turbopack module re-init.
     //
@@ -229,7 +164,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       updatedAt: now,
     };
     await this.sessionRepo.create(session);
-    this.notifyByFeatureId(featureId, {
+    this.dispatcher.notifyByFeatureId(featureId, {
       delta: '',
       done: false,
       sessionStatus: InteractiveSessionStatus.booting,
@@ -262,7 +197,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       pendingInteractionResolver: null,
       pendingUserContent: initialUserMessage,
     };
-    this.sessions.set(session.id, state);
+    this.registry.set(session.id, state);
 
     // Fire-and-forget the async boot sequence. The API returns the session
     // immediately in "booting" status; the frontend polls until "ready".
@@ -422,14 +357,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
             case 'delta':
               if (event.content) {
                 state.currentAssistantBuffer += event.content;
-                this.notify(state, { delta: event.content, done: false });
+                this.dispatcher.notify(state, { delta: event.content, done: false });
               }
               break;
 
             case 'thinking':
               if (event.content) {
                 await this.persistToolEvent(state, 'Thinking', event.content);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: 'Thinking…',
@@ -443,7 +378,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
                 const toolLabel = event.label;
                 const toolDetail = event.detail;
                 await this.persistToolEvent(state, toolLabel, toolDetail);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: `Using tool: ${toolLabel}`,
@@ -457,7 +392,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
                 const resultLabel = event.label;
                 const resultDetail = event.detail;
                 await this.persistToolEvent(state, resultLabel, resultDetail);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: `Completed: ${resultLabel}`,
@@ -469,7 +404,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
             case 'status':
               if (event.content) {
                 const statusContent = event.content;
-                this.notify(state, { delta: '', done: false, log: statusContent });
+                this.dispatcher.notify(state, { delta: '', done: false, log: statusContent });
               }
               break;
 
@@ -519,7 +454,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               state.toolEventsLog = [];
 
               // Notify subscribers of end-of-turn
-              this.notify(state, { delta: '', done: true });
+              this.dispatcher.notify(state, { delta: '', done: true });
               return; // Boot complete
             }
 
@@ -548,7 +483,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       state.toolEventsLog = [];
     } catch (err) {
       // If session was already cleaned up by stopSession, nothing more to do
-      if (!this.sessions.has(state.sessionId)) return;
+      if (!this.registry.has(state.sessionId)) return;
 
       // Boot failed — mark session as error so the frontend can show the failure
       // eslint-disable-next-line no-console
@@ -563,14 +498,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         // Best-effort DB update
       }
       if (state.agentSessionId) {
-        this.stoppedAgentSessionIds.set(state.featureId, state.agentSessionId);
+        this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
       }
-      this.sessions.delete(state.sessionId);
+      this.registry.delete(state.sessionId);
     }
   }
 
   async stopSession(sessionId: string): Promise<void> {
-    const state = this.sessions.get(sessionId);
+    const state = this.registry.get(sessionId);
     if (!state) {
       // Already stopped — idempotent
       return;
@@ -592,9 +527,9 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
     // Cache agentSessionId so resumption works when session restarts
     if (state.agentSessionId) {
-      this.stoppedAgentSessionIds.set(state.featureId, state.agentSessionId);
+      this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
     }
-    this.sessions.delete(sessionId);
+    this.registry.delete(sessionId);
 
     // Close the SDK session handle
     if (state.handle) {
@@ -621,7 +556,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       throw new Error(`Session ${sessionId} is not ready — cannot send message`);
     }
 
-    const state = this.sessions.get(sessionId);
+    const state = this.registry.get(sessionId);
     if (!state) {
       throw new Error(`Session ${sessionId} is not ready — cannot send message`);
     }
@@ -685,14 +620,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               if (event.content) {
                 responseText += event.content;
                 state.currentAssistantBuffer += event.content;
-                this.notify(state, { delta: event.content!, done: false });
+                this.dispatcher.notify(state, { delta: event.content!, done: false });
               }
               break;
 
             case 'thinking':
               if (event.content) {
                 await this.persistToolEvent(state, 'Thinking', event.content);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: 'Thinking…',
@@ -706,7 +641,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
                 const toolLabel = event.label;
                 const toolDetail = event.detail;
                 await this.persistToolEvent(state, toolLabel, toolDetail);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: `Using tool: ${toolLabel}`,
@@ -720,7 +655,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
                 const resultLabel = event.label;
                 const resultDetail = event.detail;
                 await this.persistToolEvent(state, resultLabel, resultDetail);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: `Completed: ${resultLabel}`,
@@ -732,7 +667,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
             case 'status':
               if (event.content) {
                 const statusContent = event.content;
-                this.notify(state, { delta: '', done: false, log: statusContent });
+                this.dispatcher.notify(state, { delta: '', done: false, log: statusContent });
               }
               break;
 
@@ -762,7 +697,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'unread');
 
               // Notify subscribers of end-of-turn
-              this.notify(state, { delta: '', done: true });
+              this.dispatcher.notify(state, { delta: '', done: true });
               return; // Turn complete
             }
 
@@ -781,7 +716,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
                   turns: event.usage.numTurns ?? 1,
                 });
               }
-              this.notify(state, {
+              this.dispatcher.notify(state, {
                 delta: '',
                 done: true,
                 log: `Error: ${event.content ?? 'unknown'}`,
@@ -795,7 +730,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               break;
 
             case 'api_retry':
-              this.notify(state, {
+              this.dispatcher.notify(state, {
                 delta: '',
                 done: false,
                 log: event.content ?? 'Retrying API call...',
@@ -803,13 +738,17 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               break;
 
             case 'rate_limit':
-              this.notify(state, { delta: '', done: false, log: event.content ?? 'Rate limited' });
+              this.dispatcher.notify(state, {
+                delta: '',
+                done: false,
+                log: event.content ?? 'Rate limited',
+              });
               break;
 
             case 'task_started':
               if (event.content) {
                 await this.persistToolEvent(state, 'Subtask started', event.content);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: `Subtask: ${event.content}`,
@@ -820,7 +759,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
             case 'task_progress':
               if (event.content) {
-                this.notify(state, { delta: '', done: false, log: `Subtask: ${event.content}` });
+                this.dispatcher.notify(state, {
+                  delta: '',
+                  done: false,
+                  log: `Subtask: ${event.content}`,
+                });
               }
               break;
 
@@ -828,7 +771,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
               if (event.content) {
                 const taskStatus = event.detail ?? 'completed';
                 await this.persistToolEvent(state, `Subtask ${taskStatus}`, event.content);
-                this.notify(state, {
+                this.dispatcher.notify(state, {
                   delta: '',
                   done: false,
                   log: `Subtask ${taskStatus}: ${event.content}`,
@@ -859,7 +802,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       if (responseText && state.currentAssistantBuffer) {
         await this.flushAssistantBuffer(state);
         state.toolEventsLog = [];
-        this.notify(state, { delta: '', done: true });
+        this.dispatcher.notify(state, { delta: '', done: true });
       } else if (!responseText) {
         // Stream ended without any response — SDK session likely died.
         // Mark as error so the next message triggers a fresh session.
@@ -867,15 +810,15 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         console.error(
           `[InteractiveSession] stream ended without response for session ${state.sessionId} — session may have died`
         );
-        this.notify(state, {
+        this.dispatcher.notify(state, {
           delta: '',
           done: true,
           log: 'Session disconnected — will restart on next message',
         });
         if (state.agentSessionId) {
-          this.stoppedAgentSessionIds.set(state.featureId, state.agentSessionId);
+          this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
         }
-        this.sessions.delete(state.sessionId);
+        this.registry.delete(state.sessionId);
         try {
           await this.updateSessionStatusAndNotify(
             state.sessionId,
@@ -889,13 +832,13 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       }
     } catch (err) {
       // If session was already stopped, ignore
-      if (!this.sessions.has(state.sessionId)) return;
+      if (!this.registry.has(state.sessionId)) return;
       // eslint-disable-next-line no-console
       console.error(`[InteractiveSession] turn failed for session ${state.sessionId}:`, err);
     } finally {
       // Release the turn lock and drain the queue
       state.turnInProgress = false;
-      if (this.sessions.has(state.sessionId) && state.turnQueue.length > 0) {
+      if (this.registry.has(state.sessionId) && state.turnQueue.length > 0) {
         const nextContent = state.turnQueue.shift()!;
         state.turnInProgress = true;
         void this.executeAndPersistTurn(state, nextContent);
@@ -909,14 +852,14 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
   async clearMessages(featureId: string): Promise<void> {
     // Stop any active session so the agent doesn't retain old context
-    const state = this.findActiveStateForFeature(featureId);
+    const state = this.registry.findActiveStateForFeature(featureId);
     if (state) {
       await this.stopSession(state.sessionId);
     }
     // Also clear the cached agentSessionId so next session starts fresh
-    this.stoppedAgentSessionIds.delete(featureId);
+    this.registry.deleteStoppedAgentSessionId(featureId);
     await this.workflowStepRepo.deleteByFeatureId(featureId);
-    this.activeStepByFeature.delete(featureId);
+    this.registry.clearActiveStep(featureId);
     return this.messageRepo.deleteByFeatureId(featureId);
   }
 
@@ -925,13 +868,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   subscribe(sessionId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
-    const state = this.sessions.get(sessionId);
-    if (!state) {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      return () => {};
-    }
-    state.subscribers.add(onChunk);
-    return () => state.subscribers.delete(onChunk);
+    return this.dispatcher.subscribeSession(sessionId, onChunk);
   }
 
   // ---------------------------------------------------------------------------
@@ -968,7 +905,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     }
 
     // 2. Find active session for this feature
-    let state = this.findActiveStateForFeature(featureId);
+    let state = this.registry.findActiveStateForFeature(featureId);
 
     // If the caller requested a different model/agent than the running session,
     // silently stop the current session so a new one boots with the new config.
@@ -976,11 +913,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     // instead of resuming the old one (which would keep the old model).
     if (state && model && state.model !== model) {
       await this.stopSession(state.sessionId);
-      this.stoppedAgentSessionIds.delete(featureId);
+      this.registry.deleteStoppedAgentSessionId(featureId);
       state = undefined;
     } else if (state && agentType && state.agentType !== agentType) {
       await this.stopSession(state.sessionId);
-      this.stoppedAgentSessionIds.delete(featureId);
+      this.registry.deleteStoppedAgentSessionId(featureId);
       state = undefined;
     }
 
@@ -1049,7 +986,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     const messages = await this.messageRepo.findByFeatureId(featureId);
 
     // Find active in-memory session
-    const state = this.findActiveStateForFeature(featureId);
+    const state = this.registry.findActiveStateForFeature(featureId);
     let sessionStatus: string | null = null;
     let streamingText: string | null = null;
     let sessionInfo: ChatState['sessionInfo'] = null;
@@ -1159,39 +1096,22 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   subscribeByFeature(featureId: string, onChunk: (chunk: StreamChunk) => void): UnsubscribeFn {
-    // Subscribe at the feature level so the callback survives session restarts.
-    // When a session dies (idle timeout, error) and a new one boots, the SSE
-    // connection keeps receiving events from the new session automatically.
-    let subs = this.featureSubscribers.get(featureId);
-    if (!subs) {
-      subs = new Set();
-      this.featureSubscribers.set(featureId, subs);
-    }
-    subs.add(onChunk);
-    return () => {
-      subs!.delete(onChunk);
-      if (subs!.size === 0) {
-        this.featureSubscribers.delete(featureId);
-      }
-    };
+    return this.dispatcher.subscribeByFeature(featureId, onChunk);
   }
 
   subscribeAll(onChunk: (featureId: string, chunk: StreamChunk) => void): UnsubscribeFn {
-    this.globalSubscribers.add(onChunk);
-    return () => {
-      this.globalSubscribers.delete(onChunk);
-    };
+    return this.dispatcher.subscribeAll(onChunk);
   }
 
   async stopByFeature(featureId: string): Promise<void> {
-    const state = this.findActiveStateForFeature(featureId);
+    const state = this.registry.findActiveStateForFeature(featureId);
     if (!state) return;
     await this.stopSession(state.sessionId);
   }
 
   async markRead(featureId: string): Promise<void> {
     // Find the active session for this feature and clear unread status
-    const state = this.findActiveStateForFeature(featureId);
+    const state = this.registry.findActiveStateForFeature(featureId);
     if (state) {
       void this.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
       return;
@@ -1212,7 +1132,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   async respondToInteraction(featureId: string, answers: Record<string, string>): Promise<void> {
-    const state = this.findActiveStateForFeature(featureId);
+    const state = this.registry.findActiveStateForFeature(featureId);
     if (!state?.pendingInteraction || !state.pendingInteractionResolver) {
       throw new Error(`No pending interaction for feature ${featureId}`);
     }
@@ -1259,15 +1179,15 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   // ---------------------------------------------------------------------------
 
   setActiveStep(featureId: string, stepId: string): void {
-    this.activeStepByFeature.set(featureId, stepId);
+    this.registry.setActiveStep(featureId, stepId);
   }
 
   clearActiveStep(featureId: string): void {
-    this.activeStepByFeature.delete(featureId);
+    this.registry.clearActiveStep(featureId);
   }
 
   notifyWorkflowStep(featureId: string, step: WorkflowStep): void {
-    this.notifyByFeatureId(featureId, {
+    this.dispatcher.notifyByFeatureId(featureId, {
       delta: '',
       done: false,
       workflowStep: step,
@@ -1354,14 +1274,6 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         state.pendingInteractionResolver = resolve;
       });
     };
-  }
-
-  /** Find the in-memory state for an active session for a feature. */
-  private findActiveStateForFeature(featureId: string): SessionState | undefined {
-    for (const state of this.sessions.values()) {
-      if (state.featureId === featureId) return state;
-    }
-    return undefined;
   }
 
   // ---------------------------------------------------------------------------
@@ -1473,39 +1385,6 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   // ---------------------------------------------------------------------------
-  // Event dispatch
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Dispatch a StreamChunk to all subscribers for a session.
-   *
-   * Sends to both session-level subscribers (legacy, for sessionId-based
-   * subscribe()) and feature-level subscribers (for SSE connections that
-   * must survive session restarts).
-   */
-  private notify(state: SessionState, chunk: StreamChunk): void {
-    state.subscribers.forEach((sub) => sub(chunk));
-    const featureSubs = this.featureSubscribers.get(state.featureId);
-    if (featureSubs) {
-      featureSubs.forEach((sub) => sub(chunk));
-    }
-    this.globalSubscribers.forEach((sub) => sub(state.featureId, chunk));
-  }
-
-  /**
-   * Notify feature-level subscribers when no in-memory session state is
-   * available (e.g. while persisting the user message before cold-boot).
-   * Session-scoped subscribers don't exist yet at that point.
-   */
-  private notifyByFeatureId(featureId: string, chunk: StreamChunk): void {
-    const featureSubs = this.featureSubscribers.get(featureId);
-    if (featureSubs) {
-      featureSubs.forEach((sub) => sub(chunk));
-    }
-    this.globalSubscribers.forEach((sub) => sub(featureId, chunk));
-  }
-
-  // ---------------------------------------------------------------------------
   // Mutation helpers — every DB write that changes observable state must go
   // through one of these so SSE subscribers receive a matching notification.
   // This is the contract that lets the client drop periodic polling.
@@ -1516,11 +1395,11 @@ export class InteractiveSessionService implements IInteractiveSessionService {
    *  step for the feature (if any) is stamped onto the row so every
    *  message is grouped under the right step card in the UI. */
   private async persistMessage(message: InteractiveMessage): Promise<void> {
-    const activeStepId = this.activeStepByFeature.get(message.featureId);
+    const activeStepId = this.registry.getActiveStep(message.featureId);
     const tagged: InteractiveMessage =
       message.stepId || !activeStepId ? message : { ...message, stepId: activeStepId };
     await this.messageRepo.create(tagged);
-    this.notifyByFeatureId(tagged.featureId, {
+    this.dispatcher.notifyByFeatureId(tagged.featureId, {
       delta: '',
       done: false,
       message: tagged,
@@ -1541,7 +1420,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     } else {
       await this.sessionRepo.updateStatus(sessionId, status, endedAt);
     }
-    this.notifyByFeatureId(featureId, {
+    this.dispatcher.notifyByFeatureId(featureId, {
       delta: '',
       done: false,
       sessionStatus: status,
@@ -1555,7 +1434,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     turnStatus: string
   ): Promise<void> {
     await this.sessionRepo.updateTurnStatus(sessionId, turnStatus);
-    this.notifyByFeatureId(featureId, {
+    this.dispatcher.notifyByFeatureId(featureId, {
       delta: '',
       done: false,
       turnStatus,

--- a/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
+++ b/packages/core/src/infrastructure/services/interactive/interactive-session.service.ts
@@ -1,13 +1,31 @@
 /**
  * Interactive Session Service
  *
- * Singleton service that owns the lifecycle of all interactive agent sessions.
- * Uses the IAgentExecutorFactory to create interactive executors that manage
- * persistent sessions via the agent SDK. Multi-turn context is maintained
- * by the SDK session handle internally.
+ * Thin facade that implements `IInteractiveSessionService` by delegating
+ * to extracted collaborators. Phase 5 of the strangler refactor — see
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
  *
- * Dependencies are injected via constructor for testability (no real processes
- * are spawned in unit tests — the factory is replaced with a test double).
+ * The following collaborators handle the heavy lifting:
+ * - `SessionBootstrapper`        — startSession + completeBootAsync
+ * - `SessionTerminator`          — stopSession + stopByFeature
+ * - `TurnExecutor`               — executeAndPersistTurn + queue drain
+ * - `UserInteractionCoordinator` — buildOnUserQuestionCallback + respondToInteraction
+ * - `BootPromptResolver`         — three-case boot-prompt logic
+ * - `AgentStreamConsumer`        — SDK stream event loop (phase 4)
+ * - `AgentConfigResolver`        — agent type/auth/cap resolution (phase 3)
+ * - `SessionPersistence`         — monotonic-clock DB writes (phase 2)
+ * - `SessionRegistry`            — in-memory state (phase 1)
+ * - `StreamEventDispatcher`      — SSE fan-out (phase 1)
+ *
+ * Remaining direct logic: sendMessage, sendUserMessage, getChatState,
+ * getSession, getMessages, clearMessages, markRead, getTurnStatuses,
+ * getAllActiveTurnStatuses, setActiveStep, clearActiveStep,
+ * notifyWorkflowStep, waitForTurnDone, subscribe, subscribeByFeature,
+ * subscribeAll — these are slated for phases 6+7.
+ *
+ * Dependencies are injected via constructor for testability (no real
+ * processes are spawned in unit tests — the factory is replaced with a
+ * test double).
  */
 
 import * as crypto from 'node:crypto';
@@ -20,12 +38,6 @@ import type {
 import type { IInteractiveSessionRepository } from '../../../application/ports/output/repositories/interactive-session-repository.interface.js';
 import type { IInteractiveMessageRepository } from '../../../application/ports/output/repositories/interactive-message-repository.interface.js';
 import type { IWorkflowStepRepository } from '../../../application/ports/output/repositories/workflow-step-repository.interface.js';
-import type { IAgentExecutorFactory } from '../../../application/ports/output/agents/agent-executor-factory.interface.js';
-import type {
-  InteractiveAgentSessionHandle,
-  UserInteractionData,
-} from '../../../application/ports/output/agents/interactive-agent-executor.interface.js';
-import type { IFeatureRepository } from '../../../application/ports/output/repositories/feature-repository.interface.js';
 import type {
   InteractiveSession,
   InteractiveMessage,
@@ -36,15 +48,14 @@ import {
   InteractiveMessageRole,
   WorkflowStepStatus,
 } from '../../../domain/generated/output.js';
-import { ConcurrentSessionLimitError } from '../../../domain/errors/concurrent-session-limit.error.js';
-import { type FeatureContextBuilder } from './feature-context.builder.js';
-import type { SessionRegistry, SessionState } from './core/session-registry.js';
+import type { SessionRegistry } from './core/session-registry.js';
 import type { StreamEventDispatcher } from './core/stream-event-dispatcher.js';
 import type { SessionPersistence } from './core/session-persistence.js';
-import type { AgentConfigResolver } from './lifecycle/agent-config.resolver.js';
 import type { ILogger } from '../../../application/ports/output/services/logger.interface.js';
-import { BootWatchdog } from './lifecycle/boot-watchdog.js';
-import { type AgentStreamConsumer } from './runtime/agent-stream.consumer.js';
+import type { SessionBootstrapper } from './lifecycle/session-bootstrapper.js';
+import type { SessionTerminator } from './lifecycle/session-terminator.js';
+import type { TurnExecutor } from './runtime/turn.executor.js';
+import type { UserInteractionCoordinator } from './runtime/user-interaction.coordinator.js';
 
 /**
  * Core service managing interactive agent session lifecycles.
@@ -65,20 +76,21 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   constructor(
     private readonly sessionRepo: IInteractiveSessionRepository,
     private readonly messageRepo: IInteractiveMessageRepository,
-    private readonly executorFactory: IAgentExecutorFactory,
-    private readonly featureRepo: IFeatureRepository,
-    private readonly contextBuilder: FeatureContextBuilder,
+    _featureRepo: unknown, // owned by SessionBootstrapper — kept for signature arity
+    _contextBuilder: unknown, // owned by BootPromptResolver — kept for signature arity
     private readonly workflowStepRepo: IWorkflowStepRepository,
     private readonly registry: SessionRegistry,
     private readonly dispatcher: StreamEventDispatcher,
     private readonly persistence: SessionPersistence,
-    private readonly agentConfigResolver: AgentConfigResolver,
-    private readonly streamConsumer: AgentStreamConsumer,
-    private readonly logger: ILogger
+    _logger: ILogger, // owned by collaborators — kept for signature arity
+    private readonly bootstrapper: SessionBootstrapper,
+    private readonly terminator: SessionTerminator,
+    private readonly turnExecutor: TurnExecutor,
+    private readonly interactionCoordinator: UserInteractionCoordinator
   ) {}
 
   // ---------------------------------------------------------------------------
-  // Public API
+  // Public API — delegated to collaborators
   // ---------------------------------------------------------------------------
 
   async startSession(
@@ -89,350 +101,18 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     systemPrompt?: string,
     initialUserMessage?: string
   ): Promise<InteractiveSession> {
-    const cap = this.agentConfigResolver.getCap();
-    const activeCount = await this.sessionRepo.countActiveSessions();
-    if (activeCount >= cap) {
-      throw new ConcurrentSessionLimitError(activeCount, cap);
-    }
-
-    // ─────────────────────────────────────────────────────────────
-    // Resume-aware boot: look up the previous session's agent
-    // sessionId BEFORE inserting the new row.
-    //
-    // Ordering matters CRITICALLY here. If we created the new DB
-    // session row first and then called `findByFeatureId`, the repo
-    // would return the row we just inserted (most recent by
-    // createdAt) — which has no agentSessionId yet — and the old,
-    // semantically-still-meaningful row would be invisible. That
-    // silently downgrades every reboot to a `createSession` call,
-    // stranding the agent with zero conversation history and making
-    // it answer "this appears to be the start of our conversation"
-    // to the user's second message. Look it up first.
-    // ─────────────────────────────────────────────────────────────
-    let previousAgentSessionId: string | undefined;
-    for (const s of this.registry.values()) {
-      if (s.featureId === featureId && s.agentSessionId) {
-        previousAgentSessionId = s.agentSessionId;
-        break;
-      }
-    }
-    // Also check stoppedSessions cache (populated on stop)
-    previousAgentSessionId ??= this.registry.takeStoppedAgentSessionId(featureId);
-    // Fall back to DB — the in-memory cache may be empty after
-    // service restart, hot reload, or Turbopack module re-init.
-    //
-    // Use `findLatestAgentSessionIdForFeature` (not `findByFeatureId`
-    // → `getAgentSessionId`) so we walk BACK through history to find
-    // the most recent session that actually captured an
-    // agentSessionId. This covers the case where the latest row is a
-    // failed-boot session with a NULL agentSessionId — without this,
-    // one bad boot would permanently orphan the agent conversation.
-    previousAgentSessionId ??=
-      (await this.sessionRepo.findLatestAgentSessionIdForFeature(featureId)) ?? undefined;
-
-    // Create DB record with booting status (AFTER the lookup above).
-    const now = new Date();
-    const session: InteractiveSession = {
-      id: crypto.randomUUID(),
-      featureId,
-      status: InteractiveSessionStatus.booting,
-      startedAt: now,
-      lastActivityAt: now,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await this.sessionRepo.create(session);
-    this.dispatcher.notifyByFeatureId(featureId, {
-      delta: '',
-      done: false,
-      sessionStatus: InteractiveSessionStatus.booting,
-    });
-
-    // Mark as processing immediately so the FAB shows the spinner during boot
-    void this.persistence.updateTurnStatusAndNotify(session.id, featureId, 'processing');
-
-    // Set up in-memory state. CRITICAL: pendingUserContent must be set
-    // BEFORE completeBootAsync is dispatched below. Setting it from the
-    // caller after startSession returns is a race — the async boot may
-    // already be reading state.pendingUserContent === undefined on the
-    // same microtask, fall into the "no-first-turn" branch, and silently
-    // skip the kickoff send.
-    const state: SessionState = {
-      sessionId: session.id,
+    return this.bootstrapper.startSession(
       featureId,
       worktreePath,
       model,
       agentType,
       systemPrompt,
-      handle: null,
-      agentSessionId: previousAgentSessionId,
-      currentAssistantBuffer: '',
-      toolEventsLog: [],
-      subscribers: new Set(),
-      turnInProgress: false,
-      turnQueue: [],
-      pendingInteraction: null,
-      pendingInteractionResolver: null,
-      pendingUserContent: initialUserMessage,
-    };
-    this.registry.set(session.id, state);
-
-    // Fire-and-forget the async boot sequence. The API returns the session
-    // immediately in "booting" status; the frontend polls until "ready".
-    void this.completeBootAsync(state, featureId, worktreePath);
-
-    return session;
-  }
-
-  /**
-   * Asynchronously complete the boot sequence: build feature context,
-   * create an SDK session via the interactive executor, send the boot
-   * prompt, iterate the stream for the greeting, persist the greeting,
-   * and transition the session to "ready".
-   */
-  private async completeBootAsync(
-    state: SessionState,
-    featureId: string,
-    worktreePath: string
-  ): Promise<void> {
-    try {
-      // Resolve the system prompt for the agent SDK. If the caller
-      // supplied one (e.g. Application chat uses the Shep brief,
-      // Repository/Global chats their own), use it verbatim. Otherwise
-      // fall back to the default feature-context prompt — that's still
-      // the right thing for classic `feat-*` scopes where the session
-      // service owns context-building.
-      let context: string;
-      if (state.systemPrompt !== undefined) {
-        context = state.systemPrompt;
-      } else {
-        const feature = await this.featureRepo.findById(featureId);
-        const openPRs: string[] = feature?.pr?.url ? [feature.pr.url] : [];
-        context = this.contextBuilder.buildContext(
-          feature ??
-            ({ id: featureId, name: featureId } as Parameters<
-              FeatureContextBuilder['buildContext']
-            >[0]),
-          worktreePath,
-          openPRs
-        );
-      }
-
-      // Decide what to send as the first turn (`handle.send(bootPrompt)`
-      // below). The chat is stateless from the agent's point of view —
-      // no prior history is injected, no session-restart rules, no
-      // "conversation log read-only" wrapper. Three cases:
-      //
-      // 1. User already sent a message that booted this session
-      //    (Application chat, or any scope that calls sendUserMessage
-      //    cold) → that pending content IS the first turn.
-      //
-      // 2. No pending message AND no caller-supplied systemPrompt →
-      //    legacy Feature-chat path: send the feature context as the
-      //    boot prompt so the agent greets the user based on it.
-      //
-      // 3. No pending message BUT caller supplied systemPrompt →
-      //    scope is self-describing; stay silent and wait for the user
-      //    to speak. Applicable to any generic scope (Application,
-      //    Repository, Global) where a chatty greeting isn't wanted.
-      let bootPrompt: string;
-      if (state.pendingUserContent !== undefined) {
-        bootPrompt = state.pendingUserContent;
-        state.pendingUserContent = undefined;
-      } else if (state.systemPrompt === undefined) {
-        bootPrompt = context;
-      } else {
-        bootPrompt = '';
-      }
-
-      // Resolve agent type and auth config from settings
-      const resolvedAgentType = this.agentConfigResolver.resolveAgentType(state.agentType);
-      const authConfig = this.agentConfigResolver.resolveAuthConfig();
-
-      // Create the interactive executor and session
-      const executor = this.executorFactory.createInteractiveExecutor(
-        resolvedAgentType,
-        authConfig
-      );
-      let handle: InteractiveAgentSessionHandle;
-
-      // Build the onUserQuestion callback that pauses the SDK stream
-      // and waits for user input via the UI.
-      const onUserQuestion = this.buildOnUserQuestionCallback(state);
-
-      const previousAgentSessionId = state.agentSessionId;
-      if (previousAgentSessionId) {
-        // Resume existing SDK session
-        handle = await executor.resumeSession(previousAgentSessionId, {
-          cwd: worktreePath,
-          model: state.model,
-          systemPrompt: context,
-          onUserQuestion,
-        });
-      } else {
-        // Create new SDK session
-        handle = await executor.createSession({
-          cwd: worktreePath,
-          model: state.model,
-          systemPrompt: context,
-          onUserQuestion,
-        });
-      }
-
-      state.handle = handle;
-
-      // If there's no first user turn to act on, don't push anything —
-      // the session is ready the moment the SDK handle exists. The user
-      // will send their first message through the normal turn path.
-      if (!bootPrompt) {
-        await this.persistence.updateSessionStatusAndNotify(
-          state.sessionId,
-          state.featureId,
-          InteractiveSessionStatus.ready
-        );
-        void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
-        return;
-      }
-
-      // Send the boot prompt and iterate stream for the greeting
-      await handle.send(bootPrompt);
-
-      const bootAbort = new AbortController();
-      state.streamAbort = bootAbort;
-
-      // Idle watchdog: reset on every event. If the agent goes silent
-      // for longer than BootWatchdog.IDLE_TIMEOUT_MS, abort the boot.
-      // This is NOT a wall-clock budget — long first turns (full project
-      // scaffold + install + build) are fine as long as the stream
-      // keeps producing events.
-      const watchdog = new BootWatchdog();
-      watchdog.start(() => bootAbort.abort());
-
-      let result;
-      try {
-        result = await this.streamConsumer.consume(handle, state, 'boot', bootAbort, watchdog);
-      } finally {
-        watchdog.stop();
-        state.streamAbort = undefined;
-      }
-
-      if (result.completed === 'done') {
-        // Capture the SDK session ID (available after first message exchange)
-        const sdkSessionId = result.agentSessionIdFromHandle;
-        if (sdkSessionId) {
-          // Detect CWD mismatch: if we tried to resume but got a different
-          // session ID, the SDK silently created a fresh session (typically
-          // because the cwd changed or session JSONL was lost).
-          if (previousAgentSessionId && sdkSessionId !== previousAgentSessionId) {
-            this.logger.warn(
-              `[InteractiveSession] Session resume mismatch for feature ${featureId}: ` +
-                `expected ${previousAgentSessionId}, got ${sdkSessionId}. ` +
-                `SDK created a fresh session (likely cwd changed or session expired).`
-            );
-          }
-          state.agentSessionId = sdkSessionId;
-          // Persist to DB so it survives service restarts
-          void this.sessionRepo.updateAgentSessionId(state.sessionId, sdkSessionId);
-        }
-
-        await this.persistence.updateSessionStatusAndNotify(
-          state.sessionId,
-          state.featureId,
-          InteractiveSessionStatus.ready
-        );
-
-        // If there's a pending user message, the next turn will set 'processing'.
-        // Otherwise boot greeting is expected — mark idle.
-        if (!state.pendingUserContent) {
-          void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
-        }
-
-        state.currentAssistantBuffer = '';
-        state.toolEventsLog = [];
-
-        // Notify subscribers of end-of-turn
-        this.dispatcher.notify(state, { delta: '', done: true });
-        return; // Boot complete
-      }
-
-      // ended-without-done: persist trailing text and transition to ready.
-      await this.persistence.updateSessionStatusAndNotify(
-        state.sessionId,
-        state.featureId,
-        InteractiveSessionStatus.ready
-      );
-      if (!state.pendingUserContent) {
-        void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
-      }
-      state.currentAssistantBuffer = '';
-      state.toolEventsLog = [];
-    } catch (err) {
-      // If session was already cleaned up by stopSession, nothing more to do
-      if (!this.registry.has(state.sessionId)) return;
-
-      // Boot failed — mark session as error so the frontend can show the failure
-      // eslint-disable-next-line no-console
-      console.error(`[InteractiveSession] boot failed for session ${state.sessionId}:`, err);
-      try {
-        await this.persistence.updateSessionStatusAndNotify(
-          state.sessionId,
-          state.featureId,
-          InteractiveSessionStatus.error
-        );
-      } catch {
-        // Best-effort DB update
-      }
-      if (state.agentSessionId) {
-        this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
-      }
-      this.registry.delete(state.sessionId);
-    }
+      initialUserMessage
+    );
   }
 
   async stopSession(sessionId: string): Promise<void> {
-    const state = this.registry.get(sessionId);
-    if (!state) {
-      // Already stopped — idempotent
-      return;
-    }
-
-    // eslint-disable-next-line no-console
-    console.log(
-      `[InteractiveSession] stopSession called for ${sessionId} (feature: ${state.featureId})`,
-      new Error().stack?.split('\n').slice(1, 4).join(' <- ')
-    );
-
-    // Abort any active stream iteration and clear pending turns
-    if (state.streamAbort) {
-      state.streamAbort.abort();
-      state.streamAbort = undefined;
-    }
-    state.turnQueue.length = 0;
-    state.turnInProgress = false;
-
-    // Cache agentSessionId so resumption works when session restarts
-    if (state.agentSessionId) {
-      this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
-    }
-    this.registry.delete(sessionId);
-
-    // Close the SDK session handle
-    if (state.handle) {
-      try {
-        await state.handle.close();
-      } catch {
-        // Session may already be closed
-      }
-      state.handle = null;
-    }
-
-    await this.persistence.updateSessionStatusAndNotify(
-      sessionId,
-      state.featureId,
-      InteractiveSessionStatus.stopped,
-      new Date()
-    );
-    void this.persistence.updateTurnStatusAndNotify(sessionId, state.featureId, 'idle');
+    return this.terminator.stop(sessionId);
   }
 
   async sendMessage(sessionId: string, content: string): Promise<InteractiveMessage> {
@@ -461,286 +141,10 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
     await this.sessionRepo.updateLastActivity(sessionId, now);
 
-    // Guard: only one turn at a time per session (SDK stream is not concurrent-safe)
-    if (state.turnInProgress) {
-      state.turnQueue.push(content);
-    } else {
-      state.turnInProgress = true;
-      void this.executeAndPersistTurn(state, content);
-    }
+    // Delegate turn execution to TurnExecutor (guarded: one turn at a time)
+    void this.turnExecutor.enqueueTurn(state, content);
 
     return message;
-  }
-
-  /**
-   * Execute a turn via the SDK session handle and persist the assistant response.
-   */
-  private async executeAndPersistTurn(state: SessionState, prompt: string): Promise<void> {
-    try {
-      if (!state.handle) {
-        throw new Error('No active session handle — cannot execute turn');
-      }
-
-      state.currentAssistantBuffer = '';
-      state.toolEventsLog = [];
-
-      // Mark turn as processing for dot indicator
-      void this.persistence.updateTurnStatusAndNotify(
-        state.sessionId,
-        state.featureId,
-        'processing'
-      );
-
-      // Send the message to the SDK session
-      await state.handle.send(prompt);
-
-      // Set up abort controller for this stream
-      const abort = new AbortController();
-      state.streamAbort = abort;
-
-      let responseText = '';
-
-      try {
-        for await (const event of state.handle.stream()) {
-          if (abort.signal.aborted) break;
-
-          switch (event.type) {
-            case 'delta':
-              if (event.content) {
-                responseText += event.content;
-                state.currentAssistantBuffer += event.content;
-                this.dispatcher.notify(state, { delta: event.content!, done: false });
-              }
-              break;
-
-            case 'thinking':
-              if (event.content) {
-                await this.persistence.persistToolEvent(state, 'Thinking', event.content);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: 'Thinking…',
-                  activity: { kind: 'thinking', label: 'Thinking', detail: event.content },
-                });
-              }
-              break;
-
-            case 'tool_use':
-              if (event.label) {
-                const toolLabel = event.label;
-                const toolDetail = event.detail;
-                await this.persistence.persistToolEvent(state, toolLabel, toolDetail);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Using tool: ${toolLabel}`,
-                  activity: { kind: 'tool_use', label: toolLabel, detail: toolDetail },
-                });
-              }
-              break;
-
-            case 'tool_result':
-              if (event.label) {
-                const resultLabel = event.label;
-                const resultDetail = event.detail;
-                await this.persistence.persistToolEvent(state, resultLabel, resultDetail);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Completed: ${resultLabel}`,
-                  activity: { kind: 'tool_result', label: resultLabel, detail: resultDetail },
-                });
-              }
-              break;
-
-            case 'status':
-              if (event.content) {
-                const statusContent = event.content;
-                this.dispatcher.notify(state, { delta: '', done: false, log: statusContent });
-              }
-              break;
-
-            case 'done': {
-              // All delta text has been persisted incrementally via
-              // `flushAssistantBuffer` as each tool call was recorded,
-              // so the remaining buffer holds only the trailing prose
-              // after the final tool call. Flush it as its own message.
-              // We intentionally do NOT persist `event.content` /
-              // `responseText` here — that would duplicate everything
-              // we already flushed between tools.
-              await this.persistence.flushAssistantBuffer(state);
-              state.toolEventsLog = [];
-
-              // Accumulate usage from this turn
-              if (event.usage) {
-                void this.sessionRepo.accumulateUsage(state.sessionId, {
-                  costUsd: event.usage.costUsd ?? 0,
-                  inputTokens: event.usage.inputTokens ?? 0,
-                  outputTokens: event.usage.outputTokens ?? 0,
-                  turns: event.usage.numTurns ?? 1,
-                });
-              }
-
-              // Mark as unread — if user has the chat open, the frontend
-              // will immediately call markRead to clear it
-              void this.persistence.updateTurnStatusAndNotify(
-                state.sessionId,
-                state.featureId,
-                'unread'
-              );
-
-              // Notify subscribers of end-of-turn
-              this.dispatcher.notify(state, { delta: '', done: true });
-              return; // Turn complete
-            }
-
-            case 'error':
-              // eslint-disable-next-line no-console
-              console.error(
-                `[InteractiveSession] agent error during turn for session ${state.sessionId}:`,
-                event.content
-              );
-              // Accumulate usage even on errors — cost was still incurred
-              if (event.usage) {
-                void this.sessionRepo.accumulateUsage(state.sessionId, {
-                  costUsd: event.usage.costUsd ?? 0,
-                  inputTokens: event.usage.inputTokens ?? 0,
-                  outputTokens: event.usage.outputTokens ?? 0,
-                  turns: event.usage.numTurns ?? 1,
-                });
-              }
-              this.dispatcher.notify(state, {
-                delta: '',
-                done: true,
-                log: `Error: ${event.content ?? 'unknown'}`,
-              });
-              break;
-
-            case 'init':
-              // The SDK emits init on every turn, but we only show "Session started"
-              // during boot (handled in completeBootAsync). Ignore it here to avoid
-              // spamming the chat with repeated session-started messages.
-              break;
-
-            case 'api_retry':
-              this.dispatcher.notify(state, {
-                delta: '',
-                done: false,
-                log: event.content ?? 'Retrying API call...',
-              });
-              break;
-
-            case 'rate_limit':
-              this.dispatcher.notify(state, {
-                delta: '',
-                done: false,
-                log: event.content ?? 'Rate limited',
-              });
-              break;
-
-            case 'task_started':
-              if (event.content) {
-                await this.persistence.persistToolEvent(state, 'Subtask started', event.content);
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Subtask: ${event.content}`,
-                  activity: { kind: 'system', label: 'Subtask started', detail: event.content },
-                });
-              }
-              break;
-
-            case 'task_progress':
-              if (event.content) {
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Subtask: ${event.content}`,
-                });
-              }
-              break;
-
-            case 'task_done':
-              if (event.content) {
-                const taskStatus = event.detail ?? 'completed';
-                await this.persistence.persistToolEvent(
-                  state,
-                  `Subtask ${taskStatus}`,
-                  event.content
-                );
-                this.dispatcher.notify(state, {
-                  delta: '',
-                  done: false,
-                  log: `Subtask ${taskStatus}: ${event.content}`,
-                  activity: {
-                    kind: 'system',
-                    label: `Subtask ${taskStatus}`,
-                    detail: event.content,
-                  },
-                });
-              }
-              break;
-
-            case 'user_question':
-              // AskUserQuestion is now handled by the canUseTool callback
-              // (buildOnUserQuestionCallback) which pauses the SDK stream.
-              // This event should not appear in the stream anymore, but if it
-              // does (e.g. from a different code path), ignore it here.
-              break;
-          }
-        }
-      } finally {
-        state.streamAbort = undefined;
-      }
-
-      // If we exit the stream loop without a 'done' event (stream ended),
-      // persist whatever trailing text remains in the buffer (earlier
-      // text was flushed incrementally alongside tool events).
-      if (responseText && state.currentAssistantBuffer) {
-        await this.persistence.flushAssistantBuffer(state);
-        state.toolEventsLog = [];
-        this.dispatcher.notify(state, { delta: '', done: true });
-      } else if (!responseText) {
-        // Stream ended without any response — SDK session likely died.
-        // Mark as error so the next message triggers a fresh session.
-        // eslint-disable-next-line no-console
-        console.error(
-          `[InteractiveSession] stream ended without response for session ${state.sessionId} — session may have died`
-        );
-        this.dispatcher.notify(state, {
-          delta: '',
-          done: true,
-          log: 'Session disconnected — will restart on next message',
-        });
-        if (state.agentSessionId) {
-          this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
-        }
-        this.registry.delete(state.sessionId);
-        try {
-          await this.persistence.updateSessionStatusAndNotify(
-            state.sessionId,
-            state.featureId,
-            InteractiveSessionStatus.error
-          );
-        } catch {
-          // Best-effort DB update
-        }
-        return; // Skip queue drain — session is dead
-      }
-    } catch (err) {
-      // If session was already stopped, ignore
-      if (!this.registry.has(state.sessionId)) return;
-      // eslint-disable-next-line no-console
-      console.error(`[InteractiveSession] turn failed for session ${state.sessionId}:`, err);
-    } finally {
-      // Release the turn lock and drain the queue
-      state.turnInProgress = false;
-      if (this.registry.has(state.sessionId) && state.turnQueue.length > 0) {
-        const nextContent = state.turnQueue.shift()!;
-        state.turnInProgress = true;
-        void this.executeAndPersistTurn(state, nextContent);
-      }
-    }
   }
 
   async getMessages(featureId: string, limit?: number): Promise<InteractiveMessage[]> {
@@ -751,7 +155,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     // Stop any active session so the agent doesn't retain old context
     const state = this.registry.findActiveStateForFeature(featureId);
     if (state) {
-      await this.stopSession(state.sessionId);
+      await this.terminator.stop(state.sessionId);
     }
     // Also clear the cached agentSessionId so next session starts fresh
     this.registry.deleteStoppedAgentSessionId(featureId);
@@ -785,9 +189,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     // 1. Persist user message to DB immediately — this is the source
     //    of truth. SKIPPED when `persistUserMessage === false`, which
     //    the application-creation flow uses to boot the session on top
-    //    of a user message it already wrote in the foreground (so the
-    //    chat renders the bubble instantly, long before the slow
-    //    scaffold and session-boot work completes).
+    //    of a user message it already wrote in the foreground.
     const now = new Date();
     const userMsg: InteractiveMessage = {
       id: crypto.randomUUID(),
@@ -806,14 +208,12 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
     // If the caller requested a different model/agent than the running session,
     // silently stop the current session so a new one boots with the new config.
-    // Also clear the cached agentSessionId so we create a fresh SDK session
-    // instead of resuming the old one (which would keep the old model).
     if (state && model && state.model !== model) {
-      await this.stopSession(state.sessionId);
+      await this.terminator.stop(state.sessionId);
       this.registry.deleteStoppedAgentSessionId(featureId);
       state = undefined;
     } else if (state && agentType && state.agentType !== agentType) {
-      await this.stopSession(state.sessionId);
+      await this.terminator.stop(state.sessionId);
       this.registry.deleteStoppedAgentSessionId(featureId);
       state = undefined;
     }
@@ -823,12 +223,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       if (dbSession?.status === InteractiveSessionStatus.ready) {
         // Session ready — send to agent (guarded: one turn at a time)
         await this.sessionRepo.updateLastActivity(state.sessionId, now);
-        if (state.turnInProgress) {
-          state.turnQueue.push(content);
-        } else {
-          state.turnInProgress = true;
-          void this.executeAndPersistTurn(state, content);
-        }
+        void this.turnExecutor.enqueueTurn(state, content);
       } else if (dbSession?.status === InteractiveSessionStatus.booting) {
         // Session booting — queue the message
         state.pendingUserContent = content;
@@ -836,8 +231,6 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     } else {
       // No in-memory session — check DB for an orphaned active session (e.g. after
       // service restart / hot-reload) and mark it stopped before booting a new one.
-      // The agentSessionId is persisted in DB so startSession will pick it up for
-      // SDK session resumption.
       const dbSession = await this.sessionRepo.findByFeatureId(featureId);
       if (
         dbSession &&
@@ -852,18 +245,9 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         );
       }
 
-      // Boot a new session — startSession will find the agentSessionId from DB.
-      // Pass the first-turn content as `initialUserMessage` so it's
-      // written to the session state atomically BEFORE completeBootAsync
-      // is dispatched. Do NOT set pendingUserContent after startSession
-      // returns — that races with the async boot and results in the
-      // first turn being silently dropped.
-      //
-      // When the caller supplies `agentKickoffOverride` (e.g. the
-      // application-creation flow's "read SHEP_BRIEF.md first"
-      // directive), the agent's first turn uses the override while the
-      // DB-persisted user message keeps the raw `content` untouched —
-      // so the chat UI still shows just the user's verbatim request.
+      // Boot a new session. Pass the first-turn content as `initialUserMessage`
+      // so it's written to the session state atomically BEFORE completeBootAsync
+      // is dispatched.
       const firstTurnContent = agentKickoffOverride ?? content;
       await this.startSession(
         featureId,
@@ -913,11 +297,10 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         totalOutputTokens: usage?.totalOutputTokens ?? null,
       };
     } else {
-      // No in-memory state — check DB for last session (e.g. after server restart / hot-reload)
+      // No in-memory state — check DB for last session (e.g. after server restart)
       const latest = await this.sessionRepo.findByFeatureId(featureId);
       if (latest) {
         sessionStatus = latest.status as string;
-        // Show DB info even without live process (process was lost on restart)
         if (
           latest.status !== InteractiveSessionStatus.stopped &&
           latest.status !== InteractiveSessionStatus.error
@@ -948,7 +331,6 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       const statuses = await this.sessionRepo.getTurnStatuses([featureId]);
       turnStatus = statuses.get(featureId) ?? 'idle';
     } else {
-      // Check DB for the latest session's turn status
       const latest = await this.sessionRepo.findByFeatureId(featureId);
       if (latest) {
         const statuses = await this.sessionRepo.getTurnStatuses([featureId]);
@@ -959,12 +341,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     // Include pending interaction if one exists
     const pendingInteraction = state?.pendingInteraction ?? null;
 
-    // ── Workflow view — derived entirely from the DB so a browser
-    // refresh or daemon restart sees the exact same progress state.
-    // A step row in `running` status means the orchestrator had
-    // started that step before the crash; recovery flips it to
-    // `interrupted` at boot so we never show stale "running" after
-    // the daemon dies.
+    // Workflow view — derived entirely from the DB
     const workflowSteps = await this.workflowStepRepo.listByFeature(featureId);
     let workflow: ChatState['workflow'] = null;
     if (workflowSteps.length > 0) {
@@ -974,10 +351,6 @@ export class InteractiveSessionService implements IInteractiveSessionService {
         steps: workflowSteps,
         currentStepId: running?.id ?? null,
       };
-      // Derive turnStatus from the workflow: if any step is running,
-      // the agent is working — regardless of whether the in-memory
-      // session has been reloaded yet. This is the fix for "lose
-      // in-progress after refresh": the answer is always a SELECT.
       if (running) turnStatus = 'processing';
     }
 
@@ -1001,19 +374,15 @@ export class InteractiveSessionService implements IInteractiveSessionService {
   }
 
   async stopByFeature(featureId: string): Promise<void> {
-    const state = this.registry.findActiveStateForFeature(featureId);
-    if (!state) return;
-    await this.stopSession(state.sessionId);
+    return this.terminator.stopByFeature(featureId);
   }
 
   async markRead(featureId: string): Promise<void> {
-    // Find the active session for this feature and clear unread status
     const state = this.registry.findActiveStateForFeature(featureId);
     if (state) {
       void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
       return;
     }
-    // Fallback: check DB for the latest active session
     const latest = await this.sessionRepo.findByFeatureId(featureId);
     if (latest) {
       void this.persistence.updateTurnStatusAndNotify(latest.id, featureId, 'idle');
@@ -1033,42 +402,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
     if (!state?.pendingInteraction || !state.pendingInteractionResolver) {
       throw new Error(`No pending interaction for feature ${featureId}`);
     }
-
-    // Persist the user's answers as a structured user message.
-    // The {{interaction}} prefix lets the frontend detect and render it
-    // as a compact green bubble instead of a regular text message.
-    const interactionPayload = {
-      questions: state.pendingInteraction.questions.map((q) => ({
-        header: q.header,
-        question: q.question,
-      })),
-      answers,
-    };
-    const now = new Date();
-    const userMsg: InteractiveMessage = {
-      id: crypto.randomUUID(),
-      featureId: state.featureId,
-      sessionId: state.sessionId,
-      role: InteractiveMessageRole.user,
-      content: `{{interaction}}${JSON.stringify(interactionPayload)}`,
-      createdAt: now,
-      updatedAt: now,
-    };
-    await this.persistence.persistMessage(userMsg);
-
-    // Resolve the Promise that the canUseTool callback is awaiting.
-    // This unblocks the SDK stream — the agent resumes with the user's answers.
-    state.pendingInteractionResolver(answers);
-
-    // Clear pending interaction state
-    state.pendingInteraction = null;
-    state.pendingInteractionResolver = null;
-
-    // Update turn status back to processing
-    void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'processing');
-
-    // Clear the "Waiting for your response..." log
-    state.subscribers.forEach((sub) => sub({ delta: '', done: false }));
+    return this.interactionCoordinator.respondToInteraction(state, answers);
   }
 
   // ---------------------------------------------------------------------------
@@ -1093,9 +427,7 @@ export class InteractiveSessionService implements IInteractiveSessionService {
 
   /**
    * Resolves the next time any subscriber receives a `done: true`
-   * chunk for the given feature. The orchestrator subscribes BEFORE
-   * sending the step prompt so the resolution can't race with the
-   * agent finishing before the promise is set up.
+   * chunk for the given feature.
    */
   async waitForTurnDone(featureId: string, signal?: AbortSignal): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -1118,78 +450,4 @@ export class InteractiveSessionService implements IInteractiveSessionService {
       signal?.addEventListener('abort', onAbort);
     });
   }
-
-  /**
-   * Build the onUserQuestion callback for a session.
-   * Called by the SDK's canUseTool when the agent invokes AskUserQuestion.
-   * Returns a Promise that doesn't resolve until the user submits their answers.
-   */
-  private buildOnUserQuestionCallback(state: SessionState) {
-    return async (interaction: UserInteractionData): Promise<Record<string, string>> => {
-      // Flush any accumulated assistant text as a separate message BEFORE
-      // the interaction. This ensures the agent's question text appears
-      // above the green answer bubble in the conversation history.
-      if (state.currentAssistantBuffer.trim()) {
-        const now = new Date();
-        const msg: InteractiveMessage = {
-          id: crypto.randomUUID(),
-          featureId: state.featureId,
-          sessionId: state.sessionId,
-          role: InteractiveMessageRole.assistant,
-          content: state.currentAssistantBuffer,
-          createdAt: now,
-          updatedAt: now,
-        };
-        await this.persistence.persistMessage(msg);
-        state.currentAssistantBuffer = '';
-        state.toolEventsLog = [];
-
-        // Notify subscribers so the frontend picks up the new message
-        state.subscribers.forEach((sub) => sub({ delta: '', done: true }));
-        // Small delay so the refetch completes before the interaction appears
-        await new Promise<void>((r) => setTimeout(r, 100));
-      }
-
-      // Store the interaction data for the frontend
-      state.pendingInteraction = interaction;
-
-      // Update turn status so the dot indicator shows amber
-      void this.persistence.updateTurnStatusAndNotify(
-        state.sessionId,
-        state.featureId,
-        'awaiting_input'
-      );
-
-      // Notify subscribers so SSE pushes the interaction to the frontend
-      state.subscribers.forEach((sub) =>
-        sub({
-          delta: '',
-          done: false,
-          log: 'Waiting for your response...',
-          interaction,
-        })
-      );
-
-      // Create a Promise that will be resolved when the user calls respondToInteraction
-      return new Promise<Record<string, string>>((resolve) => {
-        state.pendingInteractionResolver = resolve;
-      });
-    };
-  }
-
-  // Agent type / auth / concurrent-session cap resolution lives on
-  // `AgentConfigResolver` (`lifecycle/agent-config.resolver.ts`) — this
-  // facade delegates via `this.agentConfigResolver.*`. The resolver
-  // reads settings through an injected `ISettingsProvider` port so no
-  // component in this file calls the `settings.service` singleton.
-
-  // Persistence + monotonic-clock helpers live on SessionPersistence
-  // (`core/session-persistence.ts`) — this facade delegates via
-  // `this.persistence.*`. The collaborator is a DI singleton so the
-  // monotonic counter is shared process-wide.
-
-  // Idle-eviction timer removed. Live agent sessions are preserved
-  // indefinitely and only stop on an explicit user action (Stop
-  // button, new session reset, server shutdown). See `stopSession`
-  // for the only teardown path.
 }

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/agent-config.resolver.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/agent-config.resolver.ts
@@ -1,0 +1,56 @@
+/**
+ * AgentConfigResolver
+ *
+ * Resolves the concrete agent type, auth config, and concurrent-session
+ * cap for a pending interactive session. Consults the global Shep
+ * settings via an injected `ISettingsProvider` so this collaborator
+ * never calls the `settings.service` singleton directly — removing the
+ * clean-architecture violation where the monolithic
+ * `InteractiveSessionService` imported `getSettings` / `hasSettings`
+ * from infrastructure.
+ *
+ * Extracted from `interactive-session.service.ts` in phase 3 of the
+ * strangler refactor documented at
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import type { ISettingsProvider } from '../../../../application/ports/output/services/settings-provider.interface.js';
+import type { AgentConfig } from '../../../../domain/generated/output.js';
+import { AgentType, AgentAuthMethod } from '../../../../domain/generated/output.js';
+
+/** Default concurrent session cap when settings are absent or missing the override. */
+export const DEFAULT_CAP = 3;
+
+export class AgentConfigResolver {
+  constructor(private readonly settingsProvider: ISettingsProvider) {}
+
+  /** Resolve the agent type from an explicit override or settings. */
+  resolveAgentType(agentTypeOverride?: string): AgentType {
+    if (agentTypeOverride) {
+      return agentTypeOverride as AgentType;
+    }
+    if (this.settingsProvider.has()) {
+      return this.settingsProvider.get().agent.type;
+    }
+    return AgentType.ClaudeCode;
+  }
+
+  /** Resolve the auth config from settings, with a safe fallback. */
+  resolveAuthConfig(): AgentConfig {
+    if (this.settingsProvider.has()) {
+      return this.settingsProvider.get().agent;
+    }
+    // Fallback for when settings haven't been initialized yet
+    return {
+      type: AgentType.ClaudeCode,
+      authMethod: AgentAuthMethod.Session,
+    };
+  }
+
+  /** Read the concurrent session cap from settings or fall back to default. */
+  getCap(): number {
+    if (!this.settingsProvider.has()) return DEFAULT_CAP;
+    const settings = this.settingsProvider.get();
+    return settings.interactiveAgent?.maxConcurrentSessions ?? DEFAULT_CAP;
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.ts
@@ -1,0 +1,88 @@
+/**
+ * BootPromptResolver
+ *
+ * Pure collaborator that resolves the text to send as the agent's first turn.
+ * Encapsulates the three-case branch previously inlined in `completeBootAsync`:
+ *
+ * 1. `pendingUserContent` defined  → that content IS the boot prompt
+ *    (user-initiated boot: Application chat, or any scope that calls
+ *    `sendUserMessage` cold). The context is the system prompt override
+ *    if set, otherwise the built feature context.
+ *
+ * 2. No pending content AND no `systemPromptOverride` → feature-chat path:
+ *    the feature context doubles as the boot prompt so the agent greets the
+ *    user based on the current feature state.
+ *
+ * 3. No pending content AND `systemPromptOverride` set → silent boot:
+ *    the scope (Application, Repository, Global) is self-describing; there
+ *    is no need for a chatty greeting. `bootPrompt` is an empty string.
+ *
+ * Extracted from `interactive-session.service.ts` in phase 5 of the
+ * strangler refactor documented at
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import type { IFeatureRepository } from '../../../../application/ports/output/repositories/feature-repository.interface.js';
+import type { FeatureContextBuilder } from '../feature-context.builder.js';
+
+export interface BootPromptResult {
+  /** System prompt / context string to pass to the agent SDK. */
+  context: string;
+  /** The first turn to send to the agent (may be empty for silent boot). */
+  bootPrompt: string;
+}
+
+export class BootPromptResolver {
+  constructor(
+    private readonly featureRepo: IFeatureRepository,
+    private readonly contextBuilder: FeatureContextBuilder
+  ) {}
+
+  /**
+   * Resolve the boot context and first-turn prompt for a new session.
+   *
+   * @param featureId           Polymorphic scope key (feature UUID, repo id, "global", etc.)
+   * @param worktreePath        Absolute path to the checked-out worktree.
+   * @param pendingUserContent  User message that triggered the boot, if any.
+   * @param systemPromptOverride Caller-supplied system prompt; overrides feature-context build.
+   */
+  async resolve(
+    featureId: string,
+    worktreePath: string,
+    pendingUserContent: string | undefined,
+    systemPromptOverride: string | undefined
+  ): Promise<BootPromptResult> {
+    // Resolve the context string (= system prompt passed to the SDK session).
+    // When the caller supplied one, use it verbatim — no feature lookup needed.
+    let context: string;
+    if (systemPromptOverride !== undefined) {
+      context = systemPromptOverride;
+    } else {
+      const feature = await this.featureRepo.findById(featureId);
+      const openPRs: string[] = feature?.pr?.url ? [feature.pr.url] : [];
+      context = this.contextBuilder.buildContext(
+        feature ??
+          ({ id: featureId, name: featureId } as Parameters<
+            FeatureContextBuilder['buildContext']
+          >[0]),
+        worktreePath,
+        openPRs
+      );
+    }
+
+    // Decide what to send as the first turn (three cases — see file header).
+    let bootPrompt: string;
+    if (pendingUserContent !== undefined) {
+      // Case 1: user-initiated boot — send their message as the first turn.
+      bootPrompt = pendingUserContent;
+    } else if (systemPromptOverride === undefined) {
+      // Case 2: classic feature-chat — context IS the greeting prompt.
+      bootPrompt = context;
+    } else {
+      // Case 3: self-describing scope — stay silent.
+      bootPrompt = '';
+    }
+
+    return { context, bootPrompt };
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/boot-watchdog.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/boot-watchdog.ts
@@ -1,0 +1,82 @@
+/**
+ * Boot Watchdog
+ *
+ * Boot-phase watchdog: how long the agent is allowed to go WITHOUT
+ * emitting any stream event (delta / tool_use / tool_result / status)
+ * before we consider the boot stuck and abort it.
+ *
+ * This is an IDLE timer, not a wall-clock budget: each event received
+ * resets it. That's essential for application-creation flows where the
+ * first turn legitimately takes many minutes (scaffold + install + build
+ * a whole project). A fixed wall-clock budget would kill those mid-way.
+ *
+ * ## Contract
+ *
+ * - `start(onStall)` arms the timer. The supplied callback fires exactly
+ *   once if the timer elapses without a `bump()` in the meantime.
+ * - `bump()` resets the remaining time back to `IDLE_TIMEOUT_MS`. Called
+ *   on every stream event the consumer observes during boot.
+ * - `stop()` cancels the pending timer. Always called from a `finally`
+ *   block so a crash in the consume loop never leaks a timer.
+ *
+ * The stall handler is latched: once it fires (or `stop()` clears the
+ * timer) a subsequent `bump()` is a no-op until the next `start()`.
+ */
+
+export class BootWatchdog {
+  /**
+   * Maximum idle duration in milliseconds. Part of the public contract:
+   * unit tests and callers that format user-facing stall errors depend
+   * on this constant being readable from the outside.
+   */
+  static readonly IDLE_TIMEOUT_MS = 120_000;
+
+  private timer: NodeJS.Timeout | null = null;
+  private onStall: (() => void) | null = null;
+
+  /**
+   * Arm the timer. The supplied handler fires after `IDLE_TIMEOUT_MS`
+   * unless `bump()` or `stop()` intervenes.
+   */
+  start(onStall: () => void): void {
+    this.onStall = onStall;
+    this.schedule();
+  }
+
+  /**
+   * Reset the remaining time back to `IDLE_TIMEOUT_MS`. No-op when the
+   * watchdog is not currently armed (see file header: stall handler is
+   * latched, so post-stop bumps must not re-arm).
+   */
+  bump(): void {
+    if (!this.onStall) return;
+    this.schedule();
+  }
+
+  /**
+   * Cancel the pending timer and clear the stall handler. Idempotent —
+   * safe to call from a `finally` block even if `start()` was never
+   * invoked or `stop()` already ran.
+   */
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.onStall = null;
+  }
+
+  private schedule(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      const handler = this.onStall;
+      // Latch: clear state BEFORE firing so a re-entrant bump() during
+      // the handler (or accidental second scheduling) can't double-fire.
+      this.timer = null;
+      this.onStall = null;
+      handler?.();
+    }, BootWatchdog.IDLE_TIMEOUT_MS);
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/session-bootstrapper.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/session-bootstrapper.ts
@@ -1,0 +1,332 @@
+/**
+ * SessionBootstrapper
+ *
+ * Owns the `startSession` / `completeBootAsync` lifecycle that was previously
+ * inlined in the monolithic `InteractiveSessionService`.
+ *
+ * `startSession`:
+ * 1. Checks the concurrent-session cap via `AgentConfigResolver.getCap()`.
+ * 2. Resolves the previous agent session id (in-memory cache → stopped cache → DB).
+ * 3. Creates the DB row in `booting` status.
+ * 4. Initialises `SessionState` in the registry with `pendingUserContent` set
+ *    BEFORE dispatching `completeBootAsync` (critical ordering — avoids a race
+ *    where the async boot reads `undefined` for the first turn).
+ * 5. Fires `completeBootAsync` as a fire-and-forget promise.
+ * 6. Returns the session immediately so the API caller can poll.
+ *
+ * `completeBootAsync` (private):
+ * 1. Calls `BootPromptResolver.resolve()` for the three-case boot-prompt logic.
+ * 2. Resolves agent type + auth config.
+ * 3. Creates or resumes the SDK session via `IAgentExecutorFactory`.
+ * 4. If there is a non-empty boot prompt, sends it and consumes the stream via
+ *    `AgentStreamConsumer`. Uses `BootWatchdog` as an idle timer.
+ * 5. Detects CWD-mismatch resumption failures (SDK silently created fresh session).
+ * 6. Persists the SDK session id and transitions the DB session to `ready`.
+ *
+ * Extracted from `interactive-session.service.ts` in phase 5 of the
+ * strangler refactor documented at
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import * as crypto from 'node:crypto';
+
+import type { IInteractiveSessionRepository } from '../../../../application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { SessionRegistry, SessionState } from '../core/session-registry.js';
+import type { SessionPersistence } from '../core/session-persistence.js';
+import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
+import type { BootPromptResolver } from './boot-prompt.resolver.js';
+import type { AgentStreamConsumer } from '../runtime/agent-stream.consumer.js';
+import type { IAgentExecutorFactory } from '../../../../application/ports/output/agents/agent-executor-factory.interface.js';
+import type { AgentConfigResolver } from './agent-config.resolver.js';
+import type { UserInteractionCoordinator } from '../runtime/user-interaction.coordinator.js';
+import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
+import type { InteractiveSession } from '../../../../domain/generated/output.js';
+import { InteractiveSessionStatus } from '../../../../domain/generated/output.js';
+import { ConcurrentSessionLimitError } from '../../../../domain/errors/concurrent-session-limit.error.js';
+import { BootWatchdog } from './boot-watchdog.js';
+
+export class SessionBootstrapper {
+  constructor(
+    private readonly sessionRepo: IInteractiveSessionRepository,
+    private readonly registry: SessionRegistry,
+    private readonly persistence: SessionPersistence,
+    private readonly dispatcher: StreamEventDispatcher,
+    private readonly bootPromptResolver: BootPromptResolver,
+    private readonly streamConsumer: AgentStreamConsumer,
+    private readonly executorFactory: IAgentExecutorFactory,
+    private readonly agentConfigResolver: AgentConfigResolver,
+    private readonly interactionCoordinator: UserInteractionCoordinator,
+    private readonly logger: ILogger
+  ) {}
+
+  /**
+   * Start a new session for the given feature scope.
+   * Returns immediately in `booting` status; the async boot runs in the background.
+   */
+  async startSession(
+    featureId: string,
+    worktreePath: string,
+    model?: string,
+    agentType?: string,
+    systemPrompt?: string,
+    initialUserMessage?: string
+  ): Promise<InteractiveSession> {
+    const cap = this.agentConfigResolver.getCap();
+    const activeCount = await this.sessionRepo.countActiveSessions();
+    if (activeCount >= cap) {
+      throw new ConcurrentSessionLimitError(activeCount, cap);
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Resume-aware boot: look up the previous session's agent
+    // sessionId BEFORE inserting the new row.
+    //
+    // Ordering matters CRITICALLY here. If we created the new DB
+    // session row first and then called `findByFeatureId`, the repo
+    // would return the row we just inserted (most recent by
+    // createdAt) — which has no agentSessionId yet — and the old,
+    // semantically-still-meaningful row would be invisible. That
+    // silently downgrades every reboot to a `createSession` call,
+    // stranding the agent with zero conversation history and making
+    // it answer "this appears to be the start of our conversation"
+    // to the user's second message. Look it up first.
+    // ─────────────────────────────────────────────────────────────
+    let previousAgentSessionId: string | undefined;
+    for (const s of this.registry.values()) {
+      if (s.featureId === featureId && s.agentSessionId) {
+        previousAgentSessionId = s.agentSessionId;
+        break;
+      }
+    }
+    // Also check stoppedSessions cache (populated on stop)
+    previousAgentSessionId ??= this.registry.takeStoppedAgentSessionId(featureId);
+    // Fall back to DB — the in-memory cache may be empty after
+    // service restart, hot reload, or Turbopack module re-init.
+    previousAgentSessionId ??=
+      (await this.sessionRepo.findLatestAgentSessionIdForFeature(featureId)) ?? undefined;
+
+    // Create DB record with booting status (AFTER the lookup above).
+    const now = new Date();
+    const session: InteractiveSession = {
+      id: crypto.randomUUID(),
+      featureId,
+      status: InteractiveSessionStatus.booting,
+      startedAt: now,
+      lastActivityAt: now,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.sessionRepo.create(session);
+    this.dispatcher.notifyByFeatureId(featureId, {
+      delta: '',
+      done: false,
+      sessionStatus: InteractiveSessionStatus.booting,
+    });
+
+    // Mark as processing immediately so the FAB shows the spinner during boot
+    void this.persistence.updateTurnStatusAndNotify(session.id, featureId, 'processing');
+
+    // Set up in-memory state. CRITICAL: pendingUserContent must be set
+    // BEFORE completeBootAsync is dispatched below. Setting it from the
+    // caller after startSession returns is a race — the async boot may
+    // already be reading state.pendingUserContent === undefined on the
+    // same microtask, fall into the "no-first-turn" branch, and silently
+    // skip the kickoff send.
+    const state: SessionState = {
+      sessionId: session.id,
+      featureId,
+      worktreePath,
+      model,
+      agentType,
+      systemPrompt,
+      handle: null,
+      agentSessionId: previousAgentSessionId,
+      currentAssistantBuffer: '',
+      toolEventsLog: [],
+      subscribers: new Set(),
+      turnInProgress: false,
+      turnQueue: [],
+      pendingInteraction: null,
+      pendingInteractionResolver: null,
+      pendingUserContent: initialUserMessage,
+    };
+    this.registry.set(session.id, state);
+
+    // Fire-and-forget the async boot sequence. The API returns the session
+    // immediately in "booting" status; the frontend polls until "ready".
+    void this.completeBootAsync(state, featureId, worktreePath);
+
+    return session;
+  }
+
+  /**
+   * Asynchronously complete the boot sequence: resolve boot prompt, create
+   * the SDK session, send the boot prompt, consume the stream, and transition
+   * the session to `ready`.
+   */
+  private async completeBootAsync(
+    state: SessionState,
+    featureId: string,
+    worktreePath: string
+  ): Promise<void> {
+    try {
+      // Capture pendingUserContent NOW, before the resolver clears it.
+      // (The resolver only reads it — the value on state is cleared below.)
+      const pendingContent = state.pendingUserContent;
+
+      // Resolve context + boot prompt using the three-case branch
+      const { context, bootPrompt } = await this.bootPromptResolver.resolve(
+        featureId,
+        worktreePath,
+        pendingContent,
+        state.systemPrompt
+      );
+
+      // If we consumed pendingUserContent, clear it on state now
+      if (pendingContent !== undefined) {
+        state.pendingUserContent = undefined;
+      }
+
+      // Resolve agent type and auth config from settings
+      const resolvedAgentType = this.agentConfigResolver.resolveAgentType(state.agentType);
+      const authConfig = this.agentConfigResolver.resolveAuthConfig();
+
+      // Create the interactive executor and session
+      const executor = this.executorFactory.createInteractiveExecutor(
+        resolvedAgentType,
+        authConfig
+      );
+
+      // Build the onUserQuestion callback that pauses the SDK stream
+      // and waits for user input via the UI.
+      const onUserQuestion = this.interactionCoordinator.buildOnUserQuestionCallback(state);
+
+      const previousAgentSessionId = state.agentSessionId;
+      let handle;
+      if (previousAgentSessionId) {
+        // Resume existing SDK session
+        handle = await executor.resumeSession(previousAgentSessionId, {
+          cwd: worktreePath,
+          model: state.model,
+          systemPrompt: context,
+          onUserQuestion,
+        });
+      } else {
+        // Create new SDK session
+        handle = await executor.createSession({
+          cwd: worktreePath,
+          model: state.model,
+          systemPrompt: context,
+          onUserQuestion,
+        });
+      }
+
+      state.handle = handle;
+
+      // If there's no first user turn to act on, don't push anything —
+      // the session is ready the moment the SDK handle exists. The user
+      // will send their first message through the normal turn path.
+      if (!bootPrompt) {
+        await this.persistence.updateSessionStatusAndNotify(
+          state.sessionId,
+          state.featureId,
+          InteractiveSessionStatus.ready
+        );
+        void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+        return;
+      }
+
+      // Send the boot prompt and iterate stream for the greeting
+      await handle.send(bootPrompt);
+
+      const bootAbort = new AbortController();
+      state.streamAbort = bootAbort;
+
+      // Idle watchdog: reset on every event. If the agent goes silent
+      // for longer than BootWatchdog.IDLE_TIMEOUT_MS, abort the boot.
+      const watchdog = new BootWatchdog();
+      watchdog.start(() => bootAbort.abort());
+
+      let result;
+      try {
+        result = await this.streamConsumer.consume(handle, state, 'boot', bootAbort, watchdog);
+      } finally {
+        watchdog.stop();
+        state.streamAbort = undefined;
+      }
+
+      if (result.completed === 'done') {
+        // Capture the SDK session ID (available after first message exchange)
+        const sdkSessionId = result.agentSessionIdFromHandle;
+        if (sdkSessionId) {
+          // Detect CWD mismatch: if we tried to resume but got a different
+          // session ID, the SDK silently created a fresh session
+          if (previousAgentSessionId && sdkSessionId !== previousAgentSessionId) {
+            this.logger.warn(
+              `[InteractiveSession] Session resume mismatch for feature ${featureId}: ` +
+                `expected ${previousAgentSessionId}, got ${sdkSessionId}. ` +
+                `SDK created a fresh session (likely cwd changed or session expired).`
+            );
+          }
+          state.agentSessionId = sdkSessionId;
+          // Persist to DB so it survives service restarts
+          void this.sessionRepo.updateAgentSessionId(state.sessionId, sdkSessionId);
+        }
+
+        await this.persistence.updateSessionStatusAndNotify(
+          state.sessionId,
+          state.featureId,
+          InteractiveSessionStatus.ready
+        );
+
+        // If there's a pending user message, the next turn will set 'processing'.
+        // Otherwise boot greeting is expected — mark idle.
+        if (!state.pendingUserContent) {
+          void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+        }
+
+        state.currentAssistantBuffer = '';
+        state.toolEventsLog = [];
+
+        // Notify subscribers of end-of-turn
+        this.dispatcher.notify(state, { delta: '', done: true });
+        return; // Boot complete
+      }
+
+      // ended-without-done: persist trailing text and transition to ready.
+      await this.persistence.updateSessionStatusAndNotify(
+        state.sessionId,
+        state.featureId,
+        InteractiveSessionStatus.ready
+      );
+      if (!state.pendingUserContent) {
+        void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'idle');
+      }
+      state.currentAssistantBuffer = '';
+      state.toolEventsLog = [];
+    } catch (err) {
+      // If session was already cleaned up by stopSession, nothing more to do
+      if (!this.registry.has(state.sessionId)) return;
+
+      // Boot failed — mark session as error so the frontend can show the failure
+      this.logger.error(`[InteractiveSession] boot failed for session ${state.sessionId}`, {
+        sessionId: state.sessionId,
+        featureId,
+        error: err,
+      });
+      try {
+        await this.persistence.updateSessionStatusAndNotify(
+          state.sessionId,
+          state.featureId,
+          InteractiveSessionStatus.error
+        );
+      } catch {
+        // Best-effort DB update
+      }
+      if (state.agentSessionId) {
+        this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
+      }
+      this.registry.delete(state.sessionId);
+    }
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/session-terminator.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/session-terminator.ts
@@ -1,0 +1,100 @@
+/**
+ * SessionTerminator
+ *
+ * Encapsulates the two stop paths previously inlined in the monolithic
+ * `InteractiveSessionService`:
+ *
+ * - `stop(sessionId)`          — tears down a session by its DB id.
+ * - `stopByFeature(featureId)` — finds the active session for a feature
+ *   scope and delegates to `stop()`.
+ *
+ * Side-effects on stop:
+ * 1. Aborts any in-flight stream (cancels the AbortController).
+ * 2. Drains the turn queue so no pending turns run after teardown.
+ * 3. Caches the agent SDK session id in the registry so the next boot
+ *    can resume the same SDK conversation.
+ * 4. Closes the SDK session handle.
+ * 5. Persists `stopped` status + `idle` turn status to the DB and notifies
+ *    SSE subscribers.
+ *
+ * Replaces the `console.log(new Error().stack)` diagnostic call with a
+ * structured `logger.debug` call.
+ *
+ * Extracted from `interactive-session.service.ts` in phase 5 of the
+ * strangler refactor documented at
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import type { SessionRegistry } from '../core/session-registry.js';
+import type { SessionPersistence } from '../core/session-persistence.js';
+import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
+import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
+import { InteractiveSessionStatus } from '../../../../domain/generated/output.js';
+
+export class SessionTerminator {
+  constructor(
+    private readonly registry: SessionRegistry,
+    private readonly persistence: SessionPersistence,
+    private readonly dispatcher: StreamEventDispatcher,
+    private readonly logger: ILogger
+  ) {}
+
+  /**
+   * Stop and tear down the session identified by `sessionId`.
+   * Idempotent — returns silently when the session is already gone.
+   */
+  async stop(sessionId: string): Promise<void> {
+    const state = this.registry.get(sessionId);
+    if (!state) {
+      // Already stopped — idempotent
+      return;
+    }
+
+    this.logger.debug(
+      `[InteractiveSession] stopSession called for ${sessionId} (feature: ${state.featureId})`,
+      { sessionId, featureId: state.featureId }
+    );
+
+    // Abort any active stream iteration and clear pending turns
+    if (state.streamAbort) {
+      state.streamAbort.abort();
+      state.streamAbort = undefined;
+    }
+    state.turnQueue.length = 0;
+    state.turnInProgress = false;
+
+    // Cache agentSessionId so resumption works when session restarts
+    if (state.agentSessionId) {
+      this.registry.cacheStoppedAgentSessionId(state.featureId, state.agentSessionId);
+    }
+    this.registry.delete(sessionId);
+
+    // Close the SDK session handle
+    if (state.handle) {
+      try {
+        await state.handle.close();
+      } catch {
+        // Session may already be closed
+      }
+      state.handle = null;
+    }
+
+    await this.persistence.updateSessionStatusAndNotify(
+      sessionId,
+      state.featureId,
+      InteractiveSessionStatus.stopped,
+      new Date()
+    );
+    void this.persistence.updateTurnStatusAndNotify(sessionId, state.featureId, 'idle');
+  }
+
+  /**
+   * Find the active session for `featureId` and stop it.
+   * No-op when no active session is found.
+   */
+  async stopByFeature(featureId: string): Promise<void> {
+    const state = this.registry.findActiveStateForFeature(featureId);
+    if (!state) return;
+    await this.stop(state.sessionId);
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/session-terminator.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/session-terminator.ts
@@ -29,6 +29,8 @@ import type { SessionRegistry } from '../core/session-registry.js';
 import type { SessionPersistence } from '../core/session-persistence.js';
 import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
 import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
+import type { IInteractiveMessageRepository } from '../../../../application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { IWorkflowStepRepository } from '../../../../application/ports/output/repositories/workflow-step-repository.interface.js';
 import { InteractiveSessionStatus } from '../../../../domain/generated/output.js';
 
 export class SessionTerminator {
@@ -36,7 +38,9 @@ export class SessionTerminator {
     private readonly registry: SessionRegistry,
     private readonly persistence: SessionPersistence,
     private readonly dispatcher: StreamEventDispatcher,
-    private readonly logger: ILogger
+    private readonly logger: ILogger,
+    private readonly messageRepo: IInteractiveMessageRepository,
+    private readonly workflowStepRepo: IWorkflowStepRepository
   ) {}
 
   /**
@@ -96,5 +100,18 @@ export class SessionTerminator {
     const state = this.registry.findActiveStateForFeature(featureId);
     if (!state) return;
     await this.stop(state.sessionId);
+  }
+
+  /**
+   * Clear all messages and workflow steps for a feature scope.
+   * Stops any active session first so the agent doesn't retain old context.
+   * Also clears the cached agent session id so the next boot starts fresh.
+   */
+  async clearFeatureMessages(featureId: string): Promise<void> {
+    await this.stopByFeature(featureId);
+    this.registry.deleteStoppedAgentSessionId(featureId);
+    await this.workflowStepRepo.deleteByFeatureId(featureId);
+    this.registry.clearActiveStep(featureId);
+    await this.messageRepo.deleteByFeatureId(featureId);
   }
 }

--- a/packages/core/src/infrastructure/services/interactive/lifecycle/settings-provider.adapter.ts
+++ b/packages/core/src/infrastructure/services/interactive/lifecycle/settings-provider.adapter.ts
@@ -1,0 +1,28 @@
+/**
+ * SettingsProviderAdapter
+ *
+ * Thin infrastructure adapter that wraps the existing `settings.service`
+ * module-level singleton behind the `ISettingsProvider` application port.
+ * This is the SINGLE legitimate place the singleton may still be called —
+ * infrastructure bootstrapping, the exception allowed by the
+ * "No Singletons or Global State Outside Infrastructure Bootstrapping"
+ * rule in `.claude/rules/code-quality.md`.
+ *
+ * Every other consumer (agent-config resolver, session bootstrapper, etc.)
+ * must take an injected `ISettingsProvider` instead of importing
+ * `getSettings` / `hasSettings` directly.
+ */
+
+import type { ISettingsProvider } from '../../../../application/ports/output/services/settings-provider.interface.js';
+import type { Settings } from '../../../../domain/generated/output.js';
+import { getSettings, hasSettings } from '../../settings.service.js';
+
+export class SettingsProviderAdapter implements ISettingsProvider {
+  has(): boolean {
+    return hasSettings();
+  }
+
+  get(): Settings {
+    return getSettings();
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/runtime/agent-stream.consumer.ts
+++ b/packages/core/src/infrastructure/services/interactive/runtime/agent-stream.consumer.ts
@@ -1,0 +1,305 @@
+/**
+ * Agent Stream Consumer
+ *
+ * Single source of truth for the SDK-stream event-loop switch shared
+ * between `InteractiveSessionService.completeBootAsync` and
+ * `InteractiveSessionService.executeAndPersistTurn`. Before this
+ * collaborator existed, the two call sites each inlined ~140 lines of
+ * near-identical switch code — this class dedupes them behind a single
+ * `consume()` method that branches on `mode` ('boot' | 'turn') only
+ * where behavior legitimately differs.
+ *
+ * ## CRITICAL — Ordering invariant (do NOT violate)
+ *
+ * Every `persistToolEvent` call inside the switch is `await`-ed. This
+ * is NOT stylistic — it is an ordering invariant the frontend depends
+ * on. `SessionPersistence` uses a process-wide monotonic clock
+ * (`nextMessageDate`) to guarantee strictly-increasing `createdAt`
+ * timestamps for consecutive rows even when the SDK emits `tool_use`
+ * and `tool_result` in the same millisecond. If the consumer fires a
+ * persist call with `void` instead of `await`, two rows can interleave
+ * and end up with identical `createdAt` values, which breaks
+ * `ORDER BY created_at ASC` in `interactiveMessageRepo.findByFeatureId`
+ * and in turn breaks the tool->Output pairing in
+ * `StepTracker.classifyMessages` on the frontend.
+ *
+ * The regression is codified by:
+ *
+ * - `tests/unit/infrastructure/services/interactive/core/session-persistence.test.ts`
+ *   "persistToolEvent timestamps are strictly increasing under a frozen clock"
+ * - `tests/unit/infrastructure/services/interactive/runtime/agent-stream.consumer.test.ts`
+ *   "awaits every persistToolEvent so back-to-back tool_use + tool_result never overlap"
+ *
+ * Do not replace `await` with `void` anywhere in this file.
+ *
+ * ## Mode differences
+ *
+ * | Event   | boot                                               | turn                                                 |
+ * | ------- | -------------------------------------------------- | ---------------------------------------------------- |
+ * | (any)   | Calls `watchdog.bump()` before the switch          | No watchdog                                          |
+ * | init    | Passes through unchanged                           | Ignored (avoid repeat "Session started" messages)    |
+ * | done    | Captures `handle.sessionId` on result, NO usage    | Accumulates usage in the returned result             |
+ * | error   | Throws                                             | Logs via `ILogger`, notifies, continues              |
+ */
+
+import type { SessionPersistence } from '../core/session-persistence.js';
+import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
+import type { SessionState } from '../core/session-registry.js';
+import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
+import type {
+  InteractiveAgentEvent,
+  InteractiveAgentSessionHandle,
+} from '../../../../application/ports/output/agents/interactive-agent-executor.interface.js';
+import type { BootWatchdog } from '../lifecycle/boot-watchdog.js';
+
+export type StreamConsumeMode = 'boot' | 'turn';
+
+export interface StreamConsumeUsage {
+  costUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  numTurns: number;
+}
+
+export interface StreamConsumeResult {
+  /**
+   * `'done'` when the stream emitted a `done` event; `'ended-without-done'`
+   * when the async iterator finished (or was aborted) without one.
+   */
+  completed: 'done' | 'ended-without-done';
+  /**
+   * Usage metadata captured from the `done` (turn mode) or `error` (turn
+   * mode, when the SDK still reports cost) event. Always `undefined`
+   * in boot mode — boot greetings don't count toward session usage.
+   */
+  usage?: StreamConsumeUsage;
+  /**
+   * The agent SDK session id read off the handle when the `done` event
+   * fired during boot. The bootstrapper uses this to reconcile the DB
+   * row and detect CWD-mismatch resumption failures. Always `undefined`
+   * in turn mode.
+   */
+  agentSessionIdFromHandle?: string;
+}
+
+export class AgentStreamConsumer {
+  constructor(
+    private readonly persistence: SessionPersistence,
+    private readonly dispatcher: StreamEventDispatcher,
+    private readonly logger: ILogger
+  ) {}
+
+  async consume(
+    handle: InteractiveAgentSessionHandle,
+    state: SessionState,
+    mode: StreamConsumeMode,
+    abortController: AbortController,
+    watchdog?: BootWatchdog
+  ): Promise<StreamConsumeResult> {
+    let usage: StreamConsumeUsage | undefined;
+    let agentSessionIdFromHandle: string | undefined;
+
+    for await (const event of handle.stream()) {
+      if (abortController.signal.aborted) {
+        break;
+      }
+
+      // In boot mode, reset the idle watchdog on every event so a long-
+      // running first turn isn't killed as long as the stream keeps
+      // producing output. `bump()` is a no-op in turn mode (no watchdog).
+      if (mode === 'boot') {
+        watchdog?.bump();
+      }
+
+      const done = await this.handleEvent(event, state, mode);
+      if (done === 'stream-done') {
+        if (mode === 'boot') {
+          agentSessionIdFromHandle = handle.sessionId;
+        } else if (event.usage) {
+          usage = this.readUsage(event);
+        }
+        return { completed: 'done', usage, agentSessionIdFromHandle };
+      }
+      if (done === 'error-with-usage' && event.usage) {
+        usage = this.readUsage(event);
+      }
+    }
+
+    return { completed: 'ended-without-done', usage, agentSessionIdFromHandle };
+  }
+
+  /**
+   * Handle a single event. Returns `'stream-done'` when the caller
+   * should exit the loop with `completed: 'done'`; `'error-with-usage'`
+   * when a turn-mode error event also carried usage that the caller
+   * should harvest on its way to the natural end of the stream.
+   */
+  private async handleEvent(
+    event: InteractiveAgentEvent,
+    state: SessionState,
+    mode: StreamConsumeMode
+  ): Promise<'continue' | 'stream-done' | 'error-with-usage'> {
+    switch (event.type) {
+      case 'delta':
+        if (event.content) {
+          state.currentAssistantBuffer += event.content;
+          this.dispatcher.notify(state, { delta: event.content, done: false });
+        }
+        return 'continue';
+
+      case 'thinking':
+        if (event.content) {
+          await this.persistence.persistToolEvent(state, 'Thinking', event.content);
+          this.dispatcher.notify(state, {
+            delta: '',
+            done: false,
+            log: 'Thinking…',
+            activity: { kind: 'thinking', label: 'Thinking', detail: event.content },
+          });
+        }
+        return 'continue';
+
+      case 'tool_use':
+        if (event.label) {
+          const toolLabel = event.label;
+          const toolDetail = event.detail;
+          await this.persistence.persistToolEvent(state, toolLabel, toolDetail);
+          this.dispatcher.notify(state, {
+            delta: '',
+            done: false,
+            log: `Using tool: ${toolLabel}`,
+            activity: { kind: 'tool_use', label: toolLabel, detail: toolDetail },
+          });
+        }
+        return 'continue';
+
+      case 'tool_result':
+        if (event.label) {
+          const resultLabel = event.label;
+          const resultDetail = event.detail;
+          await this.persistence.persistToolEvent(state, resultLabel, resultDetail);
+          this.dispatcher.notify(state, {
+            delta: '',
+            done: false,
+            log: `Completed: ${resultLabel}`,
+            activity: { kind: 'tool_result', label: resultLabel, detail: resultDetail },
+          });
+        }
+        return 'continue';
+
+      case 'status':
+        if (event.content) {
+          this.dispatcher.notify(state, { delta: '', done: false, log: event.content });
+        }
+        return 'continue';
+
+      case 'done':
+        // Flush any trailing prose now so the buffered text is persisted
+        // as its own message BEFORE the caller transitions the session
+        // to ready/unread. We intentionally do NOT persist `event.content`
+        // — that would duplicate the flushed assistant text.
+        await this.persistence.flushAssistantBuffer(state);
+        state.toolEventsLog = [];
+        return 'stream-done';
+
+      case 'error':
+        if (mode === 'boot') {
+          throw new Error(`Agent error during boot: ${event.content ?? 'unknown'}`);
+        }
+        this.logger.error(
+          `[InteractiveSession] agent error during turn for session ${state.sessionId}`,
+          {
+            sessionId: state.sessionId,
+            featureId: state.featureId,
+            error: event.content,
+          }
+        );
+        this.dispatcher.notify(state, {
+          delta: '',
+          done: true,
+          log: `Error: ${event.content ?? 'unknown'}`,
+        });
+        return 'error-with-usage';
+
+      case 'init':
+        // Boot mode may eventually want to forward init once; for now
+        // both modes ignore it — the bootstrapper has its own "session
+        // started" signal when the handle is first created.
+        return 'continue';
+
+      case 'api_retry':
+        this.dispatcher.notify(state, {
+          delta: '',
+          done: false,
+          log: event.content ?? 'Retrying API call...',
+        });
+        return 'continue';
+
+      case 'rate_limit':
+        this.dispatcher.notify(state, {
+          delta: '',
+          done: false,
+          log: event.content ?? 'Rate limited',
+        });
+        return 'continue';
+
+      case 'task_started':
+        if (event.content) {
+          await this.persistence.persistToolEvent(state, 'Subtask started', event.content);
+          this.dispatcher.notify(state, {
+            delta: '',
+            done: false,
+            log: `Subtask: ${event.content}`,
+            activity: { kind: 'system', label: 'Subtask started', detail: event.content },
+          });
+        }
+        return 'continue';
+
+      case 'task_progress':
+        if (event.content) {
+          this.dispatcher.notify(state, {
+            delta: '',
+            done: false,
+            log: `Subtask: ${event.content}`,
+          });
+        }
+        return 'continue';
+
+      case 'task_done':
+        if (event.content) {
+          const taskStatus = event.detail ?? 'completed';
+          await this.persistence.persistToolEvent(state, `Subtask ${taskStatus}`, event.content);
+          this.dispatcher.notify(state, {
+            delta: '',
+            done: false,
+            log: `Subtask ${taskStatus}: ${event.content}`,
+            activity: {
+              kind: 'system',
+              label: `Subtask ${taskStatus}`,
+              detail: event.content,
+            },
+          });
+        }
+        return 'continue';
+
+      case 'user_question':
+        // AskUserQuestion is handled by the canUseTool callback
+        // (buildOnUserQuestionCallback in the facade). This event
+        // should not appear in the stream anymore, but if it does
+        // from a different code path, ignore it here.
+        return 'continue';
+
+      default:
+        return 'continue';
+    }
+  }
+
+  private readUsage(event: InteractiveAgentEvent): StreamConsumeUsage {
+    return {
+      costUsd: event.usage?.costUsd ?? 0,
+      inputTokens: event.usage?.inputTokens ?? 0,
+      outputTokens: event.usage?.outputTokens ?? 0,
+      numTurns: event.usage?.numTurns ?? 1,
+    };
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/runtime/turn.executor.ts
+++ b/packages/core/src/infrastructure/services/interactive/runtime/turn.executor.ts
@@ -1,0 +1,124 @@
+/**
+ * TurnExecutor
+ *
+ * Manages the per-session turn queue and the single-threaded turn execution
+ * loop. The SDK stream is NOT concurrent-safe, so only one turn may execute
+ * at a time per session. Additional turns are queued and drained FIFO after
+ * the current turn completes.
+ *
+ * `enqueueTurn` is the public entry point. It:
+ * 1. Pushes to `state.turnQueue` if a turn is already running.
+ * 2. Otherwise sets `state.turnInProgress = true` and calls `executeTurn`.
+ *
+ * `executeTurn` (private):
+ * 1. Calls `streamConsumer.consume(handle, state, 'turn', abort)`.
+ * 2. Accumulates usage via `sessionRepo.accumulateUsage` when the result
+ *    contains a usage payload.
+ * 3. Marks the turn as `unread` and notifies subscribers.
+ * 4. In `finally`, releases the turn lock and recursively drains the queue.
+ *
+ * Extracted from `interactive-session.service.ts` in phase 5 of the
+ * strangler refactor documented at
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import type { IInteractiveSessionRepository } from '../../../../application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { SessionRegistry, SessionState } from '../core/session-registry.js';
+import type { SessionPersistence } from '../core/session-persistence.js';
+import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
+import type { AgentStreamConsumer } from './agent-stream.consumer.js';
+import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
+
+export class TurnExecutor {
+  constructor(
+    private readonly sessionRepo: IInteractiveSessionRepository,
+    private readonly registry: SessionRegistry,
+    private readonly persistence: SessionPersistence,
+    private readonly streamConsumer: AgentStreamConsumer,
+    private readonly logger: ILogger,
+    private readonly dispatcher: StreamEventDispatcher
+  ) {}
+
+  /**
+   * Enqueue a prompt for execution. If a turn is already in progress, the
+   * prompt is appended to `state.turnQueue` and will run when the current
+   * turn completes. Otherwise the turn starts immediately.
+   */
+  async enqueueTurn(state: SessionState, prompt: string): Promise<void> {
+    if (state.turnInProgress) {
+      state.turnQueue.push(prompt);
+      return;
+    }
+    state.turnInProgress = true;
+    await this.executeTurn(state, prompt);
+  }
+
+  /**
+   * Execute a single turn: send the prompt to the SDK handle, consume the
+   * stream, persist usage, notify done, and drain the queue.
+   */
+  private async executeTurn(state: SessionState, prompt: string): Promise<void> {
+    try {
+      if (!state.handle) {
+        throw new Error('No active session handle — cannot execute turn');
+      }
+
+      state.currentAssistantBuffer = '';
+      state.toolEventsLog = [];
+
+      // Mark turn as processing for dot indicator
+      void this.persistence.updateTurnStatusAndNotify(
+        state.sessionId,
+        state.featureId,
+        'processing'
+      );
+
+      // Send the message to the SDK session
+      await state.handle.send(prompt);
+
+      // Set up abort controller for this stream
+      const abort = new AbortController();
+      state.streamAbort = abort;
+
+      let result;
+      try {
+        result = await this.streamConsumer.consume(state.handle, state, 'turn', abort);
+      } finally {
+        state.streamAbort = undefined;
+      }
+
+      // Accumulate usage from this turn
+      if (result.usage) {
+        void this.sessionRepo.accumulateUsage(state.sessionId, {
+          costUsd: result.usage.costUsd ?? 0,
+          inputTokens: result.usage.inputTokens ?? 0,
+          outputTokens: result.usage.outputTokens ?? 0,
+          turns: result.usage.numTurns ?? 1,
+        });
+      }
+
+      // Mark as unread — if user has the chat open, the frontend
+      // will immediately call markRead to clear it
+      void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'unread');
+
+      // Notify subscribers of end-of-turn
+      this.dispatcher.notify(state, { delta: '', done: true });
+    } catch (err) {
+      // If session was already stopped, ignore
+      if (!this.registry.has(state.sessionId)) return;
+      this.logger.error(`[InteractiveSession] turn failed for session ${state.sessionId}`, {
+        sessionId: state.sessionId,
+        featureId: state.featureId,
+        error: err,
+      });
+    } finally {
+      // Release the turn lock and drain the queue
+      state.turnInProgress = false;
+      if (this.registry.has(state.sessionId) && state.turnQueue.length > 0) {
+        const nextContent = state.turnQueue.shift()!;
+        state.turnInProgress = true;
+        void this.executeTurn(state, nextContent);
+      }
+    }
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/runtime/user-interaction.coordinator.ts
+++ b/packages/core/src/infrastructure/services/interactive/runtime/user-interaction.coordinator.ts
@@ -1,0 +1,139 @@
+/**
+ * UserInteractionCoordinator
+ *
+ * Manages the AskUserQuestion interaction lifecycle — the "amber dot" feature.
+ * When the agent invokes AskUserQuestion, this coordinator:
+ *
+ * 1. Flushes the current assistant text buffer so the question text appears
+ *    above the green answer bubble in the chat history.
+ * 2. Stores the interaction data in session state for the frontend to render.
+ * 3. Updates the turn status to `awaiting_input` (amber dot in the UI).
+ * 4. Returns a Promise that the SDK stream blocks on until the user answers.
+ *
+ * `respondToInteraction` is called by the facade when the user submits
+ * answers through the API. It persists the answers as a structured message
+ * and resolves the pending Promise, unblocking the SDK stream.
+ *
+ * Extracted from `interactive-session.service.ts` in phase 5 of the
+ * strangler refactor documented at
+ * `docs/plans/2026-04-14-interactive-session-service-refactor.md`.
+ */
+
+import * as crypto from 'node:crypto';
+
+import type { SessionPersistence } from '../core/session-persistence.js';
+import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
+import type { SessionState } from '../core/session-registry.js';
+import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
+import type { UserInteractionData } from '../../../../application/ports/output/agents/interactive-agent-executor.interface.js';
+import {
+  InteractiveMessageRole,
+  type InteractiveMessage,
+} from '../../../../domain/generated/output.js';
+
+export class UserInteractionCoordinator {
+  constructor(
+    private readonly persistence: SessionPersistence,
+    private readonly dispatcher: StreamEventDispatcher,
+    private readonly logger: ILogger
+  ) {}
+
+  /**
+   * Build the `onUserQuestion` callback for a session.
+   * Called by the SDK's `canUseTool` when the agent invokes AskUserQuestion.
+   * Returns a Promise that doesn't resolve until `respondToInteraction` is called.
+   */
+  buildOnUserQuestionCallback(
+    state: SessionState
+  ): (interaction: UserInteractionData) => Promise<Record<string, string>> {
+    return async (interaction: UserInteractionData): Promise<Record<string, string>> => {
+      // Flush any accumulated assistant text as a separate message BEFORE
+      // the interaction. This ensures the agent's question text appears
+      // above the green answer bubble in the conversation history.
+      if (state.currentAssistantBuffer.trim()) {
+        await this.persistence.flushAssistantBuffer(state);
+        state.toolEventsLog = [];
+
+        // Notify subscribers so the frontend picks up the new message
+        state.subscribers.forEach((sub) => sub({ delta: '', done: true }));
+        // Small delay so the refetch completes before the interaction appears
+        await new Promise<void>((r) => setTimeout(r, 100));
+      }
+
+      // Store the interaction data for the frontend
+      state.pendingInteraction = interaction;
+
+      // Update turn status so the dot indicator shows amber
+      void this.persistence.updateTurnStatusAndNotify(
+        state.sessionId,
+        state.featureId,
+        'awaiting_input'
+      );
+
+      // Notify subscribers so SSE pushes the interaction to the frontend
+      state.subscribers.forEach((sub) =>
+        sub({
+          delta: '',
+          done: false,
+          log: 'Waiting for your response...',
+          interaction,
+        })
+      );
+
+      // Create a Promise that will be resolved when the user calls respondToInteraction
+      return new Promise<Record<string, string>>((resolve) => {
+        state.pendingInteractionResolver = resolve;
+      });
+    };
+  }
+
+  /**
+   * Called by the facade when the user submits answers through the API.
+   * Persists the answers as a structured `{{interaction}}` message,
+   * resolves the pending Promise, and resets interaction state.
+   *
+   * @param state   The live session state (caller must have already looked it up).
+   * @param answers Key-value map of question answers.
+   */
+  async respondToInteraction(state: SessionState, answers: Record<string, string>): Promise<void> {
+    if (!state.pendingInteraction || !state.pendingInteractionResolver) {
+      throw new Error(`No pending interaction for session ${state.sessionId}`);
+    }
+
+    // Persist the user's answers as a structured user message.
+    // The {{interaction}} prefix lets the frontend detect and render it
+    // as a compact green bubble instead of a regular text message.
+    const interactionPayload = {
+      questions: state.pendingInteraction.questions.map((q) => ({
+        header: q.header,
+        question: q.question,
+      })),
+      answers,
+    };
+    const now = new Date();
+    const userMsg: InteractiveMessage = {
+      id: crypto.randomUUID(),
+      featureId: state.featureId,
+      sessionId: state.sessionId,
+      role: InteractiveMessageRole.user,
+      content: `{{interaction}}${JSON.stringify(interactionPayload)}`,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.persistence.persistMessage(userMsg);
+
+    // Resolve the Promise that the canUseTool callback is awaiting.
+    // This unblocks the SDK stream — the agent resumes with the user's answers.
+    state.pendingInteractionResolver(answers);
+
+    // Clear pending interaction state
+    state.pendingInteraction = null;
+    state.pendingInteractionResolver = null;
+
+    // Update turn status back to processing
+    void this.persistence.updateTurnStatusAndNotify(state.sessionId, state.featureId, 'processing');
+
+    // Clear the "Waiting for your response..." log
+    state.subscribers.forEach((sub) => sub({ delta: '', done: false }));
+  }
+}

--- a/packages/core/src/infrastructure/services/interactive/runtime/user-interaction.coordinator.ts
+++ b/packages/core/src/infrastructure/services/interactive/runtime/user-interaction.coordinator.ts
@@ -23,7 +23,7 @@ import * as crypto from 'node:crypto';
 
 import type { SessionPersistence } from '../core/session-persistence.js';
 import type { StreamEventDispatcher } from '../core/stream-event-dispatcher.js';
-import type { SessionState } from '../core/session-registry.js';
+import type { SessionRegistry, SessionState } from '../core/session-registry.js';
 import type { ILogger } from '../../../../application/ports/output/services/logger.interface.js';
 import type { UserInteractionData } from '../../../../application/ports/output/agents/interactive-agent-executor.interface.js';
 import {
@@ -35,7 +35,8 @@ export class UserInteractionCoordinator {
   constructor(
     private readonly persistence: SessionPersistence,
     private readonly dispatcher: StreamEventDispatcher,
-    private readonly logger: ILogger
+    private readonly logger: ILogger,
+    private readonly registry: SessionRegistry
   ) {}
 
   /**
@@ -85,6 +86,22 @@ export class UserInteractionCoordinator {
         state.pendingInteractionResolver = resolve;
       });
     };
+  }
+
+  /**
+   * Feature-scoped entry point: looks up the active session state for
+   * `featureId` and delegates to `respondToInteraction`. Throws when there
+   * is no pending interaction for that feature scope.
+   */
+  async respondToInteractionByFeature(
+    featureId: string,
+    answers: Record<string, string>
+  ): Promise<void> {
+    const state = this.registry.findActiveStateForFeature(featureId);
+    if (!state?.pendingInteraction || !state.pendingInteractionResolver) {
+      throw new Error(`No pending interaction for feature ${featureId}`);
+    }
+    return this.respondToInteraction(state, answers);
   }
 
   /**

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -50,6 +50,7 @@ import { InteractiveSessionService } from '@/infrastructure/services/interactive
 import { FeatureContextBuilder } from '@/infrastructure/services/interactive/feature-context.builder.js';
 import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
 import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 
 /**
  * String tokens resolved by web API routes. To regenerate, grep
@@ -197,6 +198,12 @@ describe('DI container bootstrap (integration)', () => {
     );
     const sessionRegistry = new SessionRegistry();
     const streamEventDispatcher = new StreamEventDispatcher(sessionRegistry);
+    const sessionPersistence = new SessionPersistence(
+      interactiveMessageRepo,
+      interactiveSessionRepo,
+      sessionRegistry,
+      streamEventDispatcher
+    );
     const interactiveSessionService = new InteractiveSessionService(
       interactiveSessionRepo,
       interactiveMessageRepo,
@@ -205,7 +212,8 @@ describe('DI container bootstrap (integration)', () => {
       new FeatureContextBuilder(),
       workflowStepRepoBoot,
       sessionRegistry,
-      streamEventDispatcher
+      streamEventDispatcher,
+      sessionPersistence
     );
     scopedContainer.registerInstance<IInteractiveSessionService>(
       'IInteractiveSessionService',

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -54,6 +54,11 @@ import { SessionPersistence } from '@/infrastructure/services/interactive/core/s
 import { SettingsProviderAdapter } from '@/infrastructure/services/interactive/lifecycle/settings-provider.adapter.js';
 import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
 import { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
+import { BootPromptResolver } from '@/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.js';
+import { SessionBootstrapper } from '@/infrastructure/services/interactive/lifecycle/session-bootstrapper.js';
+import { SessionTerminator } from '@/infrastructure/services/interactive/lifecycle/session-terminator.js';
+import { TurnExecutor } from '@/infrastructure/services/interactive/runtime/turn.executor.js';
+import { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
 import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 
 /**
@@ -217,19 +222,56 @@ describe('DI container bootstrap (integration)', () => {
       streamEventDispatcher,
       logger
     );
+    const featureRepository = scopedContainer.resolve<IFeatureRepository>('IFeatureRepository');
+    const agentExecutorFactory =
+      scopedContainer.resolve<IAgentExecutorFactory>('IAgentExecutorFactory');
+    const featureContextBuilder = new FeatureContextBuilder();
+    const bootPromptResolver = new BootPromptResolver(featureRepository, featureContextBuilder);
+    const interactionCoordinator = new UserInteractionCoordinator(
+      sessionPersistence,
+      streamEventDispatcher,
+      logger
+    );
+    const bootstrapper = new SessionBootstrapper(
+      interactiveSessionRepo,
+      sessionRegistry,
+      sessionPersistence,
+      streamEventDispatcher,
+      bootPromptResolver,
+      streamConsumer,
+      agentExecutorFactory,
+      agentConfigResolver,
+      interactionCoordinator,
+      logger
+    );
+    const terminator = new SessionTerminator(
+      sessionRegistry,
+      sessionPersistence,
+      streamEventDispatcher,
+      logger
+    );
+    const turnExecutor = new TurnExecutor(
+      interactiveSessionRepo,
+      sessionRegistry,
+      sessionPersistence,
+      streamConsumer,
+      logger,
+      streamEventDispatcher
+    );
     const interactiveSessionService = new InteractiveSessionService(
       interactiveSessionRepo,
       interactiveMessageRepo,
-      scopedContainer.resolve<IAgentExecutorFactory>('IAgentExecutorFactory'),
-      scopedContainer.resolve<IFeatureRepository>('IFeatureRepository'),
-      new FeatureContextBuilder(),
+      featureRepository,
+      featureContextBuilder,
       workflowStepRepoBoot,
       sessionRegistry,
       streamEventDispatcher,
       sessionPersistence,
-      agentConfigResolver,
-      streamConsumer,
-      logger
+      logger,
+      bootstrapper,
+      terminator,
+      turnExecutor,
+      interactionCoordinator
     );
     scopedContainer.registerInstance<IInteractiveSessionService>(
       'IInteractiveSessionService',

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -233,7 +233,8 @@ describe('DI container bootstrap (integration)', () => {
     const interactionCoordinator = new UserInteractionCoordinator(
       sessionPersistence,
       streamEventDispatcher,
-      logger
+      logger,
+      sessionRegistry
     );
     const bootstrapper = new SessionBootstrapper(
       interactiveSessionRepo,
@@ -251,7 +252,9 @@ describe('DI container bootstrap (integration)', () => {
       sessionRegistry,
       sessionPersistence,
       streamEventDispatcher,
-      logger
+      logger,
+      interactiveMessageRepo,
+      workflowStepRepoBoot
     );
     const turnExecutor = new TurnExecutor(
       interactiveSessionRepo,

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -51,6 +51,8 @@ import { FeatureContextBuilder } from '@/infrastructure/services/interactive/fea
 import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
 import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
 import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import { SettingsProviderAdapter } from '@/infrastructure/services/interactive/lifecycle/settings-provider.adapter.js';
+import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
 
 /**
  * String tokens resolved by web API routes. To regenerate, grep
@@ -204,6 +206,8 @@ describe('DI container bootstrap (integration)', () => {
       sessionRegistry,
       streamEventDispatcher
     );
+    const settingsProvider = new SettingsProviderAdapter();
+    const agentConfigResolver = new AgentConfigResolver(settingsProvider);
     const interactiveSessionService = new InteractiveSessionService(
       interactiveSessionRepo,
       interactiveMessageRepo,
@@ -213,7 +217,8 @@ describe('DI container bootstrap (integration)', () => {
       workflowStepRepoBoot,
       sessionRegistry,
       streamEventDispatcher,
-      sessionPersistence
+      sessionPersistence,
+      agentConfigResolver
     );
     scopedContainer.registerInstance<IInteractiveSessionService>(
       'IInteractiveSessionService',

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -48,6 +48,8 @@ import type { IAgentExecutorFactory } from '@/application/ports/output/agents/ag
 import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
 import { InteractiveSessionService } from '@/infrastructure/services/interactive/interactive-session.service.js';
 import { FeatureContextBuilder } from '@/infrastructure/services/interactive/feature-context.builder.js';
+import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
 
 /**
  * String tokens resolved by web API routes. To regenerate, grep
@@ -193,13 +195,17 @@ describe('DI container bootstrap (integration)', () => {
     const interactiveMessageRepo = scopedContainer.resolve<IInteractiveMessageRepository>(
       'IInteractiveMessageRepository'
     );
+    const sessionRegistry = new SessionRegistry();
+    const streamEventDispatcher = new StreamEventDispatcher(sessionRegistry);
     const interactiveSessionService = new InteractiveSessionService(
       interactiveSessionRepo,
       interactiveMessageRepo,
       scopedContainer.resolve<IAgentExecutorFactory>('IAgentExecutorFactory'),
       scopedContainer.resolve<IFeatureRepository>('IFeatureRepository'),
       new FeatureContextBuilder(),
-      workflowStepRepoBoot
+      workflowStepRepoBoot,
+      sessionRegistry,
+      streamEventDispatcher
     );
     scopedContainer.registerInstance<IInteractiveSessionService>(
       'IInteractiveSessionService',

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -59,6 +59,9 @@ import { SessionBootstrapper } from '@/infrastructure/services/interactive/lifec
 import { SessionTerminator } from '@/infrastructure/services/interactive/lifecycle/session-terminator.js';
 import { TurnExecutor } from '@/infrastructure/services/interactive/runtime/turn.executor.js';
 import { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
+import { MessageDispatcher } from '@/infrastructure/services/interactive/api/message-dispatcher.js';
+import { ChatStateAssembler } from '@/infrastructure/services/interactive/api/chat-state.assembler.js';
+import { WorkflowHooks } from '@/infrastructure/services/interactive/api/workflow-hooks.js';
 import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 
 /**
@@ -258,6 +261,22 @@ describe('DI container bootstrap (integration)', () => {
       logger,
       streamEventDispatcher
     );
+    const messageDispatcher = new MessageDispatcher(
+      interactiveSessionRepo,
+      interactiveMessageRepo,
+      sessionRegistry,
+      sessionPersistence,
+      bootstrapper,
+      terminator,
+      turnExecutor
+    );
+    const chatStateAssembler = new ChatStateAssembler(
+      interactiveMessageRepo,
+      interactiveSessionRepo,
+      workflowStepRepoBoot,
+      sessionRegistry
+    );
+    const workflowHooks = new WorkflowHooks(sessionRegistry, streamEventDispatcher);
     const interactiveSessionService = new InteractiveSessionService(
       interactiveSessionRepo,
       interactiveMessageRepo,
@@ -271,7 +290,10 @@ describe('DI container bootstrap (integration)', () => {
       bootstrapper,
       terminator,
       turnExecutor,
-      interactionCoordinator
+      interactionCoordinator,
+      messageDispatcher,
+      chatStateAssembler,
+      workflowHooks
     );
     scopedContainer.registerInstance<IInteractiveSessionService>(
       'IInteractiveSessionService',

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -53,6 +53,8 @@ import { StreamEventDispatcher } from '@/infrastructure/services/interactive/cor
 import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 import { SettingsProviderAdapter } from '@/infrastructure/services/interactive/lifecycle/settings-provider.adapter.js';
 import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
+import { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 
 /**
  * String tokens resolved by web API routes. To regenerate, grep
@@ -208,6 +210,13 @@ describe('DI container bootstrap (integration)', () => {
     );
     const settingsProvider = new SettingsProviderAdapter();
     const agentConfigResolver = new AgentConfigResolver(settingsProvider);
+    const noop = (_msg: string, _meta?: Record<string, unknown>) => undefined;
+    const logger: ILogger = { debug: noop, info: noop, warn: noop, error: noop };
+    const streamConsumer = new AgentStreamConsumer(
+      sessionPersistence,
+      streamEventDispatcher,
+      logger
+    );
     const interactiveSessionService = new InteractiveSessionService(
       interactiveSessionRepo,
       interactiveMessageRepo,
@@ -218,7 +227,9 @@ describe('DI container bootstrap (integration)', () => {
       sessionRegistry,
       streamEventDispatcher,
       sessionPersistence,
-      agentConfigResolver
+      agentConfigResolver,
+      streamConsumer,
+      logger
     );
     scopedContainer.registerInstance<IInteractiveSessionService>(
       'IInteractiveSessionService',

--- a/tests/unit/infrastructure/services/interactive/api/chat-state.assembler.test.ts
+++ b/tests/unit/infrastructure/services/interactive/api/chat-state.assembler.test.ts
@@ -1,0 +1,282 @@
+/**
+ * ChatStateAssembler Unit Tests
+ *
+ * TDD: RED → GREEN → REFACTOR
+ *
+ * Covers the assemble() read-side DTO logic.
+ * Pure read — no mutations. All deps are mocked.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ChatStateAssembler } from '@/infrastructure/services/interactive/api/chat-state.assembler.js';
+import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { SessionState } from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { IWorkflowStepRepository } from '@/application/ports/output/repositories/workflow-step-repository.interface.js';
+import type { InteractiveSession, InteractiveMessage } from '@/domain/generated/output.js';
+import {
+  InteractiveSessionStatus,
+  InteractiveMessageRole,
+  WorkflowStepStatus,
+} from '@/domain/generated/output.js';
+
+function makeSessionRepo(
+  overrides: Partial<IInteractiveSessionRepository> = {}
+): IInteractiveSessionRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn().mockResolvedValue(null),
+    findByFeatureId: vi.fn().mockResolvedValue(null),
+    findAllActive: vi.fn().mockResolvedValue([]),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    updateLastActivity: vi.fn().mockResolvedValue(undefined),
+    markAllActiveStopped: vi.fn().mockResolvedValue(undefined),
+    countActiveSessions: vi.fn().mockResolvedValue(0),
+    updateAgentSessionId: vi.fn().mockResolvedValue(undefined),
+    getAgentSessionId: vi.fn().mockResolvedValue(null),
+    findLatestAgentSessionIdForFeature: vi.fn().mockResolvedValue(null),
+    updateTurnStatus: vi.fn().mockResolvedValue(undefined),
+    getTurnStatuses: vi.fn().mockResolvedValue(new Map()),
+    getAllActiveTurnStatuses: vi.fn().mockResolvedValue(new Map()),
+    accumulateUsage: vi.fn().mockResolvedValue(undefined),
+    getUsage: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  } as unknown as IInteractiveSessionRepository;
+}
+
+function makeMessageRepo(messages: InteractiveMessage[] = []): IInteractiveMessageRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findByFeatureId: vi.fn().mockResolvedValue(messages),
+    findBySessionId: vi.fn().mockResolvedValue([]),
+    deleteByFeatureId: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeWorkflowStepRepo(): IWorkflowStepRepository {
+  return {
+    create: vi.fn(),
+    ensureSteps: vi.fn().mockResolvedValue([]),
+    findById: vi.fn().mockResolvedValue(null),
+    listBySession: vi.fn().mockResolvedValue([]),
+    listByFeature: vi.fn().mockResolvedValue([]),
+    updateStatus: vi.fn(),
+    markAllRunningAsInterrupted: vi.fn().mockResolvedValue(0),
+    deleteByFeatureId: vi.fn(),
+  } as unknown as IWorkflowStepRepository;
+}
+
+function makeSessionState(
+  sessionId: string,
+  featureId: string,
+  overrides: Partial<SessionState> = {}
+): SessionState {
+  return {
+    sessionId,
+    featureId,
+    worktreePath: '/tmp/test',
+    model: 'claude-sonnet-4-6',
+    agentType: 'claude-code',
+    handle: null as any,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+function makeMsg(featureId: string, content: string): InteractiveMessage {
+  return {
+    id: 'msg-1',
+    featureId,
+    role: InteractiveMessageRole.user,
+    content,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as InteractiveMessage;
+}
+
+describe('ChatStateAssembler', () => {
+  let registry: SessionRegistry;
+  let sessionRepo: IInteractiveSessionRepository;
+  let messageRepo: IInteractiveMessageRepository;
+  let workflowStepRepo: IWorkflowStepRepository;
+  let assembler: ChatStateAssembler;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    sessionRepo = makeSessionRepo();
+    messageRepo = makeMessageRepo();
+    workflowStepRepo = makeWorkflowStepRepo();
+
+    assembler = new ChatStateAssembler(messageRepo, sessionRepo, workflowStepRepo, registry);
+  });
+
+  describe('assemble — no active session', () => {
+    it('returns empty messages and null sessionStatus when no DB session', async () => {
+      const state = await assembler.assemble('feat-none');
+
+      expect(state.messages).toEqual([]);
+      expect(state.sessionStatus).toBeNull();
+      expect(state.streamingText).toBeNull();
+      expect(state.sessionInfo).toBeNull();
+      expect(state.turnStatus).toBe('idle');
+    });
+
+    it('includes messages from DB', async () => {
+      const msg = makeMsg('feat-1', 'hello');
+      vi.mocked(messageRepo.findByFeatureId).mockResolvedValueOnce([msg]);
+
+      const state = await assembler.assemble('feat-1');
+
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0].content).toBe('hello');
+    });
+
+    it('sets sessionStatus from DB when session exists but is stopped', async () => {
+      vi.mocked(sessionRepo.findByFeatureId).mockResolvedValueOnce({
+        id: 'old-session',
+        featureId: 'feat-1',
+        status: InteractiveSessionStatus.stopped,
+        startedAt: new Date(),
+        lastActivityAt: new Date(),
+      } as InteractiveSession);
+
+      const state = await assembler.assemble('feat-1');
+
+      expect(state.sessionStatus).toBe(InteractiveSessionStatus.stopped);
+      expect(state.sessionInfo).toBeNull(); // stopped sessions don't get sessionInfo
+    });
+  });
+
+  describe('assemble — active in-memory session', () => {
+    it('populates sessionInfo from registry and DB', async () => {
+      const sessionId = 'session-active-1';
+      const featureId = 'feat-active-1';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId));
+
+      const dbSession: InteractiveSession = {
+        id: sessionId,
+        featureId,
+        status: InteractiveSessionStatus.ready,
+        startedAt: new Date('2025-01-01T00:00:00Z'),
+        lastActivityAt: new Date('2025-01-01T01:00:00Z'),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as InteractiveSession;
+
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce(dbSession);
+      vi.mocked(sessionRepo.getUsage).mockResolvedValueOnce({
+        totalCostUsd: 0.05,
+        totalInputTokens: 100,
+        totalOutputTokens: 200,
+      } as any);
+      vi.mocked(sessionRepo.getTurnStatuses).mockResolvedValueOnce(
+        new Map([[featureId, 'processing']])
+      );
+
+      const state = await assembler.assemble(featureId);
+
+      expect(state.sessionStatus).toBe(InteractiveSessionStatus.ready);
+      expect(state.sessionInfo).not.toBeNull();
+      expect(state.sessionInfo!.model).toBe('claude-sonnet-4-6');
+      expect(state.sessionInfo!.totalCostUsd).toBe(0.05);
+      expect(state.turnStatus).toBe('processing');
+    });
+
+    it('includes streamingText from buffer', async () => {
+      const sessionId = 'session-streaming-1';
+      const featureId = 'feat-streaming';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId));
+
+      // Set buffer on the registered state
+      const state = registry.get(sessionId)!;
+      state.currentAssistantBuffer = 'partial response...';
+
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce({
+        id: sessionId,
+        featureId,
+        status: InteractiveSessionStatus.ready,
+        startedAt: new Date(),
+        lastActivityAt: new Date(),
+      } as InteractiveSession);
+      vi.mocked(sessionRepo.getTurnStatuses).mockResolvedValueOnce(new Map());
+
+      const chatState = await assembler.assemble(featureId);
+
+      expect(chatState.streamingText).toBe('partial response...');
+    });
+
+    it('includes pendingInteraction if present', async () => {
+      const sessionId = 'session-interact-1';
+      const featureId = 'feat-interact';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId));
+
+      const s = registry.get(sessionId)!;
+      s.pendingInteraction = { type: 'question', questions: [] } as any;
+
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce({
+        id: sessionId,
+        featureId,
+        status: InteractiveSessionStatus.ready,
+        startedAt: new Date(),
+        lastActivityAt: new Date(),
+      } as InteractiveSession);
+      vi.mocked(sessionRepo.getTurnStatuses).mockResolvedValueOnce(new Map());
+
+      const chatState = await assembler.assemble(featureId);
+
+      expect(chatState.pendingInteraction).toBeDefined();
+    });
+  });
+
+  describe('assemble — workflow steps', () => {
+    it('builds workflow DTO from DB steps', async () => {
+      const featureId = 'feat-workflow';
+
+      vi.mocked(workflowStepRepo.listByFeature).mockResolvedValueOnce([
+        {
+          id: 'step-1',
+          workflowId: 'wf-1',
+          featureId,
+          status: WorkflowStepStatus.running,
+          name: 'Step 1',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as any,
+        {
+          id: 'step-2',
+          workflowId: 'wf-1',
+          featureId,
+          status: WorkflowStepStatus.done,
+          name: 'Step 2',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as any,
+      ]);
+
+      const state = await assembler.assemble(featureId);
+
+      expect(state.workflow).not.toBeNull();
+      expect(state.workflow!.workflowId).toBe('wf-1');
+      expect(state.workflow!.steps).toHaveLength(2);
+      expect(state.workflow!.currentStepId).toBe('step-1');
+      expect(state.turnStatus).toBe('processing');
+    });
+
+    it('returns null workflow when no steps exist', async () => {
+      const state = await assembler.assemble('feat-no-wf');
+
+      expect(state.workflow).toBeNull();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/api/message-dispatcher.test.ts
+++ b/tests/unit/infrastructure/services/interactive/api/message-dispatcher.test.ts
@@ -1,0 +1,360 @@
+/**
+ * MessageDispatcher Unit Tests
+ *
+ * TDD: RED → GREEN → REFACTOR
+ *
+ * Covers sendMessage and sendUserMessage routing logic.
+ * All deps are mocked — no real processes or DB writes.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { MessageDispatcher } from '@/infrastructure/services/interactive/api/message-dispatcher.js';
+import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { SessionState } from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { SessionBootstrapper } from '@/infrastructure/services/interactive/lifecycle/session-bootstrapper.js';
+import type { SessionTerminator } from '@/infrastructure/services/interactive/lifecycle/session-terminator.js';
+import type { TurnExecutor } from '@/infrastructure/services/interactive/runtime/turn.executor.js';
+import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { InteractiveSession } from '@/domain/generated/output.js';
+import { InteractiveSessionStatus, InteractiveMessageRole } from '@/domain/generated/output.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSessionRepo(
+  overrides: Partial<IInteractiveSessionRepository> = {}
+): IInteractiveSessionRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn().mockResolvedValue(null),
+    findByFeatureId: vi.fn().mockResolvedValue(null),
+    findAllActive: vi.fn().mockResolvedValue([]),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    updateLastActivity: vi.fn().mockResolvedValue(undefined),
+    markAllActiveStopped: vi.fn().mockResolvedValue(undefined),
+    countActiveSessions: vi.fn().mockResolvedValue(0),
+    updateAgentSessionId: vi.fn().mockResolvedValue(undefined),
+    getAgentSessionId: vi.fn().mockResolvedValue(null),
+    findLatestAgentSessionIdForFeature: vi.fn().mockResolvedValue(null),
+    updateTurnStatus: vi.fn().mockResolvedValue(undefined),
+    getTurnStatuses: vi.fn().mockResolvedValue(new Map()),
+    getAllActiveTurnStatuses: vi.fn().mockResolvedValue(new Map()),
+    accumulateUsage: vi.fn().mockResolvedValue(undefined),
+    getUsage: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  } as unknown as IInteractiveSessionRepository;
+}
+
+function makeMessageRepo(): IInteractiveMessageRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findByFeatureId: vi.fn().mockResolvedValue([]),
+    findBySessionId: vi.fn().mockResolvedValue([]),
+    deleteByFeatureId: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makePersistence(): SessionPersistence {
+  return {
+    persistMessage: vi.fn().mockResolvedValue(undefined),
+    updateSessionStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    updateTurnStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SessionPersistence;
+}
+
+function makeBootstrapper(): SessionBootstrapper {
+  return {
+    startSession: vi.fn().mockResolvedValue({ id: 'session-1', featureId: 'feat-1' }),
+  } as unknown as SessionBootstrapper;
+}
+
+function makeTerminator(): SessionTerminator {
+  return {
+    stop: vi.fn().mockResolvedValue(undefined),
+    stopByFeature: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SessionTerminator;
+}
+
+function makeTurnExecutor(): TurnExecutor {
+  return {
+    enqueueTurn: vi.fn().mockResolvedValue(undefined),
+  } as unknown as TurnExecutor;
+}
+
+function makeReadyDbSession(sessionId: string, featureId: string): InteractiveSession {
+  return {
+    id: sessionId,
+    featureId,
+    status: InteractiveSessionStatus.ready,
+    startedAt: new Date(),
+    lastActivityAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as InteractiveSession;
+}
+
+function makeSessionState(
+  sessionId: string,
+  featureId: string,
+  overrides: Partial<SessionState> = {}
+): SessionState {
+  return {
+    sessionId,
+    featureId,
+    worktreePath: '/tmp/test',
+    model: 'claude-sonnet-4-6',
+    agentType: 'claude-code',
+    handle: null as any,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MessageDispatcher', () => {
+  let registry: SessionRegistry;
+  let sessionRepo: IInteractiveSessionRepository;
+  let messageRepo: IInteractiveMessageRepository;
+  let persistence: SessionPersistence;
+  let bootstrapper: SessionBootstrapper;
+  let terminator: SessionTerminator;
+  let turnExecutor: TurnExecutor;
+  let dispatcher: MessageDispatcher;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    sessionRepo = makeSessionRepo();
+    messageRepo = makeMessageRepo();
+    persistence = makePersistence();
+    bootstrapper = makeBootstrapper();
+    terminator = makeTerminator();
+    turnExecutor = makeTurnExecutor();
+
+    dispatcher = new MessageDispatcher(
+      sessionRepo,
+      messageRepo,
+      registry,
+      persistence,
+      bootstrapper,
+      terminator,
+      turnExecutor
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // sendMessage
+  // ---------------------------------------------------------------------------
+
+  describe('sendMessage', () => {
+    it('throws when session is not in DB', async () => {
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce(null);
+
+      await expect(dispatcher.sendMessage('session-1', 'hello')).rejects.toThrow(
+        'Session session-1 is not ready'
+      );
+    });
+
+    it('throws when DB session status is booting', async () => {
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce({
+        id: 'session-1',
+        featureId: 'feat-1',
+        status: InteractiveSessionStatus.booting,
+      } as InteractiveSession);
+
+      await expect(dispatcher.sendMessage('session-1', 'hello')).rejects.toThrow(
+        'Session session-1 is not ready'
+      );
+    });
+
+    it('throws when in-memory state is missing', async () => {
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce(
+        makeReadyDbSession('session-1', 'feat-1')
+      );
+      // registry has no state for session-1
+
+      await expect(dispatcher.sendMessage('session-1', 'hello')).rejects.toThrow(
+        'Session session-1 is not ready'
+      );
+    });
+
+    it('persists message and enqueues turn when ready', async () => {
+      const sessionId = 'session-ready-1';
+      const featureId = 'feat-send-1';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId));
+
+      vi.mocked(sessionRepo.findById).mockResolvedValueOnce(
+        makeReadyDbSession(sessionId, featureId)
+      );
+
+      const result = await dispatcher.sendMessage(sessionId, 'test message');
+
+      expect(result.role).toBe(InteractiveMessageRole.user);
+      expect(result.content).toBe('test message');
+      expect(result.sessionId).toBe(sessionId);
+      expect(result.featureId).toBe(featureId);
+      expect(persistence.persistMessage).toHaveBeenCalledOnce();
+      expect(sessionRepo.updateLastActivity).toHaveBeenCalledOnce();
+      expect(turnExecutor.enqueueTurn).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // sendUserMessage
+  // ---------------------------------------------------------------------------
+
+  describe('sendUserMessage', () => {
+    it('persists user message and boots new session when none exists', async () => {
+      // No DB session
+      vi.mocked(sessionRepo.findByFeatureId).mockResolvedValue(null);
+
+      const result = await dispatcher.sendUserMessage(
+        'feat-new',
+        'hello agent',
+        '/tmp/worktree',
+        'claude-sonnet-4-6'
+      );
+
+      expect(result.role).toBe(InteractiveMessageRole.user);
+      expect(result.content).toBe('hello agent');
+      expect(persistence.persistMessage).toHaveBeenCalledOnce();
+      expect(bootstrapper.startSession).toHaveBeenCalledWith(
+        'feat-new',
+        '/tmp/worktree',
+        'claude-sonnet-4-6',
+        undefined,
+        undefined,
+        'hello agent'
+      );
+    });
+
+    it('skips persistence when persistUserMessage=false', async () => {
+      vi.mocked(sessionRepo.findByFeatureId).mockResolvedValue(null);
+
+      await dispatcher.sendUserMessage(
+        'feat-no-persist',
+        'boot content',
+        '/tmp/worktree',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        false
+      );
+
+      expect(persistence.persistMessage).not.toHaveBeenCalled();
+    });
+
+    it('uses agentKickoffOverride as first turn content if provided', async () => {
+      vi.mocked(sessionRepo.findByFeatureId).mockResolvedValue(null);
+
+      await dispatcher.sendUserMessage(
+        'feat-override',
+        'user content',
+        '/tmp/worktree',
+        undefined,
+        undefined,
+        undefined,
+        'kickoff override'
+      );
+
+      expect(bootstrapper.startSession).toHaveBeenCalledWith(
+        'feat-override',
+        '/tmp/worktree',
+        undefined,
+        undefined,
+        undefined,
+        'kickoff override'
+      );
+    });
+
+    it('enqueues turn on ready session', async () => {
+      const sessionId = 'session-ready-2';
+      const featureId = 'feat-ready';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId));
+
+      vi.mocked(sessionRepo.findById).mockResolvedValue(makeReadyDbSession(sessionId, featureId));
+
+      await dispatcher.sendUserMessage(featureId, 'hello', '/tmp/worktree');
+
+      expect(turnExecutor.enqueueTurn).toHaveBeenCalledOnce();
+      expect(bootstrapper.startSession).not.toHaveBeenCalled();
+    });
+
+    it('sets pendingUserContent on booting session', async () => {
+      const sessionId = 'session-booting-1';
+      const featureId = 'feat-booting';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId));
+
+      vi.mocked(sessionRepo.findById).mockResolvedValue({
+        id: sessionId,
+        featureId,
+        status: InteractiveSessionStatus.booting,
+      } as InteractiveSession);
+
+      await dispatcher.sendUserMessage(featureId, 'queued message', '/tmp/worktree');
+
+      const registeredState = registry.get(sessionId);
+      expect(registeredState?.pendingUserContent).toBe('queued message');
+      expect(turnExecutor.enqueueTurn).not.toHaveBeenCalled();
+      expect(bootstrapper.startSession).not.toHaveBeenCalled();
+    });
+
+    it('stops model-changed session and boots a new one', async () => {
+      const sessionId = 'session-old-model';
+      const featureId = 'feat-model-change';
+
+      registry.set(sessionId, makeSessionState(sessionId, featureId, { model: 'old-model' }));
+
+      vi.mocked(sessionRepo.findByFeatureId).mockResolvedValue(null);
+
+      await dispatcher.sendUserMessage(featureId, 'hello', '/tmp/worktree', 'new-model');
+
+      // Old session was stopped
+      expect(terminator.stop).toHaveBeenCalledWith(sessionId);
+      // Should boot a new session
+      expect(bootstrapper.startSession).toHaveBeenCalledWith(
+        featureId,
+        '/tmp/worktree',
+        'new-model',
+        undefined,
+        undefined,
+        'hello'
+      );
+    });
+
+    it('marks orphaned DB session as stopped before booting', async () => {
+      // No in-memory state but DB has an active session
+      vi.mocked(sessionRepo.findByFeatureId).mockResolvedValue({
+        id: 'orphan-session',
+        featureId: 'feat-orphan',
+        status: InteractiveSessionStatus.ready,
+      } as InteractiveSession);
+
+      await dispatcher.sendUserMessage('feat-orphan', 'hello', '/tmp/worktree');
+
+      expect(persistence.updateSessionStatusAndNotify).toHaveBeenCalledWith(
+        'orphan-session',
+        'feat-orphan',
+        InteractiveSessionStatus.stopped,
+        expect.any(Date)
+      );
+      expect(bootstrapper.startSession).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/api/workflow-hooks.test.ts
+++ b/tests/unit/infrastructure/services/interactive/api/workflow-hooks.test.ts
@@ -1,0 +1,116 @@
+/**
+ * WorkflowHooks Unit Tests
+ *
+ * TDD: RED → GREEN → REFACTOR
+ *
+ * Covers setActiveStep, clearActiveStep, notifyWorkflowStep, waitForTurnDone.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { WorkflowHooks } from '@/infrastructure/services/interactive/api/workflow-hooks.js';
+import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { WorkflowStep } from '@/domain/generated/output.js';
+import { WorkflowStepStatus } from '@/domain/generated/output.js';
+
+function makeStep(id: string, featureId: string): WorkflowStep {
+  return {
+    id,
+    sessionId: 'session-1',
+    workflowId: 'wf-1',
+    featureId,
+    stepKey: 'step-key',
+    stepIndex: 0,
+    title: 'Step',
+    description: '',
+    name: 'Step',
+    status: WorkflowStepStatus.running,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as unknown as WorkflowStep;
+}
+
+describe('WorkflowHooks', () => {
+  let registry: SessionRegistry;
+  let eventDispatcher: StreamEventDispatcher;
+  let hooks: WorkflowHooks;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    eventDispatcher = new StreamEventDispatcher(registry);
+    hooks = new WorkflowHooks(registry, eventDispatcher);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('setActiveStep', () => {
+    it('delegates to registry', () => {
+      const spy = vi.spyOn(registry, 'setActiveStep');
+      hooks.setActiveStep('feat-1', 'step-1');
+      expect(spy).toHaveBeenCalledWith('feat-1', 'step-1');
+    });
+  });
+
+  describe('clearActiveStep', () => {
+    it('delegates to registry', () => {
+      const spy = vi.spyOn(registry, 'clearActiveStep');
+      hooks.clearActiveStep('feat-1');
+      expect(spy).toHaveBeenCalledWith('feat-1');
+    });
+  });
+
+  describe('notifyWorkflowStep', () => {
+    it('fans out a workflowStep chunk to feature subscribers', () => {
+      const featureId = 'feat-notify-1';
+      const step = makeStep('step-1', featureId);
+
+      const received: unknown[] = [];
+      eventDispatcher.subscribeByFeature(featureId, (chunk) => received.push(chunk));
+
+      hooks.notifyWorkflowStep(featureId, step);
+
+      expect(received).toHaveLength(1);
+      expect((received[0] as any).workflowStep).toBe(step);
+      expect((received[0] as any).done).toBe(false);
+      expect((received[0] as any).delta).toBe('');
+    });
+  });
+
+  describe('waitForTurnDone', () => {
+    it('resolves when a done chunk is emitted', async () => {
+      const featureId = 'feat-wait-done';
+      const promise = hooks.waitForTurnDone(featureId);
+
+      // Emit a non-done chunk first, then a done chunk
+      eventDispatcher.notifyByFeatureId(featureId, { delta: 'partial', done: false });
+      eventDispatcher.notifyByFeatureId(featureId, { delta: '', done: true });
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('rejects when AbortSignal is already aborted', async () => {
+      const featureId = 'feat-wait-abort';
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(hooks.waitForTurnDone(featureId, controller.signal)).rejects.toThrow(
+        'waitForTurnDone aborted'
+      );
+    });
+
+    it('rejects when AbortSignal is aborted after waiting starts', async () => {
+      const featureId = 'feat-wait-abort-2';
+      const controller = new AbortController();
+
+      const promise = hooks.waitForTurnDone(featureId, controller.signal);
+
+      // Abort after the promise has been created
+      controller.abort();
+
+      await expect(promise).rejects.toThrow('waitForTurnDone aborted');
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/core/session-persistence.test.ts
+++ b/tests/unit/infrastructure/services/interactive/core/session-persistence.test.ts
@@ -1,0 +1,265 @@
+/**
+ * SessionPersistence Unit Tests
+ *
+ * Owns the monotonic message clock + every DB mutation that must notify
+ * subscribers. The monotonic-clock regression test is mandatory — it
+ * codifies the fix that prevents same-millisecond tool_use/tool_result
+ * rows from colliding on `ORDER BY created_at ASC` and breaking
+ * StepTracker.classifyMessages.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { InteractiveMessage } from '@/domain/generated/output.js';
+import { InteractiveMessageRole, InteractiveSessionStatus } from '@/domain/generated/output.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<InteractiveMessage> = {}): InteractiveMessage {
+  const now = new Date();
+  return {
+    id: 'msg-1',
+    featureId: 'feat-1',
+    sessionId: 'sess-1',
+    role: InteractiveMessageRole.assistant,
+    content: 'hello',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeMessageRepoMock(): IInteractiveMessageRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findByFeatureId: vi.fn().mockResolvedValue([]),
+    findBySessionId: vi.fn().mockResolvedValue([]),
+    deleteByFeatureId: vi.fn().mockResolvedValue(undefined),
+    deleteBySessionId: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IInteractiveMessageRepository;
+}
+
+function makeSessionRepoMock(): IInteractiveSessionRepository {
+  return {
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    updateTurnStatus: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IInteractiveSessionRepository;
+}
+
+describe('SessionPersistence', () => {
+  let messageRepo: IInteractiveMessageRepository;
+  let sessionRepo: IInteractiveSessionRepository;
+  let registry: SessionRegistry;
+  let dispatcher: StreamEventDispatcher;
+  let persistence: SessionPersistence;
+
+  beforeEach(() => {
+    messageRepo = makeMessageRepoMock();
+    sessionRepo = makeSessionRepoMock();
+    registry = new SessionRegistry();
+    dispatcher = new StreamEventDispatcher(registry);
+    persistence = new SessionPersistence(messageRepo, sessionRepo, registry, dispatcher);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('persistMessage', () => {
+    it('persists the message via the repository and notifies feature subscribers', async () => {
+      const featureCb = vi.fn();
+      dispatcher.subscribeByFeature('feat-1', featureCb);
+      const msg = makeMessage();
+      await persistence.persistMessage(msg);
+      expect(messageRepo.create).toHaveBeenCalledWith(msg);
+      expect(featureCb).toHaveBeenCalledWith(
+        expect.objectContaining({ delta: '', done: false, message: msg })
+      );
+    });
+
+    it('tags the message with the active workflow step when one is set and stepId is empty', async () => {
+      registry.setActiveStep('feat-1', 'step-42');
+      const msg = makeMessage();
+      await persistence.persistMessage(msg);
+      const created = (messageRepo.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(created.stepId).toBe('step-42');
+    });
+
+    it('does NOT override an existing stepId on the message', async () => {
+      registry.setActiveStep('feat-1', 'step-42');
+      const msg = makeMessage({ stepId: 'explicit-step' });
+      await persistence.persistMessage(msg);
+      const created = (messageRepo.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(created.stepId).toBe('explicit-step');
+    });
+
+    it('leaves stepId absent when no active step is registered', async () => {
+      const msg = makeMessage();
+      await persistence.persistMessage(msg);
+      const created = (messageRepo.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(created.stepId).toBeUndefined();
+    });
+  });
+
+  describe('monotonic clock', () => {
+    it('assigns strictly-increasing createdAt values even when Date.now() is frozen', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      const createdAtValues: number[] = [];
+      (messageRepo.create as ReturnType<typeof vi.fn>).mockImplementation(
+        async (m: InteractiveMessage) => {
+          createdAtValues.push(m.createdAt.getTime());
+        }
+      );
+
+      const state = makeState();
+      // flushAssistantBuffer writes a new assistant message each call with nextMessageDate()
+      for (let i = 0; i < 100; i += 1) {
+        state.currentAssistantBuffer = `chunk ${i}`;
+        await persistence.flushAssistantBuffer(state);
+      }
+
+      expect(createdAtValues).toHaveLength(100);
+      for (let i = 1; i < createdAtValues.length; i += 1) {
+        expect(createdAtValues[i]).toBeGreaterThan(createdAtValues[i - 1]);
+      }
+    });
+
+    it('persistToolEvent timestamps are strictly increasing under a frozen clock', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+      const createdAtValues: number[] = [];
+      (messageRepo.create as ReturnType<typeof vi.fn>).mockImplementation(
+        async (m: InteractiveMessage) => {
+          createdAtValues.push(m.createdAt.getTime());
+        }
+      );
+
+      const state = makeState();
+      for (let i = 0; i < 20; i += 1) {
+        await persistence.persistToolEvent(state, `tool-${i}`, 'detail');
+      }
+
+      expect(createdAtValues).toHaveLength(20);
+      for (let i = 1; i < createdAtValues.length; i += 1) {
+        expect(createdAtValues[i]).toBeGreaterThan(createdAtValues[i - 1]);
+      }
+    });
+  });
+
+  describe('flushAssistantBuffer', () => {
+    it('does nothing when the buffer is empty or whitespace', async () => {
+      const state = makeState({ currentAssistantBuffer: '   ' });
+      await persistence.flushAssistantBuffer(state);
+      expect(messageRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('persists the trimmed buffer as a new assistant message and clears it', async () => {
+      const state = makeState({ currentAssistantBuffer: '  hi there  ' });
+      await persistence.flushAssistantBuffer(state);
+      expect(state.currentAssistantBuffer).toBe('');
+      const created = (messageRepo.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(created.content).toBe('hi there');
+      expect(created.role).toBe(InteractiveMessageRole.assistant);
+      expect(created.sessionId).toBe('sess-1');
+      expect(created.featureId).toBe('feat-1');
+    });
+  });
+
+  describe('persistToolEvent', () => {
+    it('flushes the assistant buffer before writing the tool row', async () => {
+      const state = makeState({ currentAssistantBuffer: 'partial prose' });
+      await persistence.persistToolEvent(state, 'Thinking', 'planning');
+
+      const createCalls = (messageRepo.create as ReturnType<typeof vi.fn>).mock.calls;
+      expect(createCalls.length).toBe(2);
+      // First call is the flushed prose
+      expect(createCalls[0][0].content).toBe('partial prose');
+      // Second call is the tool event itself
+      expect(createCalls[1][0].content).toBe('**Thinking** `planning`');
+      expect(state.currentAssistantBuffer).toBe('');
+    });
+
+    it('omits the detail in markdown when detail is undefined', async () => {
+      const state = makeState();
+      await persistence.persistToolEvent(state, 'Thinking');
+      const created = (messageRepo.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(created.content).toBe('**Thinking**');
+    });
+
+    it('swallows persistence errors — tool events must not fail the turn', async () => {
+      (messageRepo.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('db down'));
+      const state = makeState();
+      await expect(persistence.persistToolEvent(state, 'Thinking')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('updateSessionStatusAndNotify', () => {
+    it('calls updateStatus without endedAt when not supplied', async () => {
+      const featureCb = vi.fn();
+      dispatcher.subscribeByFeature('feat-1', featureCb);
+      await persistence.updateSessionStatusAndNotify(
+        'sess-1',
+        'feat-1',
+        InteractiveSessionStatus.ready
+      );
+      expect(sessionRepo.updateStatus).toHaveBeenCalledWith(
+        'sess-1',
+        InteractiveSessionStatus.ready
+      );
+      expect(featureCb).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionStatus: InteractiveSessionStatus.ready })
+      );
+    });
+
+    it('passes endedAt to updateStatus when supplied', async () => {
+      const endedAt = new Date('2026-04-14T10:00:00Z');
+      await persistence.updateSessionStatusAndNotify(
+        'sess-1',
+        'feat-1',
+        InteractiveSessionStatus.stopped,
+        endedAt
+      );
+      expect(sessionRepo.updateStatus).toHaveBeenCalledWith(
+        'sess-1',
+        InteractiveSessionStatus.stopped,
+        endedAt
+      );
+    });
+  });
+
+  describe('updateTurnStatusAndNotify', () => {
+    it('calls updateTurnStatus and notifies subscribers with the new status', async () => {
+      const featureCb = vi.fn();
+      dispatcher.subscribeByFeature('feat-1', featureCb);
+      await persistence.updateTurnStatusAndNotify('sess-1', 'feat-1', 'processing');
+      expect(sessionRepo.updateTurnStatus).toHaveBeenCalledWith('sess-1', 'processing');
+      expect(featureCb).toHaveBeenCalledWith(expect.objectContaining({ turnStatus: 'processing' }));
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/core/session-registry.test.ts
+++ b/tests/unit/infrastructure/services/interactive/core/session-registry.test.ts
@@ -1,0 +1,111 @@
+/**
+ * SessionRegistry Unit Tests
+ *
+ * Pure in-memory state container — no mocks needed beyond the value type.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+describe('SessionRegistry', () => {
+  let registry: SessionRegistry;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+  });
+
+  describe('session state CRUD', () => {
+    it('set/get/has/delete round-trips a session state', () => {
+      const state = makeState();
+      expect(registry.has('sess-1')).toBe(false);
+      registry.set('sess-1', state);
+      expect(registry.has('sess-1')).toBe(true);
+      expect(registry.get('sess-1')).toBe(state);
+      registry.delete('sess-1');
+      expect(registry.has('sess-1')).toBe(false);
+      expect(registry.get('sess-1')).toBeUndefined();
+    });
+
+    it('values() iterates every stored state', () => {
+      registry.set('a', makeState({ sessionId: 'a', featureId: 'fa' }));
+      registry.set('b', makeState({ sessionId: 'b', featureId: 'fb' }));
+      const all = Array.from(registry.values()).map((s) => s.sessionId);
+      expect(all.sort()).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('findActiveStateForFeature', () => {
+    it('returns the first state whose featureId matches', () => {
+      const s1 = makeState({ sessionId: 's1', featureId: 'fx' });
+      const s2 = makeState({ sessionId: 's2', featureId: 'fy' });
+      registry.set('s1', s1);
+      registry.set('s2', s2);
+      expect(registry.findActiveStateForFeature('fy')).toBe(s2);
+    });
+
+    it('returns undefined when no state matches', () => {
+      registry.set('s1', makeState({ featureId: 'fx' }));
+      expect(registry.findActiveStateForFeature('missing')).toBeUndefined();
+    });
+  });
+
+  describe('stopped agent session id cache', () => {
+    it('caches and retrieves an agentSessionId by feature', () => {
+      registry.cacheStoppedAgentSessionId('feat-1', 'agent-abc');
+      expect(registry.takeStoppedAgentSessionId('feat-1')).toBe('agent-abc');
+    });
+
+    it('takeStoppedAgentSessionId does NOT delete the cached entry', () => {
+      registry.cacheStoppedAgentSessionId('feat-1', 'agent-abc');
+      registry.takeStoppedAgentSessionId('feat-1');
+      expect(registry.takeStoppedAgentSessionId('feat-1')).toBe('agent-abc');
+    });
+
+    it('deleteStoppedAgentSessionId clears the cached entry', () => {
+      registry.cacheStoppedAgentSessionId('feat-1', 'agent-abc');
+      registry.deleteStoppedAgentSessionId('feat-1');
+      expect(registry.takeStoppedAgentSessionId('feat-1')).toBeUndefined();
+    });
+  });
+
+  describe('active step tracking', () => {
+    it('sets, reads, and clears the active step for a feature', () => {
+      expect(registry.getActiveStep('feat-1')).toBeUndefined();
+      registry.setActiveStep('feat-1', 'step-42');
+      expect(registry.getActiveStep('feat-1')).toBe('step-42');
+      registry.clearActiveStep('feat-1');
+      expect(registry.getActiveStep('feat-1')).toBeUndefined();
+    });
+
+    it('tracks active steps independently per feature', () => {
+      registry.setActiveStep('feat-a', 'step-1');
+      registry.setActiveStep('feat-b', 'step-2');
+      expect(registry.getActiveStep('feat-a')).toBe('step-1');
+      expect(registry.getActiveStep('feat-b')).toBe('step-2');
+      registry.clearActiveStep('feat-a');
+      expect(registry.getActiveStep('feat-a')).toBeUndefined();
+      expect(registry.getActiveStep('feat-b')).toBe('step-2');
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/core/stream-event-dispatcher.test.ts
+++ b/tests/unit/infrastructure/services/interactive/core/stream-event-dispatcher.test.ts
@@ -1,0 +1,143 @@
+/**
+ * StreamEventDispatcher Unit Tests
+ *
+ * Pure pub/sub — reads session subscribers from an injected SessionRegistry.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { StreamChunk } from '@/application/ports/output/services/interactive-session-service.interface.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+describe('StreamEventDispatcher', () => {
+  let registry: SessionRegistry;
+  let dispatcher: StreamEventDispatcher;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    dispatcher = new StreamEventDispatcher(registry);
+  });
+
+  describe('subscribeSession', () => {
+    it('adds a subscriber to the session state and returns an unsubscribe fn', () => {
+      const state = makeState();
+      registry.set('sess-1', state);
+      const cb = vi.fn();
+      const unsubscribe = dispatcher.subscribeSession('sess-1', cb);
+      expect(state.subscribers.size).toBe(1);
+      unsubscribe();
+      expect(state.subscribers.size).toBe(0);
+    });
+
+    it('returns a no-op unsubscribe when the session is unknown', () => {
+      const cb = vi.fn();
+      const unsubscribe = dispatcher.subscribeSession('missing', cb);
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+
+  describe('subscribeByFeature', () => {
+    it('receives feature-level chunks and cleans up the map on final unsubscribe', () => {
+      const cb = vi.fn();
+      const unsubscribe = dispatcher.subscribeByFeature('feat-1', cb);
+      dispatcher.notifyByFeatureId('feat-1', { delta: 'hi', done: false });
+      expect(cb).toHaveBeenCalledWith({ delta: 'hi', done: false });
+      unsubscribe();
+      dispatcher.notifyByFeatureId('feat-1', { delta: 'after', done: false });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports multiple feature subscribers without collision', () => {
+      const cb1 = vi.fn();
+      const cb2 = vi.fn();
+      dispatcher.subscribeByFeature('feat-1', cb1);
+      dispatcher.subscribeByFeature('feat-1', cb2);
+      dispatcher.notifyByFeatureId('feat-1', { delta: 'x', done: false });
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('subscribeAll', () => {
+    it('receives every chunk with its feature scope', () => {
+      const cb = vi.fn();
+      const unsubscribe = dispatcher.subscribeAll(cb);
+      const state = makeState({ featureId: 'feat-9' });
+      dispatcher.notify(state, { delta: 'hi', done: false });
+      expect(cb).toHaveBeenCalledWith('feat-9', { delta: 'hi', done: false });
+      unsubscribe();
+      dispatcher.notify(state, { delta: 'nope', done: false });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('notify', () => {
+    it('fans out to session subs, feature subs, and global subs', () => {
+      const sessionCb = vi.fn();
+      const featureCb = vi.fn();
+      const globalCb = vi.fn();
+
+      const state = makeState({ sessionId: 'sess-1', featureId: 'feat-1' });
+      state.subscribers.add(sessionCb);
+      registry.set('sess-1', state);
+
+      dispatcher.subscribeByFeature('feat-1', featureCb);
+      dispatcher.subscribeAll(globalCb);
+
+      const chunk: StreamChunk = { delta: 'hello', done: false };
+      dispatcher.notify(state, chunk);
+
+      expect(sessionCb).toHaveBeenCalledWith(chunk);
+      expect(featureCb).toHaveBeenCalledWith(chunk);
+      expect(globalCb).toHaveBeenCalledWith('feat-1', chunk);
+    });
+
+    it('does nothing extra when there are no subscribers', () => {
+      const state = makeState();
+      expect(() => dispatcher.notify(state, { delta: '', done: true })).not.toThrow();
+    });
+  });
+
+  describe('notifyByFeatureId', () => {
+    it('fans out to feature subs and global subs only', () => {
+      const featureCb = vi.fn();
+      const globalCb = vi.fn();
+      dispatcher.subscribeByFeature('feat-1', featureCb);
+      dispatcher.subscribeAll(globalCb);
+
+      const chunk: StreamChunk = { delta: '', done: false, sessionStatus: 'ready' };
+      dispatcher.notifyByFeatureId('feat-1', chunk);
+
+      expect(featureCb).toHaveBeenCalledWith(chunk);
+      expect(globalCb).toHaveBeenCalledWith('feat-1', chunk);
+    });
+
+    it('skips feature subs for other features', () => {
+      const otherCb = vi.fn();
+      dispatcher.subscribeByFeature('feat-other', otherCb);
+      dispatcher.notifyByFeatureId('feat-1', { delta: '', done: false });
+      expect(otherCb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -31,6 +31,11 @@ import { StreamEventDispatcher } from '@/infrastructure/services/interactive/cor
 import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
 import { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
+import { SessionBootstrapper } from '@/infrastructure/services/interactive/lifecycle/session-bootstrapper.js';
+import { SessionTerminator } from '@/infrastructure/services/interactive/lifecycle/session-terminator.js';
+import { TurnExecutor } from '@/infrastructure/services/interactive/runtime/turn.executor.js';
+import { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
+import { BootPromptResolver } from '@/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.js';
 import type { ISettingsProvider } from '@/application/ports/output/services/settings-provider.interface.js';
 import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
@@ -321,19 +326,47 @@ describe('InteractiveSessionService', () => {
       error: vi.fn(),
     };
     const streamConsumer = new AgentStreamConsumer(persistence, dispatcher, fakeLogger);
+    const bootPromptResolver = new BootPromptResolver(featureRepo, contextBuilder);
+    const interactionCoordinator = new UserInteractionCoordinator(
+      persistence,
+      dispatcher,
+      fakeLogger
+    );
+    const bootstrapper = new SessionBootstrapper(
+      sessionRepo,
+      registry,
+      persistence,
+      dispatcher,
+      bootPromptResolver,
+      streamConsumer,
+      executorFactory,
+      agentConfigResolver,
+      interactionCoordinator,
+      fakeLogger
+    );
+    const terminator = new SessionTerminator(registry, persistence, dispatcher, fakeLogger);
+    const turnExecutor = new TurnExecutor(
+      sessionRepo,
+      registry,
+      persistence,
+      streamConsumer,
+      fakeLogger,
+      dispatcher
+    );
     service = new InteractiveSessionService(
       sessionRepo,
       messageRepo,
-      executorFactory,
       featureRepo,
       contextBuilder,
       workflowStepRepo,
       registry,
       dispatcher,
       persistence,
-      agentConfigResolver,
-      streamConsumer,
-      fakeLogger
+      fakeLogger,
+      bootstrapper,
+      terminator,
+      turnExecutor,
+      interactionCoordinator
     );
   });
 

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -29,6 +29,8 @@ import { InteractiveSessionService } from '@/infrastructure/services/interactive
 import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
 import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
 import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
+import type { ISettingsProvider } from '@/application/ports/output/services/settings-provider.interface.js';
 import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
 import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
 import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
@@ -303,6 +305,13 @@ describe('InteractiveSessionService', () => {
     const registry = new SessionRegistry();
     const dispatcher = new StreamEventDispatcher(registry);
     const persistence = new SessionPersistence(messageRepo, sessionRepo, registry, dispatcher);
+    const fakeSettingsProvider: ISettingsProvider = {
+      has: () => false,
+      get: () => {
+        throw new Error('not initialized');
+      },
+    };
+    const agentConfigResolver = new AgentConfigResolver(fakeSettingsProvider);
     service = new InteractiveSessionService(
       sessionRepo,
       messageRepo,
@@ -312,7 +321,8 @@ describe('InteractiveSessionService', () => {
       workflowStepRepo,
       registry,
       dispatcher,
-      persistence
+      persistence,
+      agentConfigResolver
     );
   });
 

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -26,6 +26,8 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { InteractiveSessionService } from '@/infrastructure/services/interactive/interactive-session.service.js';
+import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
 import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
 import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
 import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
@@ -297,13 +299,17 @@ describe('InteractiveSessionService', () => {
       deleteByFeatureId: vi.fn(),
     };
 
+    const registry = new SessionRegistry();
+    const dispatcher = new StreamEventDispatcher(registry);
     service = new InteractiveSessionService(
       sessionRepo,
       messageRepo,
       executorFactory,
       featureRepo,
       contextBuilder,
-      workflowStepRepo
+      workflowStepRepo,
+      registry,
+      dispatcher
     );
   });
 

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -28,6 +28,7 @@ vi.mock('node:child_process', () => ({
 import { InteractiveSessionService } from '@/infrastructure/services/interactive/interactive-session.service.js';
 import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
 import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
 import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
 import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
@@ -301,6 +302,7 @@ describe('InteractiveSessionService', () => {
 
     const registry = new SessionRegistry();
     const dispatcher = new StreamEventDispatcher(registry);
+    const persistence = new SessionPersistence(messageRepo, sessionRepo, registry, dispatcher);
     service = new InteractiveSessionService(
       sessionRepo,
       messageRepo,
@@ -309,7 +311,8 @@ describe('InteractiveSessionService', () => {
       contextBuilder,
       workflowStepRepo,
       registry,
-      dispatcher
+      dispatcher,
+      persistence
     );
   });
 

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -36,6 +36,9 @@ import { SessionTerminator } from '@/infrastructure/services/interactive/lifecyc
 import { TurnExecutor } from '@/infrastructure/services/interactive/runtime/turn.executor.js';
 import { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
 import { BootPromptResolver } from '@/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.js';
+import { MessageDispatcher } from '@/infrastructure/services/interactive/api/message-dispatcher.js';
+import { ChatStateAssembler } from '@/infrastructure/services/interactive/api/chat-state.assembler.js';
+import { WorkflowHooks } from '@/infrastructure/services/interactive/api/workflow-hooks.js';
 import type { ISettingsProvider } from '@/application/ports/output/services/settings-provider.interface.js';
 import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
@@ -353,6 +356,22 @@ describe('InteractiveSessionService', () => {
       fakeLogger,
       dispatcher
     );
+    const messageDispatcher = new MessageDispatcher(
+      sessionRepo,
+      messageRepo,
+      registry,
+      persistence,
+      bootstrapper,
+      terminator,
+      turnExecutor
+    );
+    const chatStateAssembler = new ChatStateAssembler(
+      messageRepo,
+      sessionRepo,
+      workflowStepRepo,
+      registry
+    );
+    const workflowHooks = new WorkflowHooks(registry, dispatcher);
     service = new InteractiveSessionService(
       sessionRepo,
       messageRepo,
@@ -366,7 +385,10 @@ describe('InteractiveSessionService', () => {
       bootstrapper,
       terminator,
       turnExecutor,
-      interactionCoordinator
+      interactionCoordinator,
+      messageDispatcher,
+      chatStateAssembler,
+      workflowHooks
     );
   });
 

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -333,7 +333,8 @@ describe('InteractiveSessionService', () => {
     const interactionCoordinator = new UserInteractionCoordinator(
       persistence,
       dispatcher,
-      fakeLogger
+      fakeLogger,
+      registry
     );
     const bootstrapper = new SessionBootstrapper(
       sessionRepo,
@@ -347,7 +348,14 @@ describe('InteractiveSessionService', () => {
       interactionCoordinator,
       fakeLogger
     );
-    const terminator = new SessionTerminator(registry, persistence, dispatcher, fakeLogger);
+    const terminator = new SessionTerminator(
+      registry,
+      persistence,
+      dispatcher,
+      fakeLogger,
+      messageRepo,
+      workflowStepRepo
+    );
     const turnExecutor = new TurnExecutor(
       sessionRepo,
       registry,

--- a/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
+++ b/tests/unit/infrastructure/services/interactive/interactive-session.service.test.ts
@@ -30,7 +30,9 @@ import { SessionRegistry } from '@/infrastructure/services/interactive/core/sess
 import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
 import { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
+import { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
 import type { ISettingsProvider } from '@/application/ports/output/services/settings-provider.interface.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
 import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
 import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
@@ -312,6 +314,13 @@ describe('InteractiveSessionService', () => {
       },
     };
     const agentConfigResolver = new AgentConfigResolver(fakeSettingsProvider);
+    const fakeLogger: ILogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const streamConsumer = new AgentStreamConsumer(persistence, dispatcher, fakeLogger);
     service = new InteractiveSessionService(
       sessionRepo,
       messageRepo,
@@ -322,7 +331,9 @@ describe('InteractiveSessionService', () => {
       registry,
       dispatcher,
       persistence,
-      agentConfigResolver
+      agentConfigResolver,
+      streamConsumer,
+      fakeLogger
     );
   });
 

--- a/tests/unit/infrastructure/services/interactive/lifecycle/agent-config.resolver.test.ts
+++ b/tests/unit/infrastructure/services/interactive/lifecycle/agent-config.resolver.test.ts
@@ -1,0 +1,100 @@
+/**
+ * AgentConfigResolver Unit Tests
+ *
+ * Verifies that the resolver correctly derives agent type, auth config,
+ * and the concurrent-session cap from an injected ISettingsProvider —
+ * replacing the prior direct `getSettings()` / `hasSettings()` calls.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
+import type { ISettingsProvider } from '@/application/ports/output/services/settings-provider.interface.js';
+import type { Settings } from '@/domain/generated/output.js';
+import { AgentType, AgentAuthMethod } from '@/domain/generated/output.js';
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    agent: {
+      type: AgentType.CodexCli,
+      authMethod: AgentAuthMethod.Token,
+    },
+    interactiveAgent: {
+      enabled: true,
+      autoTimeoutMinutes: 15,
+      maxConcurrentSessions: 7,
+    },
+    ...overrides,
+  } as Settings;
+}
+
+class FakeSettingsProvider implements ISettingsProvider {
+  constructor(private readonly settings: Settings | null) {}
+
+  has(): boolean {
+    return this.settings !== null;
+  }
+
+  get(): Settings {
+    if (this.settings === null) {
+      throw new Error('Settings not initialized');
+    }
+    return this.settings;
+  }
+}
+
+describe('AgentConfigResolver', () => {
+  describe('resolveAgentType', () => {
+    it('returns the explicit override when provided, regardless of settings', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(makeSettings()));
+      expect(resolver.resolveAgentType(AgentType.ClaudeCode)).toBe(AgentType.ClaudeCode);
+    });
+
+    it('returns the settings.agent.type when no override is provided', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(makeSettings()));
+      expect(resolver.resolveAgentType()).toBe(AgentType.CodexCli);
+    });
+
+    it('falls back to ClaudeCode when settings are not initialized', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(null));
+      expect(resolver.resolveAgentType()).toBe(AgentType.ClaudeCode);
+    });
+  });
+
+  describe('resolveAuthConfig', () => {
+    it('returns the settings.agent config when settings are initialized', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(makeSettings()));
+      expect(resolver.resolveAuthConfig()).toEqual({
+        type: AgentType.CodexCli,
+        authMethod: AgentAuthMethod.Token,
+      });
+    });
+
+    it('falls back to ClaudeCode + Session when settings are not initialized', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(null));
+      expect(resolver.resolveAuthConfig()).toEqual({
+        type: AgentType.ClaudeCode,
+        authMethod: AgentAuthMethod.Session,
+      });
+    });
+  });
+
+  describe('getCap', () => {
+    it('returns interactiveAgent.maxConcurrentSessions when present', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(makeSettings()));
+      expect(resolver.getCap()).toBe(7);
+    });
+
+    it('falls back to DEFAULT_CAP=3 when interactiveAgent is missing', () => {
+      const settings = makeSettings();
+      delete (settings as { interactiveAgent?: unknown }).interactiveAgent;
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(settings));
+      expect(resolver.getCap()).toBe(3);
+    });
+
+    it('falls back to DEFAULT_CAP=3 when settings are not initialized', () => {
+      const resolver = new AgentConfigResolver(new FakeSettingsProvider(null));
+      expect(resolver.getCap()).toBe(3);
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.test.ts
+++ b/tests/unit/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.test.ts
@@ -1,0 +1,155 @@
+/**
+ * BootPromptResolver Unit Tests
+ *
+ * Covers the three-case branch that decides what the agent's first turn
+ * will be:
+ *
+ * 1. pendingUserContent defined → it becomes the bootPrompt (user-initiated boot)
+ * 2. No pending content AND no systemPromptOverride → feature context is the bootPrompt
+ * 3. No pending content AND systemPromptOverride set → silent boot (bootPrompt = '')
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { BootPromptResolver } from '@/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.js';
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import type { FeatureContextBuilder } from '@/infrastructure/services/interactive/feature-context.builder.js';
+
+function makeFeatureRepo(pr?: { url: string }): IFeatureRepository {
+  return {
+    findById: vi
+      .fn()
+      .mockResolvedValue(
+        pr !== undefined
+          ? { id: 'feat-1', name: 'Test Feature', pr }
+          : { id: 'feat-1', name: 'Test Feature' }
+      ),
+    create: vi.fn(),
+    findByIdPrefix: vi.fn(),
+    findBySlug: vi.fn(),
+    findByBranch: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+    findByParentId: vi.fn(),
+    delete: vi.fn(),
+    softDelete: vi.fn(),
+  } as unknown as IFeatureRepository;
+}
+
+function makeContextBuilder(result = 'built-context'): FeatureContextBuilder {
+  return {
+    buildContext: vi.fn().mockReturnValue(result),
+  } as unknown as FeatureContextBuilder;
+}
+
+describe('BootPromptResolver', () => {
+  let featureRepo: IFeatureRepository;
+  let contextBuilder: FeatureContextBuilder;
+  let resolver: BootPromptResolver;
+
+  beforeEach(() => {
+    featureRepo = makeFeatureRepo();
+    contextBuilder = makeContextBuilder();
+    resolver = new BootPromptResolver(featureRepo, contextBuilder);
+  });
+
+  // Case 1: pendingUserContent is defined
+  describe('case 1 — pendingUserContent defined', () => {
+    it('uses pendingUserContent as bootPrompt', async () => {
+      const result = await resolver.resolve('feat-1', '/wt', 'user msg', undefined);
+      expect(result.bootPrompt).toBe('user msg');
+    });
+
+    it('builds feature context when no systemPromptOverride', async () => {
+      await resolver.resolve('feat-1', '/wt', 'user msg', undefined);
+      expect(contextBuilder.buildContext).toHaveBeenCalled();
+      // context is the built feature context
+    });
+
+    it('uses systemPromptOverride as context when provided', async () => {
+      const result = await resolver.resolve('feat-1', '/wt', 'user msg', 'sys override');
+      expect(result.context).toBe('sys override');
+      expect(contextBuilder.buildContext).not.toHaveBeenCalled();
+    });
+
+    it('does not call findById when systemPromptOverride is set', async () => {
+      await resolver.resolve('feat-1', '/wt', 'user msg', 'sys');
+      expect(featureRepo.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  // Case 2: no pending content AND no systemPromptOverride → feature context IS the bootPrompt
+  describe('case 2 — no pending content, no systemPromptOverride', () => {
+    it('uses feature context as bootPrompt', async () => {
+      const result = await resolver.resolve('feat-1', '/wt', undefined, undefined);
+      expect(result.bootPrompt).toBe('built-context');
+    });
+
+    it('context equals the built feature context', async () => {
+      const result = await resolver.resolve('feat-1', '/wt', undefined, undefined);
+      expect(result.context).toBe('built-context');
+    });
+
+    it('calls buildContext with feature and worktreePath', async () => {
+      await resolver.resolve('feat-1', '/wt', undefined, undefined);
+      expect(contextBuilder.buildContext).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'feat-1' }),
+        '/wt',
+        expect.any(Array)
+      );
+    });
+
+    it('passes PR URL when feature has one', async () => {
+      featureRepo = makeFeatureRepo({ url: 'https://github.com/owner/repo/pull/1' });
+      resolver = new BootPromptResolver(featureRepo, contextBuilder);
+      await resolver.resolve('feat-1', '/wt', undefined, undefined);
+      expect(contextBuilder.buildContext).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        ['https://github.com/owner/repo/pull/1']
+      );
+    });
+
+    it('passes empty PR array when feature has no PR', async () => {
+      await resolver.resolve('feat-1', '/wt', undefined, undefined);
+      expect(contextBuilder.buildContext).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        []
+      );
+    });
+
+    it('falls back to id-as-name when feature not found', async () => {
+      (featureRepo.findById as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      await resolver.resolve('feat-unknown', '/wt', undefined, undefined);
+      expect(contextBuilder.buildContext).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'feat-unknown', name: 'feat-unknown' }),
+        '/wt',
+        []
+      );
+    });
+  });
+
+  // Case 3: no pending content AND systemPromptOverride set → silent boot
+  describe('case 3 — no pending content, systemPromptOverride set', () => {
+    it('returns empty bootPrompt (silent boot)', async () => {
+      const result = await resolver.resolve('feat-1', '/wt', undefined, 'my system prompt');
+      expect(result.bootPrompt).toBe('');
+    });
+
+    it('uses systemPromptOverride as context', async () => {
+      const result = await resolver.resolve('feat-1', '/wt', undefined, 'my system prompt');
+      expect(result.context).toBe('my system prompt');
+    });
+
+    it('does not call findById (no feature lookup needed)', async () => {
+      await resolver.resolve('feat-1', '/wt', undefined, 'my system prompt');
+      expect(featureRepo.findById).not.toHaveBeenCalled();
+    });
+
+    it('does not call buildContext', async () => {
+      await resolver.resolve('feat-1', '/wt', undefined, 'my system prompt');
+      expect(contextBuilder.buildContext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/lifecycle/boot-watchdog.test.ts
+++ b/tests/unit/infrastructure/services/interactive/lifecycle/boot-watchdog.test.ts
@@ -1,0 +1,83 @@
+/**
+ * BootWatchdog Unit Tests
+ *
+ * Idle-timer wrapper used during session boot. `start()` arms the timer,
+ * `bump()` resets it on each stream event, `stop()` cancels it. The stall
+ * handler must fire exactly once if the timer elapses without a bump.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { BootWatchdog } from '@/infrastructure/services/interactive/lifecycle/boot-watchdog.js';
+
+describe('BootWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('exposes the 120s idle timeout as a static constant', () => {
+    expect(BootWatchdog.IDLE_TIMEOUT_MS).toBe(120_000);
+  });
+
+  it('fires the stall handler after IDLE_TIMEOUT_MS with no bump', () => {
+    const watchdog = new BootWatchdog();
+    const onStall = vi.fn();
+    watchdog.start(onStall);
+    vi.advanceTimersByTime(BootWatchdog.IDLE_TIMEOUT_MS - 1);
+    expect(onStall).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+
+  it('bump() resets the timer so a steady stream never trips the stall', () => {
+    const watchdog = new BootWatchdog();
+    const onStall = vi.fn();
+    watchdog.start(onStall);
+    for (let i = 0; i < 10; i += 1) {
+      vi.advanceTimersByTime(BootWatchdog.IDLE_TIMEOUT_MS - 10);
+      watchdog.bump();
+    }
+    expect(onStall).not.toHaveBeenCalled();
+  });
+
+  it('stop() cancels the pending timer so the stall never fires', () => {
+    const watchdog = new BootWatchdog();
+    const onStall = vi.fn();
+    watchdog.start(onStall);
+    watchdog.stop();
+    vi.advanceTimersByTime(BootWatchdog.IDLE_TIMEOUT_MS * 2);
+    expect(onStall).not.toHaveBeenCalled();
+  });
+
+  it('stop() is idempotent — calling it twice does not throw', () => {
+    const watchdog = new BootWatchdog();
+    const onStall = vi.fn();
+    watchdog.start(onStall);
+    expect(() => {
+      watchdog.stop();
+      watchdog.stop();
+    }).not.toThrow();
+  });
+
+  it('bump() before start() is a no-op and does not schedule a stall', () => {
+    const watchdog = new BootWatchdog();
+    const onStall = vi.fn();
+    watchdog.bump();
+    vi.advanceTimersByTime(BootWatchdog.IDLE_TIMEOUT_MS * 2);
+    // onStall was never registered so nothing should fire
+    expect(onStall).not.toHaveBeenCalled();
+  });
+
+  it('the stall handler fires exactly once even if the timer is allowed to elapse twice', () => {
+    const watchdog = new BootWatchdog();
+    const onStall = vi.fn();
+    watchdog.start(onStall);
+    vi.advanceTimersByTime(BootWatchdog.IDLE_TIMEOUT_MS);
+    vi.advanceTimersByTime(BootWatchdog.IDLE_TIMEOUT_MS);
+    expect(onStall).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/lifecycle/session-bootstrapper.test.ts
+++ b/tests/unit/infrastructure/services/interactive/lifecycle/session-bootstrapper.test.ts
@@ -1,0 +1,360 @@
+/**
+ * SessionBootstrapper Unit Tests
+ *
+ * Covers the startSession / completeBootAsync lifecycle.
+ *
+ * Key invariants:
+ * - Cap check throws ConcurrentSessionLimitError when at limit
+ * - pendingUserContent is set BEFORE completeBootAsync runs (no race)
+ * - SDK session is created (or resumed) with the resolved context
+ * - Session is transitioned to 'ready' after boot completes
+ * - CWD-mismatch resumption is logged via ILogger.warn
+ * - Boot failures mark the session as 'error'
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { SessionBootstrapper } from '@/infrastructure/services/interactive/lifecycle/session-bootstrapper.js';
+import { SessionRegistry } from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { BootPromptResolver } from '@/infrastructure/services/interactive/lifecycle/boot-prompt.resolver.js';
+import type { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
+import type { IAgentExecutorFactory } from '@/application/ports/output/agents/agent-executor-factory.interface.js';
+import type { AgentConfigResolver } from '@/infrastructure/services/interactive/lifecycle/agent-config.resolver.js';
+import type { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
+import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
+import type {
+  IInteractiveAgentExecutor,
+  InteractiveAgentSessionHandle,
+  InteractiveAgentEvent,
+} from '@/application/ports/output/agents/interactive-agent-executor.interface.js';
+import { InteractiveSessionStatus, AgentType } from '@/domain/generated/output.js';
+import { ConcurrentSessionLimitError } from '@/domain/errors/concurrent-session-limit.error.js';
+
+async function flushPromises(rounds = 15): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
+function makeHandle(
+  events: InteractiveAgentEvent[] = [{ type: 'done', content: 'hello' }],
+  sessionId = 'agent-sid-1'
+): InteractiveAgentSessionHandle {
+  return {
+    get sessionId() {
+      return sessionId;
+    },
+    send: vi.fn().mockResolvedValue(undefined),
+    sendToolResult: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+    stream: () =>
+      (async function* () {
+        for (const ev of events) yield ev;
+      })(),
+  };
+}
+
+function makeSessionRepo(activeCount = 0): IInteractiveSessionRepository {
+  return {
+    create: vi.fn().mockResolvedValue(undefined),
+    findById: vi.fn().mockResolvedValue(null),
+    findByFeatureId: vi.fn().mockResolvedValue(null),
+    findAllActive: vi.fn().mockResolvedValue([]),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+    updateLastActivity: vi.fn().mockResolvedValue(undefined),
+    markAllActiveStopped: vi.fn().mockResolvedValue(undefined),
+    countActiveSessions: vi.fn().mockResolvedValue(activeCount),
+    updateAgentSessionId: vi.fn().mockResolvedValue(undefined),
+    getAgentSessionId: vi.fn().mockResolvedValue(null),
+    findLatestAgentSessionIdForFeature: vi.fn().mockResolvedValue(null),
+    updateTurnStatus: vi.fn().mockResolvedValue(undefined),
+    getTurnStatuses: vi.fn().mockResolvedValue(new Map()),
+    getAllActiveTurnStatuses: vi.fn().mockResolvedValue(new Map()),
+    accumulateUsage: vi.fn().mockResolvedValue(undefined),
+    getUsage: vi.fn().mockResolvedValue(null),
+  } as unknown as IInteractiveSessionRepository;
+}
+
+function makePersistence(): SessionPersistence {
+  return {
+    updateTurnStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    updateSessionStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    persistMessage: vi.fn().mockResolvedValue(undefined),
+    flushAssistantBuffer: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SessionPersistence;
+}
+
+function makeDispatcher(): StreamEventDispatcher {
+  return {
+    notify: vi.fn(),
+    notifyByFeatureId: vi.fn(),
+  } as unknown as StreamEventDispatcher;
+}
+
+function makeBootPromptResolver(
+  result: { context: string; bootPrompt: string } = {
+    context: 'feature context',
+    bootPrompt: 'boot greeting',
+  }
+): BootPromptResolver {
+  return {
+    resolve: vi.fn().mockResolvedValue(result),
+  } as unknown as BootPromptResolver;
+}
+
+function makeStreamConsumer(
+  result: Awaited<ReturnType<AgentStreamConsumer['consume']>> = {
+    completed: 'done',
+    agentSessionIdFromHandle: 'agent-sid-1',
+  }
+): AgentStreamConsumer {
+  return {
+    consume: vi.fn().mockResolvedValue(result),
+  } as unknown as AgentStreamConsumer;
+}
+
+function makeAgentConfigResolver(cap = 3): AgentConfigResolver {
+  return {
+    getCap: vi.fn().mockReturnValue(cap),
+    resolveAgentType: vi.fn().mockReturnValue(AgentType.ClaudeCode),
+    resolveAuthConfig: vi.fn().mockReturnValue({ type: AgentType.ClaudeCode }),
+  } as unknown as AgentConfigResolver;
+}
+
+function makeInteractionCoordinator(): UserInteractionCoordinator {
+  return {
+    buildOnUserQuestionCallback: vi.fn().mockReturnValue(() => Promise.resolve({})),
+    respondToInteraction: vi.fn().mockResolvedValue(undefined),
+  } as unknown as UserInteractionCoordinator;
+}
+
+function makeLogger(): ILogger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeExecutorFactory(handle: InteractiveAgentSessionHandle): IAgentExecutorFactory {
+  const executor: IInteractiveAgentExecutor = {
+    createSession: vi.fn().mockResolvedValue(handle),
+    resumeSession: vi.fn().mockResolvedValue(handle),
+  };
+  return {
+    createInteractiveExecutor: vi.fn().mockReturnValue(executor),
+    createExecutor: vi.fn(),
+    getSupportedAgents: vi.fn().mockReturnValue([AgentType.ClaudeCode]),
+    getCliInfo: vi.fn().mockReturnValue([]),
+    getSupportedModels: vi.fn().mockReturnValue([]),
+    listAvailableModels: vi.fn().mockResolvedValue([]),
+    supportsInteractive: vi.fn().mockReturnValue(true),
+  } as unknown as IAgentExecutorFactory;
+}
+
+describe('SessionBootstrapper', () => {
+  let registry: SessionRegistry;
+  let sessionRepo: IInteractiveSessionRepository;
+  let persistence: SessionPersistence;
+  let dispatcher: StreamEventDispatcher;
+  let bootPromptResolver: BootPromptResolver;
+  let streamConsumer: AgentStreamConsumer;
+  let executorFactory: IAgentExecutorFactory;
+  let agentConfigResolver: AgentConfigResolver;
+  let interactionCoordinator: UserInteractionCoordinator;
+  let logger: ILogger;
+  let bootstrapper: SessionBootstrapper;
+  let handle: InteractiveAgentSessionHandle;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    registry = new SessionRegistry();
+    sessionRepo = makeSessionRepo();
+    persistence = makePersistence();
+    dispatcher = makeDispatcher();
+    bootPromptResolver = makeBootPromptResolver();
+    streamConsumer = makeStreamConsumer();
+    handle = makeHandle();
+    executorFactory = makeExecutorFactory(handle);
+    agentConfigResolver = makeAgentConfigResolver();
+    interactionCoordinator = makeInteractionCoordinator();
+    logger = makeLogger();
+
+    bootstrapper = new SessionBootstrapper(
+      sessionRepo,
+      registry,
+      persistence,
+      dispatcher,
+      bootPromptResolver,
+      streamConsumer,
+      executorFactory,
+      agentConfigResolver,
+      interactionCoordinator,
+      logger
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('startSession', () => {
+    it('throws ConcurrentSessionLimitError when at cap', async () => {
+      sessionRepo = makeSessionRepo(3);
+      bootstrapper = new SessionBootstrapper(
+        sessionRepo,
+        registry,
+        persistence,
+        dispatcher,
+        bootPromptResolver,
+        streamConsumer,
+        executorFactory,
+        agentConfigResolver,
+        interactionCoordinator,
+        logger
+      );
+      await expect(bootstrapper.startSession('feat-1', '/wt')).rejects.toBeInstanceOf(
+        ConcurrentSessionLimitError
+      );
+    });
+
+    it('creates a DB record with booting status', async () => {
+      await bootstrapper.startSession('feat-1', '/wt');
+      expect(sessionRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ status: InteractiveSessionStatus.booting, featureId: 'feat-1' })
+      );
+    });
+
+    it('returns immediately in booting status', async () => {
+      const session = await bootstrapper.startSession('feat-1', '/wt');
+      expect(session.status).toBe(InteractiveSessionStatus.booting);
+    });
+
+    it('registers state in registry', async () => {
+      const session = await bootstrapper.startSession('feat-1', '/wt');
+      expect(registry.has(session.id)).toBe(true);
+    });
+
+    it('stores initialUserMessage in state.pendingUserContent', async () => {
+      await bootstrapper.startSession('feat-1', '/wt', undefined, undefined, undefined, 'hi agent');
+      // pendingUserContent may already be cleared by the time boot runs in microtask
+      // but the BootPromptResolver should have received it
+      await flushPromises();
+      expect(bootPromptResolver.resolve).toHaveBeenCalledWith(
+        'feat-1',
+        '/wt',
+        'hi agent',
+        undefined
+      );
+    });
+
+    it('notifies booting status to SSE subscribers', async () => {
+      await bootstrapper.startSession('feat-1', '/wt');
+      expect(dispatcher.notifyByFeatureId).toHaveBeenCalledWith(
+        'feat-1',
+        expect.objectContaining({
+          sessionStatus: InteractiveSessionStatus.booting,
+        })
+      );
+    });
+  });
+
+  describe('completeBootAsync', () => {
+    it('calls createSession on the executor when no previous session', async () => {
+      const executor = executorFactory.createInteractiveExecutor as ReturnType<typeof vi.fn>;
+      await bootstrapper.startSession('feat-1', '/wt');
+      await flushPromises();
+
+      const createdExecutor = executor.mock.results[0].value as IInteractiveAgentExecutor;
+      expect(createdExecutor.createSession).toHaveBeenCalled();
+    });
+
+    it('transitions session to ready after boot', async () => {
+      await bootstrapper.startSession('feat-1', '/wt');
+      await flushPromises();
+      expect(persistence.updateSessionStatusAndNotify).toHaveBeenCalledWith(
+        expect.any(String),
+        'feat-1',
+        InteractiveSessionStatus.ready
+      );
+    });
+
+    it('persists the SDK session id to the DB', async () => {
+      await bootstrapper.startSession('feat-1', '/wt');
+      await flushPromises();
+      expect(sessionRepo.updateAgentSessionId).toHaveBeenCalledWith(
+        expect.any(String),
+        'agent-sid-1'
+      );
+    });
+
+    it('logs warn on CWD-mismatch resumption', async () => {
+      // Pre-seed a previous session id
+      registry.cacheStoppedAgentSessionId('feat-1', 'old-sid');
+      streamConsumer = makeStreamConsumer({
+        completed: 'done',
+        agentSessionIdFromHandle: 'new-sid-different',
+      });
+      bootstrapper = new SessionBootstrapper(
+        sessionRepo,
+        registry,
+        persistence,
+        dispatcher,
+        bootPromptResolver,
+        streamConsumer,
+        executorFactory,
+        agentConfigResolver,
+        interactionCoordinator,
+        logger
+      );
+
+      await bootstrapper.startSession('feat-1', '/wt');
+      await flushPromises();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('resume mismatch'));
+    });
+
+    it('marks session as error when boot throws', async () => {
+      (streamConsumer.consume as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('agent failed')
+      );
+
+      await bootstrapper.startSession('feat-1', '/wt');
+      await flushPromises();
+
+      expect(persistence.updateSessionStatusAndNotify).toHaveBeenCalledWith(
+        expect.any(String),
+        'feat-1',
+        InteractiveSessionStatus.error
+      );
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('skips sending boot prompt and goes to ready when bootPrompt is empty (silent boot)', async () => {
+      bootPromptResolver = makeBootPromptResolver({ context: 'ctx', bootPrompt: '' });
+      bootstrapper = new SessionBootstrapper(
+        sessionRepo,
+        registry,
+        persistence,
+        dispatcher,
+        bootPromptResolver,
+        streamConsumer,
+        executorFactory,
+        agentConfigResolver,
+        interactionCoordinator,
+        logger
+      );
+
+      await bootstrapper.startSession('feat-1', '/wt');
+      await flushPromises();
+
+      // stream consume should NOT have been called (no bootPrompt to send)
+      expect(streamConsumer.consume).not.toHaveBeenCalled();
+      expect(persistence.updateSessionStatusAndNotify).toHaveBeenCalledWith(
+        expect.any(String),
+        'feat-1',
+        InteractiveSessionStatus.ready
+      );
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/lifecycle/session-terminator.test.ts
+++ b/tests/unit/infrastructure/services/interactive/lifecycle/session-terminator.test.ts
@@ -1,0 +1,200 @@
+/**
+ * SessionTerminator Unit Tests
+ *
+ * Covers the two stop paths:
+ * - stop(sessionId): stops a session by ID
+ * - stopByFeature(featureId): finds the active session and delegates to stop()
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { SessionTerminator } from '@/infrastructure/services/interactive/lifecycle/session-terminator.js';
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
+import { InteractiveSessionStatus } from '@/domain/generated/output.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+function makePersistence(): SessionPersistence {
+  return {
+    updateSessionStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    updateTurnStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    persistMessage: vi.fn().mockResolvedValue(undefined),
+    flushAssistantBuffer: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SessionPersistence;
+}
+
+function makeDispatcher(): StreamEventDispatcher {
+  return {
+    notify: vi.fn(),
+    notifyByFeatureId: vi.fn(),
+  } as unknown as StreamEventDispatcher;
+}
+
+function makeLogger(): ILogger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('SessionTerminator', () => {
+  let registry: SessionRegistry;
+  let persistence: SessionPersistence;
+  let dispatcher: StreamEventDispatcher;
+  let logger: ILogger;
+  let terminator: SessionTerminator;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    persistence = makePersistence();
+    dispatcher = makeDispatcher();
+    logger = makeLogger();
+    terminator = new SessionTerminator(registry, persistence, dispatcher, logger);
+  });
+
+  // ---------------------------------------------------------------------------
+  // stop
+  // ---------------------------------------------------------------------------
+
+  describe('stop', () => {
+    it('is idempotent when session does not exist', async () => {
+      await expect(terminator.stop('nonexistent')).resolves.toBeUndefined();
+    });
+
+    it('removes the session from the registry', async () => {
+      const state = makeState();
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      expect(registry.has('sess-1')).toBe(false);
+    });
+
+    it('aborts active stream', async () => {
+      const abort = new AbortController();
+      const abortSpy = vi.spyOn(abort, 'abort');
+      const state = makeState({ streamAbort: abort });
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      expect(abortSpy).toHaveBeenCalled();
+    });
+
+    it('clears turnQueue and resets turnInProgress', async () => {
+      const state = makeState({ turnInProgress: true, turnQueue: ['msg1', 'msg2'] });
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      expect(state.turnQueue).toHaveLength(0);
+      expect(state.turnInProgress).toBe(false);
+    });
+
+    it('caches agentSessionId for resumption', async () => {
+      const state = makeState({ agentSessionId: 'agent-sess-abc' });
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      // After stop, the cached session id should be available for the next boot
+      const cached = registry.takeStoppedAgentSessionId('feat-1');
+      expect(cached).toBe('agent-sess-abc');
+    });
+
+    it('calls close on the handle', async () => {
+      const closeMock = vi.fn().mockResolvedValue(undefined);
+      const state = makeState({
+        handle: {
+          close: closeMock,
+          send: vi.fn(),
+          stream: vi.fn(),
+          abort: vi.fn(),
+          sessionId: 's',
+        } as any,
+      });
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      expect(closeMock).toHaveBeenCalled();
+    });
+
+    it('does not throw when handle.close() throws', async () => {
+      const state = makeState({
+        handle: {
+          close: vi.fn().mockRejectedValue(new Error('already closed')),
+          send: vi.fn(),
+          stream: vi.fn(),
+          abort: vi.fn(),
+          sessionId: 's',
+        } as any,
+      });
+      registry.set('sess-1', state);
+      await expect(terminator.stop('sess-1')).resolves.toBeUndefined();
+    });
+
+    it('calls updateSessionStatusAndNotify with stopped', async () => {
+      const state = makeState();
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      expect(persistence.updateSessionStatusAndNotify).toHaveBeenCalledWith(
+        'sess-1',
+        'feat-1',
+        InteractiveSessionStatus.stopped,
+        expect.any(Date)
+      );
+    });
+
+    it('calls updateTurnStatusAndNotify with idle', async () => {
+      const state = makeState();
+      registry.set('sess-1', state);
+      await terminator.stop('sess-1');
+      expect(persistence.updateTurnStatusAndNotify).toHaveBeenCalledWith(
+        'sess-1',
+        'feat-1',
+        'idle'
+      );
+    });
+
+    it('uses logger.debug instead of console.log for diagnostic', async () => {
+      const state = makeState();
+      registry.set('sess-1', state);
+      const consoleSpy = vi.spyOn(console, 'log');
+      await terminator.stop('sess-1');
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // stopByFeature
+  // ---------------------------------------------------------------------------
+
+  describe('stopByFeature', () => {
+    it('is a no-op when no active session for the feature', async () => {
+      await expect(terminator.stopByFeature('feat-1')).resolves.toBeUndefined();
+    });
+
+    it('stops the active session for the feature', async () => {
+      const state = makeState();
+      registry.set('sess-1', state);
+      await terminator.stopByFeature('feat-1');
+      expect(registry.has('sess-1')).toBe(false);
+      expect(persistence.updateSessionStatusAndNotify).toHaveBeenCalledWith(
+        'sess-1',
+        'feat-1',
+        InteractiveSessionStatus.stopped,
+        expect.any(Date)
+      );
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/lifecycle/session-terminator.test.ts
+++ b/tests/unit/infrastructure/services/interactive/lifecycle/session-terminator.test.ts
@@ -16,6 +16,8 @@ import {
 import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 import type { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
 import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
+import type { IInteractiveMessageRepository } from '@/application/ports/output/repositories/interactive-message-repository.interface.js';
+import type { IWorkflowStepRepository } from '@/application/ports/output/repositories/workflow-step-repository.interface.js';
 import { InteractiveSessionStatus } from '@/domain/generated/output.js';
 
 function makeState(overrides: Partial<SessionState> = {}): SessionState {
@@ -55,11 +57,25 @@ function makeLogger(): ILogger {
   return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 }
 
+function makeMessageRepo(): IInteractiveMessageRepository {
+  return {
+    deleteByFeatureId: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IInteractiveMessageRepository;
+}
+
+function makeWorkflowStepRepo(): IWorkflowStepRepository {
+  return {
+    deleteByFeatureId: vi.fn().mockResolvedValue(undefined),
+  } as unknown as IWorkflowStepRepository;
+}
+
 describe('SessionTerminator', () => {
   let registry: SessionRegistry;
   let persistence: SessionPersistence;
   let dispatcher: StreamEventDispatcher;
   let logger: ILogger;
+  let messageRepo: IInteractiveMessageRepository;
+  let workflowStepRepo: IWorkflowStepRepository;
   let terminator: SessionTerminator;
 
   beforeEach(() => {
@@ -67,7 +83,16 @@ describe('SessionTerminator', () => {
     persistence = makePersistence();
     dispatcher = makeDispatcher();
     logger = makeLogger();
-    terminator = new SessionTerminator(registry, persistence, dispatcher, logger);
+    messageRepo = makeMessageRepo();
+    workflowStepRepo = makeWorkflowStepRepo();
+    terminator = new SessionTerminator(
+      registry,
+      persistence,
+      dispatcher,
+      logger,
+      messageRepo,
+      workflowStepRepo
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/infrastructure/services/interactive/runtime/agent-stream.consumer.test.ts
+++ b/tests/unit/infrastructure/services/interactive/runtime/agent-stream.consumer.test.ts
@@ -1,0 +1,390 @@
+/**
+ * AgentStreamConsumer Unit Tests
+ *
+ * Owns the stream event-loop switch shared between boot and turn modes.
+ * This is the most important test file in the interactive-service
+ * refactor: it codifies the ordering invariant (every `persistToolEvent`
+ * call is AWAITED — never fired with `void`) that prevents duplicate
+ * `createdAt` rows from breaking `StepTracker.classifyMessages` on the
+ * frontend. See session-persistence.test.ts "persistToolEvent timestamps
+ * are strictly increasing under a frozen clock" for the companion
+ * regression.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
+import { BootWatchdog } from '@/infrastructure/services/interactive/lifecycle/boot-watchdog.js';
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
+import type {
+  InteractiveAgentEvent,
+  InteractiveAgentSessionHandle,
+} from '@/application/ports/output/agents/interactive-agent-executor.interface.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+function makeHandle(
+  events: InteractiveAgentEvent[],
+  sessionId = 'agent-sid-1'
+): InteractiveAgentSessionHandle {
+  return {
+    sessionId,
+    send: vi.fn().mockResolvedValue(undefined),
+    sendToolResult: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+    stream: () =>
+      (async function* () {
+        for (const ev of events) yield ev;
+      })(),
+  };
+}
+
+function makeLogger(): ILogger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+interface PersistenceCall {
+  kind: 'persistToolEvent' | 'flushAssistantBuffer' | 'updateSessionStatus' | 'updateTurnStatus';
+  args?: unknown[];
+}
+
+function makePersistence(): {
+  persistence: SessionPersistence;
+  calls: PersistenceCall[];
+  persistOrder: string[];
+  persistConcurrencyPeak: { current: number; peak: number };
+} {
+  const calls: PersistenceCall[] = [];
+  const persistOrder: string[] = [];
+  const persistConcurrencyPeak = { current: 0, peak: 0 };
+
+  const persistence = {
+    async persistToolEvent(state: SessionState, label: string, detail?: string): Promise<void> {
+      persistConcurrencyPeak.current += 1;
+      persistConcurrencyPeak.peak = Math.max(
+        persistConcurrencyPeak.peak,
+        persistConcurrencyPeak.current
+      );
+      persistOrder.push(`start:${label}`);
+      calls.push({ kind: 'persistToolEvent', args: [state, label, detail] });
+      // Simulate async I/O so back-to-back calls would overlap if not awaited.
+      await new Promise<void>((r) => setTimeout(r, 0));
+      persistOrder.push(`end:${label}`);
+      persistConcurrencyPeak.current -= 1;
+    },
+    async flushAssistantBuffer(state: SessionState): Promise<void> {
+      calls.push({ kind: 'flushAssistantBuffer', args: [state] });
+      state.currentAssistantBuffer = '';
+    },
+    async updateSessionStatusAndNotify(
+      sessionId: string,
+      featureId: string,
+      status: string
+    ): Promise<void> {
+      calls.push({ kind: 'updateSessionStatus', args: [sessionId, featureId, status] });
+    },
+    async updateTurnStatusAndNotify(
+      sessionId: string,
+      featureId: string,
+      turnStatus: string
+    ): Promise<void> {
+      calls.push({ kind: 'updateTurnStatus', args: [sessionId, featureId, turnStatus] });
+    },
+    // Methods the consumer never touches, stubbed for completeness.
+    persistMessage: vi.fn(),
+  } as unknown as SessionPersistence;
+
+  return { persistence, calls, persistOrder, persistConcurrencyPeak };
+}
+
+describe('AgentStreamConsumer', () => {
+  let registry: SessionRegistry;
+  let dispatcher: StreamEventDispatcher;
+  let dispatcherNotifySpy: ReturnType<typeof vi.spyOn>;
+  let logger: ILogger;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    dispatcher = new StreamEventDispatcher(registry);
+    dispatcherNotifySpy = vi.spyOn(dispatcher, 'notify');
+    logger = makeLogger();
+  });
+
+  describe('ordering invariant (await persistToolEvent)', () => {
+    it('awaits every persistToolEvent so back-to-back tool_use + tool_result never overlap', async () => {
+      const { persistence, persistOrder, persistConcurrencyPeak } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        { type: 'tool_use', label: 'Write', detail: 'file.ts' },
+        { type: 'tool_result', label: 'Write', detail: 'ok' },
+        { type: 'done' },
+      ]);
+
+      await consumer.consume(handle, state, 'turn', new AbortController());
+
+      // Peak concurrency MUST be 1 — if `void` was used instead of
+      // `await`, two calls would overlap and the peak would be 2.
+      expect(persistConcurrencyPeak.peak).toBe(1);
+      // Ordering: start/end bracket each call strictly.
+      expect(persistOrder).toEqual(['start:Write', 'end:Write', 'start:Write', 'end:Write']);
+    });
+  });
+
+  describe('boot mode', () => {
+    it('returns completed=done on clean boot with a delta + done', async () => {
+      const { persistence, calls } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle(
+        [{ type: 'delta', content: 'hello' }, { type: 'done' }],
+        'agent-boot-sid'
+      );
+      const watchdog = new BootWatchdog();
+      const bumpSpy = vi.spyOn(watchdog, 'bump');
+
+      const result = await consumer.consume(handle, state, 'boot', new AbortController(), watchdog);
+
+      expect(result.completed).toBe('done');
+      expect(result.agentSessionIdFromHandle).toBe('agent-boot-sid');
+      // watchdog.bump() fired on every event (delta + done = 2 events)
+      expect(bumpSpy).toHaveBeenCalledTimes(2);
+      // delta accumulated into the buffer
+      expect(state.currentAssistantBuffer).toBe('');
+      // flushAssistantBuffer was called on done
+      expect(calls.some((c) => c.kind === 'flushAssistantBuffer')).toBe(true);
+    });
+
+    it('throws on error event during boot', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([{ type: 'error', content: 'boom' }]);
+
+      await expect(
+        consumer.consume(handle, state, 'boot', new AbortController(), new BootWatchdog())
+      ).rejects.toThrow(/Agent error during boot/);
+    });
+
+    it('does not accumulate usage on done in boot mode', async () => {
+      const { persistence, calls } = makePersistence();
+      // Consumer must not touch sessionRepo in boot mode (it doesn't even get one).
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        { type: 'done', usage: { costUsd: 0.1, inputTokens: 100, outputTokens: 50, numTurns: 1 } },
+      ]);
+
+      const result = await consumer.consume(
+        handle,
+        state,
+        'boot',
+        new AbortController(),
+        new BootWatchdog()
+      );
+      expect(result.completed).toBe('done');
+      expect(result.usage).toBeUndefined();
+      // Only flushAssistantBuffer; no accumulateUsage call.
+      expect(calls.filter((c) => c.kind === 'persistToolEvent')).toHaveLength(0);
+    });
+  });
+
+  describe('turn mode', () => {
+    it('returns usage on done in turn mode', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        { type: 'delta', content: 'partial ' },
+        { type: 'tool_use', label: 'Read', detail: 'file.ts' },
+        { type: 'tool_result', label: 'Read', detail: 'ok' },
+        { type: 'delta', content: 'done.' },
+        {
+          type: 'done',
+          usage: { costUsd: 0.25, inputTokens: 200, outputTokens: 100, numTurns: 2 },
+        },
+      ]);
+
+      const result = await consumer.consume(handle, state, 'turn', new AbortController());
+      expect(result.completed).toBe('done');
+      expect(result.usage).toEqual({
+        costUsd: 0.25,
+        inputTokens: 200,
+        outputTokens: 100,
+        numTurns: 2,
+      });
+    });
+
+    it('logs via ILogger.error and continues on error event in turn mode', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        { type: 'error', content: 'transient' },
+        { type: 'done', usage: { costUsd: 0, inputTokens: 1, outputTokens: 1, numTurns: 1 } },
+      ]);
+
+      const result = await consumer.consume(handle, state, 'turn', new AbortController());
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('agent error during turn'),
+        expect.objectContaining({ sessionId: 'sess-1' })
+      );
+      expect(result.completed).toBe('done');
+      // error event must notify with log: 'Error: ...'
+      const errLog = dispatcherNotifySpy.mock.calls.find(
+        ([_state, chunk]: [unknown, { log?: string }]) => chunk.log?.startsWith('Error:')
+      );
+      expect(errLog).toBeDefined();
+    });
+
+    it('captures usage from error event even when no subsequent done fires', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        {
+          type: 'error',
+          content: 'boom',
+          usage: { costUsd: 0.1, inputTokens: 5, outputTokens: 5, numTurns: 1 },
+        },
+      ]);
+
+      const result = await consumer.consume(handle, state, 'turn', new AbortController());
+      expect(result.completed).toBe('ended-without-done');
+      expect(result.usage).toEqual({
+        costUsd: 0.1,
+        inputTokens: 5,
+        outputTokens: 5,
+        numTurns: 1,
+      });
+    });
+
+    it('ignores init events in turn mode (no "Session started" spam)', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([{ type: 'init', content: 'Session started' }, { type: 'done' }]);
+
+      await consumer.consume(handle, state, 'turn', new AbortController());
+      // init must NOT produce a dispatcher.notify with a log message
+      const initLog = dispatcherNotifySpy.mock.calls.find(
+        ([_state, chunk]: [unknown, { log?: string }]) => chunk.log === 'Session started'
+      );
+      expect(initLog).toBeUndefined();
+    });
+
+    it('persists task_started and task_done events', async () => {
+      const { persistence, calls } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        { type: 'task_started', content: 'subtask A' },
+        { type: 'task_done', content: 'subtask A', detail: 'completed' },
+        { type: 'done' },
+      ]);
+
+      await consumer.consume(handle, state, 'turn', new AbortController());
+      const toolCalls = calls.filter((c) => c.kind === 'persistToolEvent');
+      // task_started + task_done = 2 persist calls
+      expect(toolCalls).toHaveLength(2);
+      expect((toolCalls[0].args as unknown[])[1]).toBe('Subtask started');
+      expect((toolCalls[1].args as unknown[])[1]).toBe('Subtask completed');
+    });
+
+    it('dispatches api_retry and rate_limit events as log messages', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([
+        { type: 'api_retry', content: 'retrying' },
+        { type: 'rate_limit', content: 'slow down' },
+        { type: 'done' },
+      ]);
+
+      await consumer.consume(handle, state, 'turn', new AbortController());
+      const logs = dispatcherNotifySpy.mock.calls.map(
+        ([_state, chunk]: [unknown, { log?: string }]) => chunk.log
+      );
+      expect(logs).toContain('retrying');
+      expect(logs).toContain('slow down');
+    });
+
+    it('notifies status events with the status content as a log', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([{ type: 'status', content: 'compacting' }, { type: 'done' }]);
+
+      await consumer.consume(handle, state, 'turn', new AbortController());
+      const logs = dispatcherNotifySpy.mock.calls.map(
+        ([_state, chunk]: [unknown, { log?: string }]) => chunk.log
+      );
+      expect(logs).toContain('compacting');
+    });
+  });
+
+  describe('abort + fallbacks', () => {
+    it('breaks out of the loop cleanly when the abort signal trips mid-stream', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const controller = new AbortController();
+      // A stream that yields forever until someone aborts.
+      const handle: InteractiveAgentSessionHandle = {
+        sessionId: 'sid',
+        send: vi.fn().mockResolvedValue(undefined),
+        sendToolResult: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        abort: vi.fn(),
+        stream: () =>
+          (async function* () {
+            yield { type: 'delta', content: 'a' };
+            controller.abort();
+            yield { type: 'delta', content: 'b' };
+            yield { type: 'done' };
+          })(),
+      };
+
+      const result = await consumer.consume(handle, state, 'turn', controller);
+      // After abort, loop breaks — no done was observed.
+      expect(result.completed).toBe('ended-without-done');
+    });
+
+    it('returns ended-without-done when the stream ends naturally without a done event', async () => {
+      const { persistence } = makePersistence();
+      const consumer = new AgentStreamConsumer(persistence, dispatcher, logger);
+      const state = makeState();
+      const handle = makeHandle([{ type: 'delta', content: 'orphaned' }]);
+
+      const result = await consumer.consume(handle, state, 'turn', new AbortController());
+      expect(result.completed).toBe('ended-without-done');
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/runtime/turn.executor.test.ts
+++ b/tests/unit/infrastructure/services/interactive/runtime/turn.executor.test.ts
@@ -1,0 +1,258 @@
+/**
+ * TurnExecutor Unit Tests
+ *
+ * Covers the enqueueTurn → executeTurn → queue-drain pipeline.
+ *
+ * Key invariants:
+ * - Only one turn executes at a time per session (SDK not concurrent-safe)
+ * - Extra turns are queued and drained in order after the current turn completes
+ * - Usage is accumulated when the stream emits it
+ * - Turn status is set to 'unread' on completion
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TurnExecutor } from '@/infrastructure/services/interactive/runtime/turn.executor.js';
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
+import { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { AgentStreamConsumer } from '@/infrastructure/services/interactive/runtime/agent-stream.consumer.js';
+import type { IInteractiveSessionRepository } from '@/application/ports/output/repositories/interactive-session-repository.interface.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
+import type {
+  InteractiveAgentSessionHandle,
+  InteractiveAgentEvent,
+} from '@/application/ports/output/agents/interactive-agent-executor.interface.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+function makeHandle(events: InteractiveAgentEvent[] = []): InteractiveAgentSessionHandle {
+  return {
+    sessionId: 'agent-sid-1',
+    send: vi.fn().mockResolvedValue(undefined),
+    sendToolResult: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    abort: vi.fn(),
+    stream: () =>
+      (async function* () {
+        for (const ev of events) yield ev;
+      })(),
+  };
+}
+
+function makePersistence(): SessionPersistence {
+  return {
+    updateTurnStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    persistMessage: vi.fn().mockResolvedValue(undefined),
+    flushAssistantBuffer: vi.fn().mockResolvedValue(undefined),
+    updateSessionStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    persistToolEvent: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SessionPersistence;
+}
+
+function makeSessionRepo(): IInteractiveSessionRepository {
+  return {
+    accumulateUsage: vi.fn().mockResolvedValue(undefined),
+    updateLastActivity: vi.fn().mockResolvedValue(undefined),
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByFeatureId: vi.fn(),
+    findAllActive: vi.fn(),
+    updateStatus: vi.fn(),
+    markAllActiveStopped: vi.fn(),
+    countActiveSessions: vi.fn(),
+    updateAgentSessionId: vi.fn(),
+    getAgentSessionId: vi.fn(),
+    findLatestAgentSessionIdForFeature: vi.fn(),
+    updateTurnStatus: vi.fn(),
+    getTurnStatuses: vi.fn(),
+    getAllActiveTurnStatuses: vi.fn(),
+    getUsage: vi.fn(),
+  } as unknown as IInteractiveSessionRepository;
+}
+
+function makeStreamConsumer(
+  result: Awaited<ReturnType<AgentStreamConsumer['consume']>> = { completed: 'done' }
+): AgentStreamConsumer {
+  return {
+    consume: vi.fn().mockResolvedValue(result),
+  } as unknown as AgentStreamConsumer;
+}
+
+function makeLogger(): ILogger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('TurnExecutor', () => {
+  let registry: SessionRegistry;
+  let sessionRepo: IInteractiveSessionRepository;
+  let persistence: SessionPersistence;
+  let streamConsumer: AgentStreamConsumer;
+  let logger: ILogger;
+  let dispatcher: StreamEventDispatcher;
+  let executor: TurnExecutor;
+
+  beforeEach(() => {
+    registry = new SessionRegistry();
+    sessionRepo = makeSessionRepo();
+    persistence = makePersistence();
+    streamConsumer = makeStreamConsumer();
+    logger = makeLogger();
+    dispatcher = new StreamEventDispatcher(registry);
+    executor = new TurnExecutor(
+      sessionRepo,
+      registry,
+      persistence,
+      streamConsumer,
+      logger,
+      dispatcher
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // enqueueTurn
+  // ---------------------------------------------------------------------------
+
+  describe('enqueueTurn', () => {
+    it('queues the turn when one is already in progress', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle, turnInProgress: true });
+      registry.set('sess-1', state);
+
+      await executor.enqueueTurn(state, 'second message');
+      expect(state.turnQueue).toContain('second message');
+      expect(streamConsumer.consume).not.toHaveBeenCalled();
+    });
+
+    it('executes the turn immediately when no turn is in progress', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+
+      await executor.enqueueTurn(state, 'first message');
+      expect(streamConsumer.consume).toHaveBeenCalled();
+    });
+
+    it('sets turnInProgress before calling consume', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+
+      let wasInProgressDuringConsume = false;
+      (streamConsumer.consume as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        wasInProgressDuringConsume = state.turnInProgress;
+        return { completed: 'done' };
+      });
+
+      await executor.enqueueTurn(state, 'msg');
+      expect(wasInProgressDuringConsume).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // executeTurn (private — tested via enqueueTurn)
+  // ---------------------------------------------------------------------------
+
+  describe('turn execution', () => {
+    it('calls updateTurnStatusAndNotify with unread on completion', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+
+      await executor.enqueueTurn(state, 'hello');
+      expect(persistence.updateTurnStatusAndNotify).toHaveBeenCalledWith(
+        'sess-1',
+        'feat-1',
+        'unread'
+      );
+    });
+
+    it('accumulates usage when stream returns it', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+
+      (streamConsumer.consume as ReturnType<typeof vi.fn>).mockResolvedValue({
+        completed: 'done',
+        usage: { costUsd: 0.01, inputTokens: 100, outputTokens: 50, numTurns: 1 },
+      });
+
+      await executor.enqueueTurn(state, 'hello');
+      expect(sessionRepo.accumulateUsage).toHaveBeenCalledWith('sess-1', {
+        costUsd: 0.01,
+        inputTokens: 100,
+        outputTokens: 50,
+        turns: 1,
+      });
+    });
+
+    it('does not call accumulateUsage when no usage in result', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+
+      await executor.enqueueTurn(state, 'hello');
+      expect(sessionRepo.accumulateUsage).not.toHaveBeenCalled();
+    });
+
+    it('notifies done after turn completes via dispatcher', async () => {
+      const sub = vi.fn();
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+      // Subscribe via dispatcher (the real path)
+      dispatcher.subscribeSession('sess-1', sub);
+
+      await executor.enqueueTurn(state, 'hello');
+      expect(sub).toHaveBeenCalledWith(expect.objectContaining({ delta: '', done: true }));
+    });
+
+    it('releases the turn lock after execution', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle });
+      registry.set('sess-1', state);
+
+      await executor.enqueueTurn(state, 'hello');
+      expect(state.turnInProgress).toBe(false);
+    });
+
+    it('drains the queue and executes the next turn', async () => {
+      const handle = makeHandle();
+      const state = makeState({ handle, turnInProgress: true, turnQueue: ['queued-msg'] });
+      registry.set('sess-1', state);
+
+      // Reset so we can start the first turn normally
+      state.turnInProgress = false;
+      await executor.enqueueTurn(state, 'first-msg');
+
+      // consume should have been called at least twice (first + queued)
+      expect(streamConsumer.consume).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws when no handle is set', async () => {
+      const state = makeState({ handle: null });
+      registry.set('sess-1', state);
+
+      // Should not throw at the outer level — errors are caught internally
+      await expect(executor.enqueueTurn(state, 'hello')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/infrastructure/services/interactive/runtime/user-interaction.coordinator.test.ts
+++ b/tests/unit/infrastructure/services/interactive/runtime/user-interaction.coordinator.test.ts
@@ -12,7 +12,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
 import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
 import type { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
-import type { SessionState } from '@/infrastructure/services/interactive/core/session-registry.js';
+import {
+  SessionRegistry,
+  type SessionState,
+} from '@/infrastructure/services/interactive/core/session-registry.js';
 import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
 import type { UserInteractionData } from '@/application/ports/output/agents/interactive-agent-executor.interface.js';
 
@@ -73,6 +76,7 @@ describe('UserInteractionCoordinator', () => {
   let persistence: SessionPersistence;
   let dispatcher: StreamEventDispatcher;
   let logger: ILogger;
+  let registry: SessionRegistry;
   let coordinator: UserInteractionCoordinator;
 
   beforeEach(() => {
@@ -80,7 +84,8 @@ describe('UserInteractionCoordinator', () => {
     ({ persistence } = makePersistence());
     dispatcher = makeDispatcher();
     logger = makeLogger();
-    coordinator = new UserInteractionCoordinator(persistence, dispatcher, logger);
+    registry = new SessionRegistry();
+    coordinator = new UserInteractionCoordinator(persistence, dispatcher, logger, registry);
   });
 
   afterEach(() => {

--- a/tests/unit/infrastructure/services/interactive/runtime/user-interaction.coordinator.test.ts
+++ b/tests/unit/infrastructure/services/interactive/runtime/user-interaction.coordinator.test.ts
@@ -1,0 +1,277 @@
+/**
+ * UserInteractionCoordinator Unit Tests
+ *
+ * Covers the AskUserQuestion interaction lifecycle — the "amber dot" feature.
+ *
+ * buildOnUserQuestionCallback: pauses the SDK stream and waits for user input.
+ * respondToInteraction:        persists user answers and resumes the agent stream.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { UserInteractionCoordinator } from '@/infrastructure/services/interactive/runtime/user-interaction.coordinator.js';
+import type { SessionPersistence } from '@/infrastructure/services/interactive/core/session-persistence.js';
+import type { StreamEventDispatcher } from '@/infrastructure/services/interactive/core/stream-event-dispatcher.js';
+import type { SessionState } from '@/infrastructure/services/interactive/core/session-registry.js';
+import type { ILogger } from '@/application/ports/output/services/logger.interface.js';
+import type { UserInteractionData } from '@/application/ports/output/agents/interactive-agent-executor.interface.js';
+
+function makeState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    sessionId: 'sess-1',
+    featureId: 'feat-1',
+    worktreePath: '/repo/wt',
+    handle: null,
+    currentAssistantBuffer: '',
+    toolEventsLog: [],
+    subscribers: new Set(),
+    turnInProgress: false,
+    turnQueue: [],
+    pendingInteraction: null,
+    pendingInteractionResolver: null,
+    ...overrides,
+  };
+}
+
+function makePersistence(): { persistence: SessionPersistence; flushCalled: number[] } {
+  const flushCalled: number[] = [];
+  const persistence = {
+    flushAssistantBuffer: vi.fn().mockImplementation(async () => {
+      flushCalled.push(Date.now());
+    }),
+    updateTurnStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+    persistMessage: vi.fn().mockResolvedValue(undefined),
+    persistToolEvent: vi.fn().mockResolvedValue(undefined),
+    updateSessionStatusAndNotify: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SessionPersistence;
+  return { persistence, flushCalled };
+}
+
+function makeDispatcher(): StreamEventDispatcher {
+  return {
+    notify: vi.fn(),
+    notifyByFeatureId: vi.fn(),
+    subscribeSession: vi.fn(),
+    subscribeByFeature: vi.fn(),
+    subscribeAll: vi.fn(),
+  } as unknown as StreamEventDispatcher;
+}
+
+function makeLogger(): ILogger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeInteraction(overrides: Partial<UserInteractionData> = {}): UserInteractionData {
+  return {
+    toolCallId: 'tc-1',
+    questions: [{ header: 'Q1', question: 'What is your name?', options: [], multiSelect: false }],
+    ...overrides,
+  };
+}
+
+describe('UserInteractionCoordinator', () => {
+  let persistence: SessionPersistence;
+  let dispatcher: StreamEventDispatcher;
+  let logger: ILogger;
+  let coordinator: UserInteractionCoordinator;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ({ persistence } = makePersistence());
+    dispatcher = makeDispatcher();
+    logger = makeLogger();
+    coordinator = new UserInteractionCoordinator(persistence, dispatcher, logger);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // buildOnUserQuestionCallback
+  // ---------------------------------------------------------------------------
+
+  describe('buildOnUserQuestionCallback', () => {
+    it('returns a function', () => {
+      const state = makeState();
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+      expect(typeof cb).toBe('function');
+    });
+
+    it('flushes the assistant buffer when it has content', async () => {
+      const state = makeState({ currentAssistantBuffer: 'Hello! ' });
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+
+      // Don't await — just start the callback; it blocks waiting for resolver
+      const promise = cb(makeInteraction());
+
+      // Let async ops before setTimeout run
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(persistence.flushAssistantBuffer).toHaveBeenCalledWith(state);
+
+      // Advance the 100ms delay then let the rest of the callback run
+      vi.advanceTimersByTime(100);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Resolve via pendingInteractionResolver to unblock the promise
+      state.pendingInteractionResolver?.({ Q1: 'Alice' });
+      await promise;
+    });
+
+    it('skips flush when buffer is empty/whitespace', async () => {
+      const state = makeState({ currentAssistantBuffer: '   ' });
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+
+      const promise = cb(makeInteraction());
+      await Promise.resolve();
+      expect(persistence.flushAssistantBuffer).not.toHaveBeenCalled();
+
+      state.pendingInteractionResolver?.({ Q1: 'Alice' });
+      await promise;
+    });
+
+    it('stores the interaction in state.pendingInteraction', async () => {
+      const state = makeState();
+      const interaction = makeInteraction();
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+
+      const promise = cb(interaction);
+      await Promise.resolve();
+      expect(state.pendingInteraction).toBe(interaction);
+
+      state.pendingInteractionResolver?.({ Q1: 'Alice' });
+      await promise;
+    });
+
+    it('calls updateTurnStatusAndNotify with awaiting_input', async () => {
+      const state = makeState();
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+
+      const promise = cb(makeInteraction());
+      await Promise.resolve();
+      expect(persistence.updateTurnStatusAndNotify).toHaveBeenCalledWith(
+        'sess-1',
+        'feat-1',
+        'awaiting_input'
+      );
+
+      state.pendingInteractionResolver?.({ Q1: 'Alice' });
+      await promise;
+    });
+
+    it('returns the answers when resolver is called', async () => {
+      const state = makeState();
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+
+      const promise = cb(makeInteraction());
+      await Promise.resolve();
+
+      state.pendingInteractionResolver?.({ Q1: 'Alice', Q2: 'Blue' });
+      const result = await promise;
+      expect(result).toEqual({ Q1: 'Alice', Q2: 'Blue' });
+    });
+
+    it('notifies subscribers with interaction payload', async () => {
+      const state = makeState();
+      const sub = vi.fn();
+      state.subscribers.add(sub);
+      const interaction = makeInteraction();
+      const cb = coordinator.buildOnUserQuestionCallback(state);
+
+      const promise = cb(interaction);
+      await Promise.resolve();
+      expect(sub).toHaveBeenCalledWith(
+        expect.objectContaining({ interaction, log: 'Waiting for your response...' })
+      );
+
+      state.pendingInteractionResolver?.({});
+      await promise;
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // respondToInteraction
+  // ---------------------------------------------------------------------------
+
+  describe('respondToInteraction', () => {
+    it('throws when no pending interaction', async () => {
+      const state = makeState({ pendingInteraction: null, pendingInteractionResolver: null });
+      await expect(coordinator.respondToInteraction(state, {})).rejects.toThrow();
+    });
+
+    it('persists the answers as a structured user message', async () => {
+      const interaction = makeInteraction();
+      const resolver = vi.fn();
+      const state = makeState({
+        pendingInteraction: interaction,
+        pendingInteractionResolver: resolver,
+      });
+
+      await coordinator.respondToInteraction(state, { Q1: 'Alice' });
+
+      expect(persistence.persistMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining('{{interaction}}'),
+          featureId: 'feat-1',
+          sessionId: 'sess-1',
+        })
+      );
+    });
+
+    it('calls the pendingInteractionResolver with the answers', async () => {
+      const interaction = makeInteraction();
+      const resolver = vi.fn();
+      const state = makeState({
+        pendingInteraction: interaction,
+        pendingInteractionResolver: resolver,
+      });
+
+      await coordinator.respondToInteraction(state, { Q1: 'Alice' });
+      expect(resolver).toHaveBeenCalledWith({ Q1: 'Alice' });
+    });
+
+    it('clears pendingInteraction and pendingInteractionResolver', async () => {
+      const interaction = makeInteraction();
+      const resolver = vi.fn();
+      const state = makeState({
+        pendingInteraction: interaction,
+        pendingInteractionResolver: resolver,
+      });
+
+      await coordinator.respondToInteraction(state, {});
+      expect(state.pendingInteraction).toBeNull();
+      expect(state.pendingInteractionResolver).toBeNull();
+    });
+
+    it('calls updateTurnStatusAndNotify with processing', async () => {
+      const resolver = vi.fn();
+      const state = makeState({
+        pendingInteraction: makeInteraction(),
+        pendingInteractionResolver: resolver,
+      });
+
+      await coordinator.respondToInteraction(state, {});
+      expect(persistence.updateTurnStatusAndNotify).toHaveBeenCalledWith(
+        'sess-1',
+        'feat-1',
+        'processing'
+      );
+    });
+
+    it('notifies subscribers to clear the waiting message', async () => {
+      const sub = vi.fn();
+      const resolver = vi.fn();
+      const state = makeState({
+        pendingInteraction: makeInteraction(),
+        pendingInteractionResolver: resolver,
+      });
+      state.subscribers.add(sub);
+
+      await coordinator.respondToInteraction(state, {});
+      expect(sub).toHaveBeenCalledWith(expect.objectContaining({ delta: '', done: false }));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Strangler refactor of the 1576-line `interactive-session.service.ts` monolith into a thin delegation facade (219 lines) backed by 16 focused collaborators organized into four layered subdirectories: `core/`, `lifecycle/`, `runtime/`, `api/`.

**Before → after**
- Monolith: 1576 → **219 lines** (−86%)
- Files: 1 → **17** source files + 1 new `ISettingsProvider` port
- Tests: 52 baseline → **198** (16 mirrored test files)
- 0 `console.*` calls in the service layer (logger injected via `ILogger`)
- 0 `getSettings()` singleton reads (now behind `ISettingsProvider`)
- Layering enforced via ESLint `no-restricted-imports`: `core/ ← lifecycle/ ← runtime/ ← api/`

**Preserved invariants**
- `persistToolEvent` is always **awaited** (never `void`) — the monotonic-clock ordering guarantee that prevents duplicate `createdAt` rows breaking `StepTracker.classifyMessages`. Regression test persists 100 messages under a frozen `vi.setSystemTime()` clock and asserts strictly-increasing timestamps.
- `IInteractiveSessionService` port contract unchanged — all 20+ web routes and CLI paths see the same shape.
- Boot watchdog idle timeout, session-registry bookkeeping, and workflow-hook semantics preserved.

## Phase commits

1. `e270f6a0` extract session registry + stream event dispatcher
2. `1193c738` extract session persistence with monotonic clock
3. `fc842df4` add settings provider port + agent config resolver
4. `5dab64bd` extract agent stream consumer + boot watchdog
5. `f9148b43` extract bootstrapper, terminator, turn executor, user-interaction coordinator
6. `afe262a0` extract message dispatcher, chat state assembler, workflow hooks
7. `dc905071` reshape facade to thin delegation shell + ESLint layer lint

Plan committed in `a0dadf60`: [docs/plans/2026-04-14-interactive-session-service-refactor.md](docs/plans/2026-04-14-interactive-session-service-refactor.md).

## Test plan

- [x] `pnpm validate` (lint + format + typecheck + tsp compile)
- [x] `pnpm test:unit` + `pnpm test:int` — 550 files, 7326 tests passing
- [x] CLI e2e — 14 files, 84 tests passing
- [x] Targeted interactive suite — 16 files, 198 tests passing
- [ ] Web e2e — 2 failures in `tests/e2e/web/chat-tab.spec.ts` (both also fail on `main`; caused by Arabic-locale leak from prior i18n test, unrelated to this refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)