### PR TITLE
feat(web): scaffolding progress tracker + dark-mode card surface lift

### DIFF
--- a/src/presentation/web/components/features/application-page/application-page.tsx
+++ b/src/presentation/web/components/features/application-page/application-page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import type { Application } from '@shepai/core/domain/generated/output';
-import { DeploymentState } from '@shepai/core/domain/generated/output';
+import { ApplicationStatus, DeploymentState } from '@shepai/core/domain/generated/output';
 import type { ChatState } from '@shepai/core/application/ports/output/services/interactive-session-service.interface';
 import { featureIdForApplication } from '@shepai/core/domain/shared/feature-id';
 
 import { ChatTab } from '@/components/features/chat/ChatTab';
+import type { ScaffoldingState } from '@/components/features/chat/ChatTab';
 import { APPLICATION_CREATION_PLACEHOLDER_STEPS } from '@/components/features/chat/workflow-placeholder';
 import { useCloudDeployAction } from '@/hooks/use-cloud-deploy-action';
 import { useDeployAction } from '@/hooks/use-deploy-action';
@@ -73,6 +74,35 @@ export function ApplicationPage({ application, initialChatState }: ApplicationPa
     agentRunning,
   });
 
+  // Derive the synthetic scaffolding card state from the Application
+  // entity. Scaffolding (`BunShadcnScaffolder`) runs BEFORE the agent
+  // turn and has no real `workflow_steps` row, so the tracker would
+  // otherwise show all-pending cards during an expensive `bun install`.
+  // The card uses `application.createdAt` as the approximate start —
+  // the Application row is persisted moments before the scaffolder
+  // kicks off, so the duration is a couple of hundred ms high at most.
+  //   - Error state: Application.status flipped to `Error` → failed.
+  //   - Completed: `setupComplete` flipped to `true` → done.
+  //   - Otherwise: still running.
+  // `ChatTab` additionally forces `done` once real workflow rows arrive,
+  // which covers the window between `setupComplete=false` and the
+  // first workflow step SSE chunk.
+  const scaffoldingState: ScaffoldingState = application.setupComplete
+    ? {
+        status: 'done',
+        startedAt: new Date(application.createdAt).getTime(),
+      }
+    : application.status === ApplicationStatus.Error
+      ? {
+          status: 'failed',
+          startedAt: new Date(application.createdAt).getTime(),
+          error: 'Scaffolding failed — check the logs for details.',
+        }
+      : {
+          status: 'running',
+          startedAt: new Date(application.createdAt).getTime(),
+        };
+
   return (
     <div className="bg-background flex h-dvh flex-col">
       <AppTopBar
@@ -94,6 +124,7 @@ export function ApplicationPage({ application, initialChatState }: ApplicationPa
             initialChatState={initialChatState}
             hideHeader
             workflowPlaceholder={APPLICATION_CREATION_PLACEHOLDER_STEPS}
+            scaffoldingState={scaffoldingState}
             onResumeWorkflow={() => {
               void fetch(`/api/applications/${application.id}/resume`, { method: 'POST' });
             }}

--- a/src/presentation/web/components/features/applications/application-card.tsx
+++ b/src/presentation/web/components/features/applications/application-card.tsx
@@ -234,9 +234,16 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
         data-testid="application-card"
         onClick={navigate}
         className={cn(
-          'bg-card group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl',
-          'border-border/60 border shadow-sm',
-          'hover:border-border transition-all duration-200 hover:shadow-lg',
+          // In dark mode `--color-card` resolves to `#0a0a0a`, which is the
+          // same value as `--color-background` — so a plain `bg-card` card
+          // has no contrast against the page. Lift the dark-mode surface
+          // one step (`neutral-900` = `#171717`) and soften the border so
+          // the card reads as an elevated tile instead of a hole in the
+          // page. Light mode is unchanged.
+          'group relative flex cursor-pointer flex-col overflow-hidden rounded-2xl',
+          'bg-card dark:bg-neutral-900',
+          'border-border/60 border shadow-sm dark:border-white/10',
+          'hover:border-border transition-all duration-200 hover:shadow-lg dark:hover:border-white/20 dark:hover:shadow-black/40',
           // min-h keeps all cards in a row visually aligned; flex-1 on
           // the context zone pushes the footer to the bottom.
           'min-h-[280px]',
@@ -301,8 +308,12 @@ export function ApplicationCard({ application, className }: ApplicationCardProps
           ) : (
             // Ambient placeholder — no title overlay; name/description
             // always render in the body below so they stay consistent
-            // across every card state.
-            <div className="absolute inset-0 overflow-hidden bg-[#111827]">
+            // across every card state. Stays dark in BOTH modes because
+            // the MockPreview SVG strokes are white-at-low-opacity and
+            // would be invisible on a light background. In dark mode we
+            // lift it to `neutral-800` (one notch above the card body's
+            // `neutral-900`), giving the header a distinct elevation tier.
+            <div className="absolute inset-0 overflow-hidden bg-[#111827] dark:bg-neutral-800">
               <MockPreview name={application.name} />
             </div>
           )}

--- a/src/presentation/web/components/features/chat/ChatTab.tsx
+++ b/src/presentation/web/components/features/chat/ChatTab.tsx
@@ -15,6 +15,7 @@ import { ChatComposer } from './ChatComposer';
 import { InteractionBubble } from './InteractionBubble';
 import { StepTracker } from './StepTracker';
 import type { PlaceholderStep } from './workflow-placeholder';
+import { SCAFFOLD_STEP_KEY } from './workflow-placeholder';
 import type { EnhancedStepState } from './useChatRuntime';
 
 export interface ChatTabProps {
@@ -57,6 +58,32 @@ export interface ChatTabProps {
   workflowPlaceholder?: PlaceholderStep[];
   /** Called when the user clicks Continue on an interrupted workflow step. */
   onResumeWorkflow?: () => void;
+  /**
+   * When provided, injects a synthetic "Scaffolding" step card at the
+   * top of the tracker so the user sees in-progress feedback during
+   * the `BunShadcnScaffolder` phase (project-tree + `bun install`),
+   * which happens BEFORE the agent turn and therefore has no real
+   * `workflow_steps` row. See `workflow-placeholder.ts` for the
+   * broader context.
+   */
+  scaffoldingState?: ScaffoldingState;
+}
+
+/**
+ * Frontend-synthesised state for the "Scaffolding" card. The card is
+ * purely presentational — the scaffolder does not write a
+ * `workflow_steps` row, so the caller derives this from the
+ * Application entity and passes it in.
+ */
+export interface ScaffoldingState {
+  /** Lifecycle of the scaffold phase. */
+  status: 'running' | 'done' | 'failed';
+  /** Milliseconds since epoch when scaffolding started. */
+  startedAt: number;
+  /** Milliseconds since epoch when scaffolding reached a terminal state. */
+  finishedAt?: number;
+  /** Optional short error message to render inside the card body. */
+  error?: string;
 }
 
 const IS_DEV = process.env.NODE_ENV === 'development';
@@ -94,6 +121,7 @@ export function ChatTab({
   onAllStepsComplete,
   workflowPlaceholder,
   onResumeWorkflow,
+  scaffoldingState,
 }: ChatTabProps) {
   const [overrideAgent, setOverrideAgent] = useState<string | undefined>(initialAgent);
   const [overrideModel, setOverrideModel] = useState<string | undefined>(initialModel);
@@ -193,27 +221,70 @@ export function ChatTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- att.addAttachment is a stable callback from useAttachments
   }, [featureId, att.addAttachment]);
 
-  // Compute the tracker's step list: real workflow rows when the
-  // orchestrator has written them, otherwise synthesised pending
-  // cards from `workflowPlaceholder` so the user sees the full
-  // progress skeleton from the first paint. Real rows replace the
-  // placeholder atomically the moment the first `workflow_step`
-  // SSE chunk lands.
-  const trackerSteps: EnhancedStepState[] = stepProgress.hasPlan
+  // Compute the tracker's step list:
+  //   1. Real workflow rows when the orchestrator has written them,
+  //      otherwise synthesised pending cards from `workflowPlaceholder`
+  //      so the user sees the full progress skeleton from the first
+  //      paint. Real rows replace the placeholder atomically the
+  //      moment the first `workflow_step` SSE chunk lands.
+  //   2. If `scaffoldingState` is provided, ALWAYS prepend a synthetic
+  //      "Scaffolding" card at the top. It is the only card visible
+  //      during the `BunShadcnScaffolder` phase (project-tree +
+  //      `bun install`), which happens BEFORE the agent turn and
+  //      therefore has no real `workflow_steps` row. Once real rows
+  //      arrive, the scaffold card is flipped to `done` and kept at
+  //      index 0 so the full history stays visible.
+  const baseSteps: EnhancedStepState[] = stepProgress.hasPlan
     ? stepProgress.steps
-    : (workflowPlaceholder ?? []).map((p) => ({
+    : (workflowPlaceholder ?? [])
+        .filter((p) => p.stepKey !== SCAFFOLD_STEP_KEY)
+        .map((p) => ({
+          definition: {
+            id: `placeholder-${p.stepKey}`,
+            stepKey: p.stepKey,
+            title: p.title,
+            description: p.description,
+          },
+          status: 'pending' as const,
+          metadata: null,
+          toolMessages: [],
+          startedAt: null,
+          finishedAt: null,
+        }));
+
+  // Capture a stable `finishedAt` for the scaffold card the first
+  // time we observe real workflow rows appear (`hasPlan` flips to
+  // true). Without this, `Date.now()` would be re-sampled every
+  // render and the card's displayed duration would keep jittering.
+  const scaffoldFinishedAtRef = useRef<number | null>(null);
+  if (stepProgress.hasPlan && scaffoldFinishedAtRef.current == null) {
+    scaffoldFinishedAtRef.current = Date.now();
+  }
+
+  const scaffoldCard: EnhancedStepState | null = scaffoldingState
+    ? {
         definition: {
-          id: `placeholder-${p.stepKey}`,
-          stepKey: p.stepKey,
-          title: p.title,
-          description: p.description,
+          id: `placeholder-${SCAFFOLD_STEP_KEY}`,
+          stepKey: SCAFFOLD_STEP_KEY,
+          title: 'Preparing your project',
+          description: 'Scaffolding the project tree and installing dependencies',
         },
-        status: 'pending' as const,
-        metadata: null,
+        // Once real workflow rows exist the scaffolder is guaranteed
+        // to have finished (the orchestrator runs scaffold → workflow
+        // sequentially), so we force `done` regardless of what the
+        // caller passes — this keeps the UI consistent even if a
+        // page refresh races the Application row's setupComplete flag.
+        status: stepProgress.hasPlan ? 'done' : scaffoldingState.status,
+        metadata: scaffoldingState.error ? { error: scaffoldingState.error } : null,
         toolMessages: [],
-        startedAt: null,
-        finishedAt: null,
-      }));
+        startedAt: scaffoldingState.startedAt,
+        finishedAt:
+          scaffoldingState.finishedAt ??
+          (stepProgress.hasPlan ? scaffoldFinishedAtRef.current : null),
+      }
+    : null;
+
+  const trackerSteps: EnhancedStepState[] = scaffoldCard ? [scaffoldCard, ...baseSteps] : baseSteps;
   const showTracker = trackerSteps.length > 0;
   const workflowInFlight = isWorkflowInFlight(stepProgress);
 

--- a/src/presentation/web/components/features/chat/StepTracker.stories.tsx
+++ b/src/presentation/web/components/features/chat/StepTracker.stories.tsx
@@ -127,3 +127,62 @@ export const StuckRunningWithForceStop: Story = {
     onForceStop: (stepId: string) => console.log('force-stop', stepId),
   },
 };
+
+/**
+ * Scaffolding phase — the synthetic first-card state that ChatTab
+ * prepends via the `scaffoldingState` prop while `BunShadcnScaffolder`
+ * installs dependencies. The rest of the tracker still shows the
+ * pending placeholder cards because the agent turn has not started
+ * yet.
+ */
+export const ScaffoldingRunning: Story = {
+  args: {
+    steps: [
+      {
+        definition: {
+          id: 'placeholder-scaffold',
+          stepKey: 'scaffold',
+          title: 'Preparing your project',
+          description: 'Scaffolding the project tree and installing dependencies',
+        },
+        status: 'running' as const,
+        metadata: null,
+        toolMessages: [],
+        startedAt: Date.now() - 40 * 1000,
+        finishedAt: null,
+      },
+      ...build(),
+    ],
+  },
+};
+
+/**
+ * Scaffolding finished and the real workflow has begun — the scaffold
+ * card flips to `done` with a captured duration while the first real
+ * step (`components`) goes `running`.
+ */
+export const ScaffoldingDoneWorkflowRunning: Story = {
+  args: {
+    steps: [
+      {
+        definition: {
+          id: 'placeholder-scaffold',
+          stepKey: 'scaffold',
+          title: 'Preparing your project',
+          description: 'Scaffolding the project tree and installing dependencies',
+        },
+        status: 'done' as const,
+        metadata: null,
+        toolMessages: [],
+        startedAt: Date.now() - 90 * 1000,
+        finishedAt: Date.now() - 30 * 1000,
+      },
+      ...build({
+        components: {
+          status: 'running',
+          startedAt: Date.now() - 25 * 1000,
+        },
+      }),
+    ],
+  },
+};

--- a/src/presentation/web/components/features/chat/workflow-placeholder.ts
+++ b/src/presentation/web/components/features/chat/workflow-placeholder.ts
@@ -2,20 +2,25 @@
  * Client-side mirror of the application-creation workflow's
  * user-facing step titles + descriptions. Used to render a
  * placeholder tracker BEFORE the backend orchestrator has written
- * the real `workflow_steps` rows — the user sees all 5 pending
+ * the real `workflow_steps` rows — the user sees all the pending
  * cards the instant they land on the application page, instead
  * of a blank area that suddenly pops into existence a few
  * hundred milliseconds later.
  *
- * The old `scaffold` placeholder is gone — scaffolding now runs
- * deterministically in `BunShadcnScaffolder` BEFORE the agent turn
- * starts, so the project is already flat + dependency-installed
- * when the user lands on the application page.
+ * The first entry — `scaffold` — is a SYNTHETIC step that does not
+ * correspond to a real `workflow_steps` row. It represents the
+ * `BunShadcnScaffolder` phase (project-tree creation + `bun install`)
+ * which runs BEFORE the agent turn starts. That phase can take a
+ * long time (dependency install), and without this card the user
+ * would see an all-pending tracker and think nothing is happening.
  *
- * Keep this in sync with
+ * The rest of the list mirrors the real workflow steps. Keep them
+ * in sync with
  * `packages/core/src/application/use-cases/applications/application-creation.workflow.ts`.
- * The real steps replace the placeholder as soon as the first
- * `workflow_step` SSE chunk arrives.
+ * The real rows replace the non-scaffold placeholders as soon as the
+ * first `workflow_step` SSE chunk arrives; the scaffold card is
+ * injected on top by `ChatTab` via `scaffoldingState` so it stays
+ * visible across both phases.
  */
 
 export interface PlaceholderStep {
@@ -23,6 +28,13 @@ export interface PlaceholderStep {
   title: string;
   description: string;
 }
+
+/**
+ * Stable key for the synthetic scaffold card. Exported so `ChatTab`
+ * can prepend a matching `EnhancedStepState` and the rest of the
+ * tracker plumbing can identify it without stringly-typed comparisons.
+ */
+export const SCAFFOLD_STEP_KEY = 'scaffold';
 
 export const APPLICATION_CREATION_PLACEHOLDER_STEPS: PlaceholderStep[] = [
   {


### PR DESCRIPTION
Two commits bundled on top of `origin/main` — the scaffolding progress indicator plus the dark-mode surface lift that was previously in #563 (now closed in favour of this single PR).

## Commit 1 — `feat(web): show scaffolding progress in chat tracker`

### Problem

When creating a new application, the `BunShadcnScaffolder` phase (project tree creation + `bun install`) runs **before** the agent turn starts. That phase has no `workflow_steps` row, so the chat tracker showed an all-pending placeholder skeleton for the entire duration of the install. On a slow network `bun install` can take tens of seconds or longer and the user sees no signal that anything is happening — the first real step card ("Building the pieces") sits in `pending` the whole time.

### Fix

Prepend a synthetic **Scaffolding** card at the top of the tracker that reflects the scaffold phase lifecycle independently of the real workflow rows.

**`workflow-placeholder.ts`** — exported `SCAFFOLD_STEP_KEY` and rewrote the stale comment that claimed scaffolding "runs deterministically before the user lands".

**`ChatTab.tsx`** — new optional prop `scaffoldingState: { status, startedAt, finishedAt?, error? }`. When provided, synthesises an `EnhancedStepState` card with `stepKey = 'scaffold'` and id `placeholder-scaffold`. Status is forced to `done` the moment real workflow rows arrive (`stepProgress.hasPlan === true`) because the orchestrator runs scaffold → workflow sequentially. A client-side ref captures `Date.now()` the first time `hasPlan` flips true so the `done` card has a stable `finishedAt` that doesn't re-sample on every render. The card is prepended to `baseSteps`:

- Phase A (no real rows): `[scaffold running, components pending, wire pending, …]`
- Phase B (real rows arrived): `[scaffold done, components running, wire pending, …]`

`allDone` / `onAllStepsComplete` / `activeStepId` are derived from the real `stepProgress` only, so the synthetic card can never break auto-deploy or live-status behaviour.

**`application-page.tsx`** — derives `scaffoldingState` from the Application entity:

- `application.setupComplete === true` → `{ status: 'done', startedAt: createdAt }`
- `application.status === ApplicationStatus.Error` → `{ status: 'failed', error: '…' }`
- otherwise → `{ status: 'running', startedAt: createdAt }`

`createdAt` is the approximate scaffold start (the Application row is persisted moments before `dispatchScaffoldAndWorkflow` kicks off).

**`StepTracker.stories.tsx`** — two new variants: `ScaffoldingRunning` and `ScaffoldingDoneWorkflowRunning`.

## Commit 2 — `fix(web): lift application card surface in dark mode`

### Problem

Application cards on `/applications` were invisible in dark mode — the card bled straight into the page background because `--color-card` and `--color-background` both resolve to `#0a0a0a` in the dark theme:

```css
:root { --color-background: #ffffff; --color-card: #ffffff; }
.dark { --color-background: #0a0a0a; --color-card: #0a0a0a; }
```

Cards read as holes in the page instead of elevated tiles.

### Fix

Dark-mode-only overrides applied **locally** on `ApplicationCard` — did not touch the global `--color-card` token, which would ripple through every `bg-card` consumer (settings panels, dialogs, popovers) and silently change their contrast.

**Card body**

| | Before | After |
|---|---|---|
| Background | `bg-card` (`#0a0a0a`) | `dark:bg-neutral-900` (`#171717`) |
| Border | `border-border/60` | `+ dark:border-white/10` |
| Hover border | `hover:border-border` | `+ dark:hover:border-white/20` |
| Hover shadow | `hover:shadow-lg` | `+ dark:hover:shadow-black/40` |

**SVG wireframe header** — goes from `bg-[#111827]` (fixed, same in both modes) to `bg-[#111827] dark:bg-neutral-800` (`#262626`), one tier above the card body. Light mode keeps `#111827` because the `MockPreview` SVG strokes are `rgba(255,255,255,0.04–0.13)` and would vanish on a light background.

Result in dark mode:

```
page           →  #0a0a0a
card body      →  #171717  (dark:bg-neutral-900)
wireframe hdr  →  #262626  (dark:bg-neutral-800)
```

One clear two-tier elevation inside each card.

## Local verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0/0)
- `pnpm format:check` ✅
- `pnpm build:storybook` ✅
- `pnpm vitest run` for chat tests ✅

Playwright is blocked by system admin policy on this machine so Please eyeball:

- `Features/Chat/StepTracker → ScaffoldingRunning`
- `Features/Chat/StepTracker → ScaffoldingDoneWorkflowRunning`
- The `/applications` page in dark mode — cards should read as lifted tiles with visible borders.

## Manual test plan

- [ ] Create a new application. While `bun install` runs in the terminal, the tracker shows a spinner on the Scaffolding card with a ticking duration. Placeholder cards below remain pending.
- [ ] Scaffolding finishes → first real workflow step flips to `running`. Scaffolding card flips to `done` with a captured duration that stays stable.
- [ ] Refresh mid-scaffold → tracker re-renders with the scaffold card still running (driven from `application.createdAt`).
- [ ] Refresh after all steps done → scaffold card stays visible at the top; `onAllStepsComplete` still fires and auto-deploy still triggers.
- [ ] Application with `status === Error` (simulated scaffolder failure) → Scaffolding card shows failed.
- [ ] `/applications` in dark mode — cards lift cleanly above the page background with a faint white/10 border and a visible two-tier elevation inside each card. Hover raises the border and drops a soft black shadow.
- [ ] `/applications` in light mode — unchanged.
