### PR TITLE
chore(agents): add opus 4 7 support

### DIFF
--- a/packages/core/src/infrastructure/services/agents/common/agent-executor-factory.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-executor-factory.service.ts
@@ -237,7 +237,12 @@ export class AgentExecutorFactory implements IAgentExecutorFactory {
 }
 
 // Static model lists per executor — update here when new models are released
-const CLAUDE_CODE_MODELS: string[] = ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'];
+const CLAUDE_CODE_MODELS: string[] = [
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+];
 const GEMINI_CLI_MODELS: string[] = [
   'gemini-3.1-pro',
   'gemini-3-flash',
@@ -245,6 +250,7 @@ const GEMINI_CLI_MODELS: string[] = [
   'gemini-2.5-flash',
 ];
 const CURSOR_MODELS: string[] = [
+  'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
   'gpt-5.4-high',
@@ -272,6 +278,7 @@ const COPILOT_CLI_MODELS = [
   'claude-haiku-4.5',
   'claude-opus-4.5',
   'claude-opus-4.6',
+  'claude-opus-4.7',
   'claude-sonnet-4',
   'claude-sonnet-4.5',
   'claude-sonnet-4.6',

--- a/src/presentation/web/lib/model-metadata.ts
+++ b/src/presentation/web/lib/model-metadata.ts
@@ -9,6 +9,7 @@ export interface ModelMeta {
  */
 const MODEL_METADATA: Record<string, ModelMeta> = {
   // Claude models
+  'claude-opus-4-7': { displayName: 'Opus 4.7', description: 'Most capable, complex tasks' },
   'claude-opus-4-6': { displayName: 'Opus 4.6', description: 'Most capable, complex tasks' },
   'claude-sonnet-4-6': { displayName: 'Sonnet 4.6', description: 'Fast & balanced' },
   'claude-haiku-4-5': { displayName: 'Haiku 4.5', description: 'Lightweight & quick' },

--- a/tsp/domain/entities/settings.tsp
+++ b/tsp/domain/entities/settings.tsp
@@ -56,9 +56,9 @@ import "../../common/enums/terminal.tsp";
  * ## Supported Models
  *
  * Valid model IDs depend on the configured agent executor:
- * - claude-code: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5
+ * - claude-code: claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5
  * - gemini-cli: gemini-3.1-pro, gemini-3-flash, gemini-2.5-pro, gemini-2.5-flash
- * - cursor: claude-opus-4-6, claude-sonnet-4-6, gpt-5.4, gpt-5, gpt-5.3-codex, gemini-3.1-pro, composer-1.5, grok-code
+ * - cursor: claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6, gpt-5.4, gpt-5, gpt-5.3-codex, gemini-3.1-pro, composer-1.5, grok-code
  */
 @doc("AI model configuration for the SDLC agent")
 model ModelConfiguration {


### PR DESCRIPTION
## Request

```
add opus 4.7 support```

## Agent report

## Add Opus 4.7 Support

Added `claude-opus-4-7` as a supported model across the shep codebase.

### Changes

**`packages/core/src/infrastructure/services/agents/common/agent-executor-factory.service.ts`**
- Added `claude-opus-4-7` to `CLAUDE_CODE_MODELS` (the static model list for the Claude Code agent executor)
- Added `claude-opus-4-7` to `CURSOR_MODELS` (Cursor supports Claude models)
- Added `claude-opus-4.7` to `COPILOT_CLI_MODELS` (Copilot CLI uses dot-notation model IDs)

**`src/presentation/web/lib/model-metadata.ts`**
- Added display metadata for `claude-opus-4-7`: display name "Opus 4.7", description "Most capable, complex tasks"

**`tsp/domain/entities/settings.tsp`**
- Updated the JSDoc comment listing supported Claude Code and Cursor model IDs to include `claude-opus-4-7`

### Verification
- `pnpm run generate` — TypeSpec compiled successfully (output.ts unchanged, as expected — no domain model changes)
- `pnpm run lint` — no warnings or errors
- `pnpm run typecheck` — clean
- `pnpm run build` — succeeded

---

Generated by `agent-request` workflow run 24832974439.
Wait for CI on this PR (lint, typecheck, tests, build,
dev-release). Preview via the npm dev tag posted in the
PR comment or `gh pr checkout` locally. Merge when satisfied.
