### PR TITLE
fix(web): lift application card surface in dark mode

### DIFF
--- a/src/presentation/web/components/features/applications/application-card.tsx
+++ b/src/presentation/web/components/features/applications/application-card.tsx
@@ -234,9 +234,16 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
         data-testid="application-card"
         onClick={navigate}
         className={cn(
-          'bg-card group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl',
-          'border-border/60 border shadow-sm',
-          'hover:border-border transition-all duration-200 hover:shadow-lg',
+          // In dark mode `--color-card` resolves to `#0a0a0a`, which is the
+          // same value as `--color-background` — so a plain `bg-card` card
+          // has no contrast against the page. Lift the dark-mode surface
+          // one step (`neutral-900` = `#171717`) and soften the border so
+          // the card reads as an elevated tile instead of a hole in the
+          // page. Light mode is unchanged.
+          'group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl',
+          'bg-card dark:bg-neutral-900',
+          'border-border/60 border shadow-sm dark:border-white/10',
+          'hover:border-border transition-all duration-200 hover:shadow-lg dark:hover:border-white/20 dark:hover:shadow-black/40',
           // min-h keeps all cards in a row visually aligned; flex-1 on
           // the context zone pushes the footer to the bottom.
           'min-h-[280px]',
@@ -301,8 +308,12 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
           ) : (
             // Ambient placeholder — no title overlay; name/description
             // always render in the body below so they stay consistent
-            // across every card state.
-            <div className="absolute inset-0 overflow-hidden bg-[#111827]">
+            // across every card state. Stays dark in BOTH modes because
+            // the MockPreview SVG strokes are white-at-low-opacity and
+            // would be invisible on a light background. In dark mode we
+            // lift it to `neutral-800` (one notch above the card body's
+            // `neutral-900`), giving the header a distinct elevation tier.
+            <div className="absolute inset-0 overflow-hidden bg-[#111827] dark:bg-neutral-800">
               <MockPreview name={application.name} />
             </div>
           )}


### PR DESCRIPTION
## Problem

Application cards on `/applications` were invisible in dark mode — the card bled straight into the page background because `--color-card` and `--color-background` both resolve to `#0a0a0a` in the dark theme. Cards read as holes in the page rather than elevated tiles.

```css
/* src/presentation/web/app/globals.css */
:root { --color-background: #ffffff; --color-card: #ffffff; }
.dark { --color-background: #0a0a0a; --color-card: #0a0a0a; }  /* identical */
```

## Fix

Dark-mode-only overrides applied locally on the `ApplicationCard` — **I did not touch the global `--color-card` token**, because that would ripple through every `bg-card` consumer in the app (settings panels, dialogs, popovers, etc.) and silently change their contrast too.

### Card body

| | Before | After |
|---|---|---|
| Background | `bg-card` (=`#0a0a0a`) | `dark:bg-neutral-900` (`#171717`) |
| Border | `border-border/60` | `+ dark:border-white/10` |
| Hover border | `hover:border-border` | `+ dark:hover:border-white/20` |
| Hover shadow | `hover:shadow-lg` | `+ dark:hover:shadow-black/40` |

One step of elevation above the page so the card reads as a distinct surface.

### SVG wireframe header

Goes from `bg-[#111827]` (light mode only, matched the old card body) to `bg-[#111827] dark:bg-neutral-800` (`#262626`).

This sits one tier **above** the card body in dark mode, giving every card a clear two-tier elevation:

```
page           →  #0a0a0a
card body      →  #171717  (dark:bg-neutral-900)
wireframe hdr  →  #262626  (dark:bg-neutral-800)
```

Light mode keeps `#111827` because the `MockPreview` SVG strokes are `rgba(255,255,255,0.04–0.13)` — white at low opacity — and would be invisible on a light background.

## Local verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 warnings)
- `pnpm format:check` ✅

Playwright is still blocked by a system admin policy on this machine so I can't grab a screenshot — please eyeball the cards in dark mode on this branch. Expected:

- Cards visibly lifted above the page, with a faint white/10 border.
- Inside each card, the wireframe header sits one shade lighter than the body (distinct but subtle).
- Hover raises the border and drops a soft black shadow.
- Light mode unchanged.

## Scope

One file, 16 insertions, 5 deletions: `src/presentation/web/components/features/applications/application-card.tsx`.
