### PR TITLE
fix(web): application card live preview and consistent title

### DIFF
--- a/src/presentation/web/components/features/applications/application-card.tsx
+++ b/src/presentation/web/components/features/applications/application-card.tsx
@@ -216,6 +216,13 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
   const isBooting = deploy.status === DeploymentState.Booting || deploy.deployLoading;
   const isLocalRunning = deploy.status === DeploymentState.Ready && Boolean(effectiveDeploymentUrl);
 
+  // Resolve the URL to show in the header iframe. Prefer the local
+  // dev server when it's running (it reflects uncommitted in-progress
+  // changes), else fall back to the cloud deploy URL so a deployed
+  // app shows its actual live site instead of an abstract placeholder.
+  const previewUrl = isLocalRunning ? effectiveDeploymentUrl : isCloudLive ? cloudUrl : null;
+  const hasLivePreview = Boolean(previewUrl);
+
   const navigate = () => router.push(`/application/${application.id}`);
 
   // Repository display name from path
@@ -237,34 +244,27 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
         )}
       >
         {/* ── Header visual ──────────────────────────────────── */}
-        {/* When local server is running: real iframe. Otherwise: gradient + text overlay. */}
+        {/* Preference order:
+             1. Live iframe preview (local dev server OR cloud deploy URL)
+             2. Booting spinner while a local deploy is coming up
+             3. Abstract dark SVG wireframe (ambient placeholder) */}
         <div className="relative overflow-hidden" style={{ height: 160 }}>
-          {isLocalRunning || isBooting ? (
-            // ── Live preview ──────────────────────────────────
+          {hasLivePreview ? (
             <div className="absolute inset-0 bg-white dark:bg-neutral-900">
-              {isLocalRunning ? (
-                <iframe
-                  src={effectiveDeploymentUrl!}
-                  title={`${application.name} preview`}
-                  className="pointer-events-none absolute top-0 left-0 origin-top-left border-0"
-                  style={{ width: '250%', height: '250%', transform: 'scale(0.4)' }}
-                  sandbox="allow-same-origin allow-scripts"
-                  loading="lazy"
-                />
-              ) : (
-                <div className="flex h-full flex-col items-center justify-center gap-2">
-                  <Loader2 className="h-6 w-6 animate-spin text-amber-500" />
-                  <span className="text-[11px] font-medium text-amber-600 dark:text-amber-400">
-                    Starting…
-                  </span>
-                </div>
-              )}
-              {/* hover overlay */}
-              {isLocalRunning ? (
-                <div
-                  className="absolute inset-0 flex items-center justify-center gap-2 bg-black/60 opacity-0 transition-opacity group-hover:opacity-100"
-                  onClick={(e) => e.stopPropagation()}
-                >
+              <iframe
+                src={previewUrl!}
+                title={`${application.name} preview`}
+                className="pointer-events-none absolute top-0 left-0 origin-top-left border-0"
+                style={{ width: '250%', height: '250%', transform: 'scale(0.4)' }}
+                sandbox="allow-same-origin allow-scripts"
+                loading="lazy"
+              />
+              {/* hover overlay — stop/open for LOCAL running; open-only for cloud */}
+              <div
+                className="absolute inset-0 flex items-center justify-center gap-2 bg-black/60 opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {isLocalRunning ? (
                   <button
                     type="button"
                     onClick={() => void deploy.stop()}
@@ -278,32 +278,32 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
                     )}
                     Stop
                   </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      window.open(effectiveDeploymentUrl!, '_blank', 'noopener,noreferrer')
-                    }
-                    className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-full bg-white/90 px-3 text-[11px] font-semibold text-neutral-900 hover:bg-white"
-                  >
-                    <ExternalLink className="h-3 w-3" />
-                    Open
-                  </button>
-                </div>
-              ) : null}
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => window.open(previewUrl!, '_blank', 'noopener,noreferrer')}
+                  className="inline-flex h-7 cursor-pointer items-center gap-1 rounded-full bg-white/90 px-3 text-[11px] font-semibold text-neutral-900 hover:bg-white"
+                >
+                  <ExternalLink className="h-3 w-3" />
+                  Open
+                </button>
+              </div>
+            </div>
+          ) : isBooting ? (
+            <div className="absolute inset-0 bg-white dark:bg-neutral-900">
+              <div className="flex h-full flex-col items-center justify-center gap-2">
+                <Loader2 className="h-6 w-6 animate-spin text-amber-500" />
+                <span className="text-[11px] font-medium text-amber-600 dark:text-amber-400">
+                  Starting…
+                </span>
+              </div>
             </div>
           ) : (
-            // ── Abstract dark preview header ──────────────────
+            // Ambient placeholder — no title overlay; name/description
+            // always render in the body below so they stay consistent
+            // across every card state.
             <div className="absolute inset-0 overflow-hidden bg-[#111827]">
               <MockPreview name={application.name} />
-              {/* bottom scrim blends into card body + holds name/desc */}
-              <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-[#111827] via-[#111827]/70 to-transparent px-3.5 pt-12 pb-3">
-                <h3 className="line-clamp-1 text-[14px] leading-tight font-semibold text-white">
-                  {application.name}
-                </h3>
-                <p className="mt-0.5 line-clamp-1 text-[11px] leading-relaxed text-white/55">
-                  {application.description}
-                </p>
-              </div>
             </div>
           )}
 
@@ -366,27 +366,20 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
         </div>
 
         {/* ── Context zone ───────────────────────────────────── */}
-        {/* State-specific informational content so every card feels
-            relevant rather than generic. */}
-        <div className="flex flex-1 flex-col gap-1.5 px-3 pt-2.5 pb-0">
-          {/* Name + description always visible below the header.
-              When the gradient header is showing, the name/desc are
-              rendered in white on the gradient — we still show a
-              shorter subtitle here so the info section has content.
-              When the iframe is showing, we show the full name + desc. */}
-          {/* Name + description only when the header can't show them
-              (iframe live/booting mode). The dark SVG header overlay
-              already renders name + desc for all other states. */}
-          {isLocalRunning || isBooting ? (
-            <div>
-              <h3 className="text-foreground line-clamp-1 text-[14px] leading-tight font-bold">
-                {application.name}
-              </h3>
-              <p className="text-muted-foreground line-clamp-2 text-[11px] leading-relaxed">
+        {/* Name + description always rendered in the body so they stay
+            consistent regardless of what the header is showing (live
+            iframe, booting spinner, or ambient SVG placeholder). */}
+        <div className="flex flex-1 flex-col gap-1.5 px-3.5 pt-3 pb-0">
+          <div>
+            <h3 className="text-foreground line-clamp-1 text-[14px] leading-tight font-semibold">
+              {application.name}
+            </h3>
+            {application.description ? (
+              <p className="text-muted-foreground mt-0.5 line-clamp-1 text-[11px] leading-relaxed">
                 {application.description}
               </p>
-            </div>
-          ) : null}
+            ) : null}
+          </div>
 
           {/* State-specific context — the live URL now lives in the
               footer so we skip rendering it here to avoid duplication. */}
@@ -436,7 +429,7 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
 
         {/* ── Footer ─────────────────────────────────────────── */}
         <div
-          className="flex items-center gap-2 px-3 pt-1.5 pb-2.5"
+          className="flex items-center gap-2 px-3.5 pt-2 pb-3"
           onClick={(e) => e.stopPropagation()}
         >
           {/* Left cluster: repo dir + cloud URL — both compact, inline */}


### PR DESCRIPTION
## Problem

Cloud-deployed application cards on `/applications` were rendering broken:

- The ambient SVG wireframe placeholder was showing instead of an actual live preview, even though the card carried a `LIVE` badge from the cloud deployment.
- Title and description were invisible or misplaced — they were rendered only inside a bottom gradient overlay layered on top of the SVG header, and in several states (build interrupted, layout squeeze) the overlay was effectively hidden.
- Spacing drifted between header, body, and footer because the body title was gated on `isLocalRunning || isBooting`, leaving cloud-live cards with a zero-height body zone.

## Fix

Restructured the card header so the preview choice and the text zone are independent.

**1. Preview URL derivation**

```ts
const previewUrl = isLocalRunning
  ? effectiveDeploymentUrl
  : isCloudLive
    ? cloudUrl
    : null;
```

- Prefers the local dev server when running (uncommitted in-progress changes).
- Falls back to `cloudDeploymentUrl` when the app is cloud-deployed.
- `null` when neither is live — we render the ambient placeholder.

**2. Header preference order**

1. **Live iframe preview** (`hasLivePreview`) — renders the scaled iframe for either local or cloud. Hover overlay shows Stop/Open for local, Open-only for cloud (we don't control cloud lifecycle from the card).
2. **Booting spinner** — only when `isBooting` and there's no preview yet.
3. **Ambient SVG wireframe** — pure placeholder. No overlay text, no gradient. Just texture.

**3. Title always in the body zone**

Removed the bottom gradient overlay inside the header entirely. Name + description now always render in the context zone below the header:

```tsx
<div className="flex flex-1 flex-col gap-1.5 px-3.5 pt-3 pb-0">
  <div>
    <h3 …>{application.name}</h3>
    {application.description && <p …>{application.description}</p>}
  </div>
  …
</div>
```

One source of truth, visible in every card state.

**4. Consistent paddings**

Body and footer aligned on `px-3.5` so side gutters match regardless of what the header is showing.

## Local verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 warnings)
- `pnpm build:storybook` ✅
- Dev server started locally and `/applications` returned 200; visual inspection is on you since Playwright is blocked by a system admin policy on this machine — please eyeball before merging.

## Manual test plan

- [ ] Cloud-deployed app: card shows iframe of the cloud URL + LIVE badge, hover reveals Open button, title visible in body.
- [ ] Local dev server running: card shows local iframe, hover reveals Stop + Open, title visible in body.
- [ ] Neither live: card shows ambient SVG wireframe, title still visible in body.
- [ ] Booting: card shows amber spinner, title visible in body.
- [ ] Build interrupted / failed: card shows SVG, status chip + title all visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
