### PR TITLE
feat(agents): add opus 4.7 support

### DIFF
--- a/packages/core/src/infrastructure/services/agents/common/agent-executor-factory.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-executor-factory.service.ts
@@ -237,7 +237,12 @@ export class AgentExecutorFactory implements IAgentExecutorFactory {
 }
 
 // Static model lists per executor — update here when new models are released
-const CLAUDE_CODE_MODELS: string[] = ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'];
+const CLAUDE_CODE_MODELS: string[] = [
+  'claude-opus-4-7',
+  'claude-opus-4-6',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+];
 const GEMINI_CLI_MODELS: string[] = [
   'gemini-3.1-pro',
   'gemini-3-flash',
@@ -245,6 +250,7 @@ const GEMINI_CLI_MODELS: string[] = [
   'gemini-2.5-flash',
 ];
 const CURSOR_MODELS: string[] = [
+  'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
   'gpt-5.4-high',
@@ -272,6 +278,7 @@ const COPILOT_CLI_MODELS = [
   'claude-haiku-4.5',
   'claude-opus-4.5',
   'claude-opus-4.6',
+  'claude-opus-4.7',
   'claude-sonnet-4',
   'claude-sonnet-4.5',
   'claude-sonnet-4.6',

--- a/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
@@ -348,7 +348,12 @@ describe('AgentExecutorFactory', () => {
     it('should return claude-code model list', () => {
       const models = factory.getSupportedModels(AgentType.ClaudeCode);
 
-      expect(models).toEqual(['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5']);
+      expect(models).toEqual([
+        'claude-opus-4-7',
+        'claude-opus-4-6',
+        'claude-sonnet-4-6',
+        'claude-haiku-4-5',
+      ]);
     });
 
     it('should return gemini-cli model list', () => {
@@ -366,6 +371,7 @@ describe('AgentExecutorFactory', () => {
       const models = factory.getSupportedModels(AgentType.Cursor);
 
       expect(models).toEqual([
+        'claude-opus-4-7',
         'claude-opus-4-6',
         'claude-sonnet-4-6',
         'gpt-5.4-high',
@@ -400,11 +406,12 @@ describe('AgentExecutorFactory', () => {
     it('should return copilot-cli model list with 7 models', () => {
       const models = factory.getSupportedModels(AgentType.CopilotCli);
 
-      expect(models).toHaveLength(13);
+      expect(models).toHaveLength(14);
       expect(models).toEqual([
         'claude-haiku-4.5',
         'claude-opus-4.5',
         'claude-opus-4.6',
+        'claude-opus-4.7',
         'claude-sonnet-4',
         'claude-sonnet-4.5',
         'claude-sonnet-4.6',


### PR DESCRIPTION
## Request

```
https://github.com/shep-ai/shep/pull/571 this pr failed on unit tests, fix and watch till green```

## Agent report

## Fix: Add claude-opus-4-7 to supported model lists

PR #571 added `claude-opus-4-7` to the agent executor factory's model lists but did not update the corresponding unit tests, causing three test failures.

### Changes Made

**`packages/core/src/infrastructure/services/agents/common/agent-executor-factory.service.ts`**
- Prepended `claude-opus-4-7` to `CLAUDE_CODE_MODELS` (Claude Code executor)
- Prepended `claude-opus-4-7` to `CURSOR_MODELS` (Cursor executor)
- Inserted `claude-opus-4.7` after `claude-opus-4.6` in `COPILOT_CLI_MODELS` (Copilot CLI executor)

**`tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts`**
- Updated `should return claude-code model list` to expect 4 models including `claude-opus-4-7` at index 0
- Updated `should return cursor model list` to expect 9 models including `claude-opus-4-7` at index 0
- Updated `should return copilot-cli model list with 7 models` to expect 14 models including `claude-opus-4.7`

All 6604 unit tests pass. Lint and typecheck are clean.

---

Generated by `agent-request` workflow run 24833825846.
Wait for CI on this PR (lint, typecheck, tests, build,
dev-release). Preview via the npm dev tag posted in the
PR comment or `gh pr checkout` locally. Merge when satisfied.
