### PR TITLE
feat(web): apps-only desktop surface (spec 091)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "prepare": "husky",
     "validate": "pnpm run lint:fix && pnpm run format && pnpm run typecheck && pnpm run tsp:compile",
     "electron:dev": "pnpm --filter @shepai/electron dev",
+    "apps:dev": "cross-env ELECTRON_RUN_AS_NODE= SHEP_SHELL_VARIANT=apps-only pnpm --filter @shepai/electron dev",
     "electron:compile": "pnpm --filter @shepai/electron compile",
     "electron:build": "pnpm --filter @shepai/electron build",
     "electron:build:mac": "pnpm --filter @shepai/electron build:mac",

--- a/packages/core/src/infrastructure/services/scaffolding/bun-shadcn-scaffolder.service.ts
+++ b/packages/core/src/infrastructure/services/scaffolding/bun-shadcn-scaffolder.service.ts
@@ -275,7 +275,7 @@ export class BunShadcnScaffolder implements IApplicationScaffolder {
 
     // Phase 5 — overlay the fat template on top of the raw scaffold.
     emit('Info', 'Applying Shep base template');
-    const overlay = applyTemplateOverlay(repositoryPath);
+    const overlay = await applyTemplateOverlay(repositoryPath);
 
     emit(
       'Info',

--- a/packages/core/src/infrastructure/services/scaffolding/template-overlay.ts
+++ b/packages/core/src/infrastructure/services/scaffolding/template-overlay.ts
@@ -18,7 +18,8 @@
  */
 
 import { fileURLToPath } from 'node:url';
-import { readdirSync, statSync, mkdirSync, copyFileSync, readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
+import { readdir, stat, mkdir, copyFile } from 'node:fs/promises';
 import { dirname, join, relative, resolve } from 'node:path';
 
 export interface TemplateOverlayResult {
@@ -32,17 +33,42 @@ interface TemplateManifest {
 }
 
 /**
- * Resolve the absolute path to the template root relative to THIS
- * compiled file. In `dist/` the file sits at
- * `dist/infrastructure/services/scaffolding/template-overlay.js` and
- * the templates sit at `dist/infrastructure/templates/vite-shadcn-base/`,
- * so the relative path `../../templates/vite-shadcn-base` is stable
- * across dev (`src/`) and prod (`dist/`) as long as the prebuild copies
- * the template directory alongside the compiled `.js` files.
+ * Resolve the absolute path to the template root. We try several
+ * well-known layouts in order because this module is consumed in
+ * three distinct runtime layouts:
+ *
+ *  1. `src/` during `pnpm dev:cli` — file at
+ *     `.../infrastructure/services/scaffolding/template-overlay.ts`,
+ *     templates at `.../infrastructure/templates/vite-shadcn-base/`.
+ *  2. `dist/` after `tsc` — same relative `../../templates/...` path.
+ *  3. Bundled into Electron's `main.cjs` — `import.meta.url` resolves
+ *     to the bundle at `packages/electron/dist/main.cjs`, so the
+ *     original `../../templates/...` lookup lands in the wrong place.
+ *     The Electron build copies templates next to the bundle, so we
+ *     also check `${here}/templates/vite-shadcn-base/`.
+ *
+ * A `SHEP_TEMPLATE_ROOT` env var override takes precedence over both
+ * for packaging flexibility and testing.
  */
 function resolveTemplateRoot(): string {
+  const envOverride = process.env.SHEP_TEMPLATE_ROOT;
+  if (envOverride && existsSync(envOverride)) return envOverride;
+
   const here = dirname(fileURLToPath(import.meta.url));
-  return resolve(here, '..', '..', 'templates', 'vite-shadcn-base');
+  const candidates = [
+    // src/ and tsc dist layout
+    resolve(here, '..', '..', 'templates', 'vite-shadcn-base'),
+    // bundled layout — templates copied next to the bundle entry
+    resolve(here, 'templates', 'vite-shadcn-base'),
+    // bundled layout — templates copied into an infrastructure/ subtree
+    resolve(here, 'infrastructure', 'templates', 'vite-shadcn-base'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  // Fall back to the first (original) path — applyTemplateOverlay
+  // will throw a descriptive error naming this path.
+  return candidates[0];
 }
 
 /**
@@ -52,7 +78,7 @@ function resolveTemplateRoot(): string {
  * The `.template-manifest.json` file is read for metadata only and
  * is NOT copied into the user's project.
  */
-export function applyTemplateOverlay(repositoryPath: string): TemplateOverlayResult {
+export async function applyTemplateOverlay(repositoryPath: string): Promise<TemplateOverlayResult> {
   const templateRoot = resolveTemplateRoot();
   if (!existsSync(templateRoot)) {
     throw new Error(
@@ -78,7 +104,7 @@ export function applyTemplateOverlay(repositoryPath: string): TemplateOverlayRes
   }
 
   const copied: string[] = [];
-  walkAndCopy(templateRoot, templateRoot, repositoryPath, copied);
+  await walkAndCopy(templateRoot, templateRoot, repositoryPath, copied);
 
   return {
     templateFiles: copied,
@@ -89,26 +115,36 @@ export function applyTemplateOverlay(repositoryPath: string): TemplateOverlayRes
 /**
  * Recursively walk `current` under `root` and copy each file into
  * `destRoot`, preserving the subtree. Skips the manifest file.
+ *
+ * Uses `fs/promises` so libuv offloads file I/O to the thread pool —
+ * critical when this module runs inside Electron's main process,
+ * where synchronous I/O on a large template tree blocks IPC long
+ * enough to trigger the OS "not responding" watchdog.
  */
-function walkAndCopy(root: string, current: string, destRoot: string, collected: string[]): void {
-  const entries = readdirSync(current);
+async function walkAndCopy(
+  root: string,
+  current: string,
+  destRoot: string,
+  collected: string[]
+): Promise<void> {
+  const entries = await readdir(current);
   for (const entry of entries) {
     const srcPath = join(current, entry);
     // Hidden manifest file is metadata, not content — don't ship it
     // into the user's project.
     if (current === root && entry === '.template-manifest.json') continue;
 
-    const stat = statSync(srcPath);
-    if (stat.isDirectory()) {
-      walkAndCopy(root, srcPath, destRoot, collected);
+    const entryStat = await stat(srcPath);
+    if (entryStat.isDirectory()) {
+      await walkAndCopy(root, srcPath, destRoot, collected);
       continue;
     }
-    if (!stat.isFile()) continue;
+    if (!entryStat.isFile()) continue;
 
     const rel = relative(root, srcPath);
     const destPath = join(destRoot, rel);
-    mkdirSync(dirname(destPath), { recursive: true });
-    copyFileSync(srcPath, destPath);
+    await mkdir(dirname(destPath), { recursive: true });
+    await copyFile(srcPath, destPath);
     collected.push(rel);
   }
 }

--- a/packages/electron/scripts/build.mjs
+++ b/packages/electron/scripts/build.mjs
@@ -11,9 +11,34 @@
  */
 
 import { build } from 'esbuild';
-import { copyFileSync, existsSync, readFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/**
+ * Recursively copy a directory tree. Used to stage runtime assets
+ * (templates, etc.) alongside the bundled Electron main entry so that
+ * modules bundled from `@shepai/core` which resolve data directories
+ * via `import.meta.url` can locate them at runtime.
+ */
+function copyDirSync(src, dst) {
+  mkdirSync(dst, { recursive: true });
+  for (const entry of readdirSync(src)) {
+    const s = path.join(src, entry);
+    const d = path.join(dst, entry);
+    const st = statSync(s);
+    if (st.isDirectory()) copyDirSync(s, d);
+    else if (st.isFile()) copyFileSync(s, d);
+  }
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
@@ -105,14 +130,22 @@ async function main() {
     logLevel: 'info',
   });
 
-  // Build preload script separately (runs in isolated renderer context)
-  // Electron 28+ supports ESM preload scripts with contextIsolation: true
+  // Build preload script separately (runs in isolated renderer context).
+  //
+  // IMPORTANT: CJS format. Electron's preload loader attaches the
+  // contextBridge at document_start for CJS preloads; ESM preloads have
+  // observable races where the bridge isn't on `window` by the time
+  // React mounts in the renderer. Using CJS also avoids the
+  // sandbox-incompatibility issues with ESM preloads. The preload
+  // `require`s 'electron' synchronously, which is valid in this
+  // context.
   await build({
     entryPoints: [path.join(root, 'src/preload.ts')],
     bundle: true,
     platform: 'node',
     target: 'node22',
-    format: 'esm',
+    format: 'cjs',
+    outExtension: { '.js': '.cjs' },
     outdir: distDir,
     external: ['electron'],
     sourcemap: true,
@@ -136,6 +169,60 @@ async function main() {
   if (existsSync(entrySrc)) {
     copyFileSync(entrySrc, entryDst);
     console.log('Copied entry.cjs to dist/');
+  }
+
+  // Compile each SQLite migration .ts file into dist/migrations/*.js
+  // alongside the main bundle. `getMigrationsDir()` in the core package
+  // resolves the directory as a sibling of the compiled file via
+  // `import.meta.url` — in the Electron bundle that lands on
+  // `dist/main.cjs`, so the runtime discovery looks for
+  // `dist/migrations/`. Node 22 can't `import('./foo.ts')` so we pre-
+  // compile each file to CJS .js. Without this, migrations 035+
+  // (including the workflow_steps table) never run and startup crashes
+  // the first time a fresh SHEP_HOME is used.
+  const migrationsSrc = path.join(coreDir, 'infrastructure', 'persistence', 'sqlite', 'migrations');
+  const migrationsDst = path.join(distDir, 'migrations');
+  if (existsSync(migrationsSrc)) {
+    const entries = readdirSync(migrationsSrc)
+      .filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+      .map((f) => path.join(migrationsSrc, f));
+    if (entries.length > 0) {
+      await build({
+        entryPoints: entries,
+        bundle: false, // one-file-in/one-file-out — no bundling
+        platform: 'node',
+        target: 'node22',
+        format: 'cjs',
+        outdir: migrationsDst,
+        sourcemap: true,
+        logLevel: 'info',
+      });
+      // Electron's package.json declares "type": "module", so Node
+      // treats plain .js files as ESM and refuses `module.exports`.
+      // Drop a directory-local package.json that pins CJS for every
+      // .js file in dist/migrations/ — overrides the parent without
+      // changing migration file extensions (keeping the discovery
+      // logic in core untouched).
+      writeFileSync(
+        path.join(migrationsDst, 'package.json'),
+        JSON.stringify({ type: 'commonjs' }, null, 2)
+      );
+      console.log(`Compiled ${entries.length} migrations to dist/migrations/`);
+    }
+  }
+
+  // Copy scaffolding templates next to the bundle. The template-overlay
+  // resolver (bundled into main.cjs) falls back to `${here}/templates/
+  // vite-shadcn-base` when its default lookup fails, so placing the
+  // tree at `dist/templates/` is enough for the bundled runtime to
+  // find it. Without this, creating a new Application fails with:
+  // `Template overlay failed: template root ".../packages/templates/
+  // vite-shadcn-base" does not exist.`
+  const templatesSrc = path.join(coreDir, 'infrastructure', 'templates');
+  const templatesDst = path.join(distDir, 'templates');
+  if (existsSync(templatesSrc)) {
+    copyDirSync(templatesSrc, templatesDst);
+    console.log('Copied scaffolding templates to dist/templates/');
   }
 
   console.log('Electron build complete.');

--- a/packages/electron/src/app.ts
+++ b/packages/electron/src/app.ts
@@ -21,6 +21,7 @@ import {
   type ElectronAdapterResult,
 } from './electron-adapters.js';
 import { setupIpcHandlers, type IpcHandlerDeps } from './ipc/channels.js';
+import { IPC_CHANNELS } from './ipc/constants.js';
 import { resolvePort, type PortConflictDeps } from './port-conflict.js';
 import { checkForUpdates, type UpdateCheckerDeps } from './update-checker.js';
 import type { IWebServerService } from '@shepai/core/application/ports/output/services/web-server-service.interface.js';
@@ -40,6 +41,9 @@ export interface AppBrowserWindow {
   hide(): void;
   close(): void;
   minimize(): void;
+  maximize(): void;
+  unmaximize(): void;
+  isMaximized(): boolean;
   isDestroyed(): boolean;
   isMinimized(): boolean;
   restore(): void;
@@ -61,6 +65,9 @@ export interface AppElectronApi {
   Menu: { buildFromTemplate(template: unknown[]): unknown };
   nativeImage: { createFromPath(p: string): { setTemplateImage(v: boolean): void } };
 }
+
+/** Shell variant controlling which web surface the Electron window loads. */
+export type ShellVariant = 'full' | 'apps-only';
 
 /** Dependencies for the app lifecycle. */
 export interface AppDeps {
@@ -87,6 +94,14 @@ export interface AppDeps {
   ipcHandlerDeps: Omit<IpcHandlerDeps, 'getMainWindow' | 'serverPort'>;
   /** Factory for update checker deps (needs mainWindow at runtime). */
   updateCheckerDeps: Omit<UpdateCheckerDeps, 'sendToRenderer'>;
+  /** Which web shell to load. Defaults to 'full'. */
+  shellVariant?: ShellVariant;
+  /**
+   * Sets the `shep-shell-variant` cookie on the Electron session scoped to the
+   * local web server. Awaited BEFORE loadURL so the first HTML render sees it.
+   * Only called when shellVariant === 'apps-only'.
+   */
+  setShellVariantCookie?: (port: number, variant: ShellVariant) => Promise<void>;
 }
 
 /** Application state (exposed for testing). */
@@ -139,14 +154,20 @@ export function createMainWindow(
   windowStateKeeper: AppDeps['windowStateKeeper'],
   port: number,
   preloadPath: string,
-  state: AppState
+  state: AppState,
+  initialPath = '/',
+  shellVariant: ShellVariant = 'full'
 ): AppBrowserWindow {
   const windowState = windowStateKeeper({
     defaultWidth: 1280,
     defaultHeight: 800,
   });
 
-  const win = new BrowserWindow({
+  // Apps-only mode ships a custom, sleek top bar (see AppsOnlyShell).
+  // Drop the OS window frame so the renderer owns the chrome; keep
+  // the window draggable via `-webkit-app-region: drag` on the header.
+  const isAppsOnly = shellVariant === 'apps-only';
+  const windowOpts: Record<string, unknown> = {
     x: windowState.x,
     y: windowState.y,
     width: windowState.width,
@@ -158,16 +179,42 @@ export function createMainWindow(
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
+      // CJS preload — Electron attaches the contextBridge at
+      // document_start, before the renderer hydrates React, so
+      // `window.shepElectron` is available from the first paint.
+      // Sandbox stays ON because CJS preloads are sandbox-compatible
+      // and we expose only typed IPC channels (no Node primitives).
       sandbox: true,
       preload: preloadPath,
     },
-  });
+  };
+  if (isAppsOnly) {
+    windowOpts.frame = false;
+    // `hiddenInset` keeps native traffic-light buttons on macOS; Linux/Windows
+    // render no native buttons — our AppsOnlyShell draws its own.
+    windowOpts.titleBarStyle = 'hiddenInset';
+    // Transparent window + CSS rounded-corner wrapper lets Linux/X11 and
+    // Windows show rounded corners on a frameless window. macOS rounds
+    // automatically; Windows 11 rounds frameless windows; on older
+    // Linux compositors the transparent bits just show the desktop
+    // behind the corner. The body/html in apps-only mode is transparent
+    // so the AppsOnlyShell's `rounded-xl overflow-hidden` clips cleanly.
+    windowOpts.transparent = true;
+    // Use a fully-transparent hex so the OS compositor can honor the
+    // rounded-corner mask set by our CSS.
+    windowOpts.backgroundColor = '#00000000';
+    // Cannot resize while keeping transparency on some X11 setups —
+    // keep resizable (default true) so the user can drag edges, but
+    // don't allow hasShadow to misalign with the rounded corners.
+    windowOpts.hasShadow = true;
+  }
+  const win = new BrowserWindow(windowOpts);
 
   // Let electron-window-state track this window
   windowState.manage(win);
 
   // Load the Next.js web UI
-  win.loadURL(`http://localhost:${port}`);
+  win.loadURL(`http://localhost:${port}${initialPath}`);
 
   // When ready, show main window and close splash
   win.once('ready-to-show', () => {
@@ -184,6 +231,17 @@ export function createMainWindow(
       (event as { preventDefault(): void }).preventDefault();
       win.hide();
     }
+  });
+
+  // Broadcast maximize state changes to the renderer so the custom window
+  // controls in apps-only mode can swap between the "maximize" and
+  // "restore" icons. Fires for OS-level gestures too (double-click title
+  // bar, Win+Up, macOS green button).
+  win.on('maximize', () => {
+    win.webContents.send(IPC_CHANNELS.WINDOW_MAXIMIZED_CHANGED, true);
+  });
+  win.on('unmaximize', () => {
+    win.webContents.send(IPC_CHANNELS.WINDOW_MAXIMIZED_CHANGED, false);
   });
 
   return win;
@@ -313,13 +371,24 @@ export async function startApp(deps: AppDeps): Promise<AppState> {
       console.log(`${TAG} Connecting to existing server at http://localhost:${port}`);
     }
 
+    // Step 4b: If apps-only variant, set the cookie BEFORE creating the window so
+    // the first HTML render already carries the variant signal.
+    const shellVariant: ShellVariant = deps.shellVariant ?? 'full';
+    if (shellVariant === 'apps-only' && deps.setShellVariantCookie) {
+      await deps.setShellVariantCookie(port, shellVariant);
+      console.log(`${TAG} shell-variant cookie set: apps-only`);
+    }
+    const initialPath = shellVariant === 'apps-only' ? '/applications' : '/';
+
     // Step 5: Create main window
     state.mainWindow = createMainWindow(
       electron.BrowserWindow,
       deps.windowStateKeeper,
       port,
       deps.preloadPath,
-      state
+      state,
+      initialPath,
+      shellVariant
     );
 
     // Step 6: Set up IPC handlers

--- a/packages/electron/src/ipc/channels.ts
+++ b/packages/electron/src/ipc/channels.ts
@@ -16,6 +16,9 @@ import { IPC_CHANNELS } from './constants.js';
 interface WindowLike {
   minimize(): void;
   hide(): void;
+  maximize(): void;
+  unmaximize(): void;
+  isMaximized(): boolean;
 }
 
 interface IpcEvent {
@@ -69,6 +72,18 @@ export function setupIpcHandlers(deps: IpcHandlerDeps): void {
       return;
     }
     getMainWindow()?.minimize();
+  });
+
+  // shep:maximize-toggle — toggle between maximized and restored states
+  ipcMain.on(IPC_CHANNELS.MAXIMIZE_TOGGLE, (event) => {
+    if (!isValidOrigin(event, serverPort)) {
+      console.warn(`Rejected IPC on ${IPC_CHANNELS.MAXIMIZE_TOGGLE} from ${event.senderFrame.url}`);
+      return;
+    }
+    const win = getMainWindow();
+    if (!win) return;
+    if (win.isMaximized()) win.unmaximize();
+    else win.maximize();
   });
 
   // shep:close — hide the main window (minimize to tray)

--- a/packages/electron/src/ipc/constants.ts
+++ b/packages/electron/src/ipc/constants.ts
@@ -9,7 +9,9 @@ export const IPC_CHANNELS = {
   GET_VERSION: 'shep:get-version',
   UPDATE_AVAILABLE: 'shep:update-available',
   MINIMIZE: 'shep:minimize',
+  MAXIMIZE_TOGGLE: 'shep:maximize-toggle',
   CLOSE: 'shep:close',
+  WINDOW_MAXIMIZED_CHANGED: 'shep:window-maximized-changed',
 } as const;
 
 /** The key used for contextBridge.exposeInMainWorld(). */

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -21,6 +21,7 @@ import {
   shell,
   ipcMain,
   dialog,
+  session as electronSession,
 } from 'electron';
 import path from 'node:path';
 import windowStateKeeper from 'electron-window-state';
@@ -53,6 +54,9 @@ import fs from 'node:fs';
 
 /* eslint-disable no-console */
 
+const shellVariant: 'full' | 'apps-only' =
+  process.env.SHEP_SHELL_VARIANT === 'apps-only' ? 'apps-only' : 'full';
+
 const deps = {
   electron: { app, BrowserWindow, Tray, Menu, nativeImage },
   windowStateKeeper,
@@ -79,7 +83,7 @@ const deps = {
   },
   resourcesDir: path.join(import.meta.dirname, '..', 'resources'),
   splashHtmlPath: path.join(import.meta.dirname, 'splash.html'),
-  preloadPath: path.join(import.meta.dirname, 'preload.js'),
+  preloadPath: path.join(import.meta.dirname, 'preload.cjs'),
 
   // Phase 3: Electron adapter deps
   adapterDeps: {
@@ -144,6 +148,18 @@ const deps = {
     repoName: 'cli',
     fetch: (url: string) => globalThis.fetch(url),
     warn: (msg: string, error?: unknown) => console.warn(msg, error),
+  },
+
+  // Shell variant: controls whether the Electron window loads the full shell
+  // or the slim Applications-only surface. Driven by SHEP_SHELL_VARIANT env.
+  shellVariant,
+  setShellVariantCookie: async (port: number, variant: 'full' | 'apps-only') => {
+    await electronSession.defaultSession.cookies.set({
+      url: `http://localhost:${port}`,
+      name: 'shep-shell-variant',
+      value: variant,
+      path: '/',
+    });
   },
 };
 

--- a/packages/electron/src/preload.ts
+++ b/packages/electron/src/preload.ts
@@ -11,6 +11,7 @@
  * imports and exposeInMainWorld call happen at module scope (only in Electron).
  */
 
+import type * as ElectronMod from 'electron';
 import { IPC_CHANNELS, BRIDGE_KEY } from './ipc/constants.js';
 
 /** Update info sent from main process to renderer. */
@@ -26,7 +27,11 @@ export interface ShepElectronApi {
   onUpdateAvailable: (callback: (info: UpdateInfo) => void) => void;
   windowControls: {
     minimize: () => void;
+    maximizeToggle: () => void;
     close: () => void;
+    /** Subscribe to maximize-state changes. Fires for both IPC-driven toggles
+     *  and OS gestures (double-click title, Win+Up, macOS green button). */
+    onMaximizedChange: (callback: (isMaximized: boolean) => void) => void;
   };
 }
 
@@ -60,16 +65,33 @@ export function createShepElectronApi(deps: PreloadDeps): ShepElectronApi {
 
     windowControls: {
       minimize: () => deps.ipcRenderer.send(IPC_CHANNELS.MINIMIZE),
+      maximizeToggle: () => deps.ipcRenderer.send(IPC_CHANNELS.MAXIMIZE_TOGGLE),
       close: () => deps.ipcRenderer.send(IPC_CHANNELS.CLOSE),
+      onMaximizedChange: (callback) => {
+        deps.ipcRenderer.on(IPC_CHANNELS.WINDOW_MAXIMIZED_CHANGED, (data) => {
+          callback(Boolean(data));
+        });
+      },
     },
   };
 }
 
 // When running in Electron, wire the real contextBridge and ipcRenderer.
 // This code only executes in the actual Electron preload context.
+//
+// Using a synchronous `require('electron')` — esbuild emits this preload
+// as CJS (see build.mjs) so the renderer sees the API attached during
+// document_start, before React mounts and calls readWindowControls().
+// The original `await import('electron')` pattern silently failed for
+// preloads loaded under certain sandbox / frameless configs because
+// top-level await races the contextBridge attach with first paint.
+/* eslint-disable @typescript-eslint/no-require-imports */
 try {
-  // Dynamic import to avoid errors when testing outside Electron
-  const { contextBridge, ipcRenderer } = await import('electron');
+  // `electron` is only resolvable inside the Electron renderer's preload
+  // context; the require call throws in Node-mode tests, and the catch
+  // keeps test environments happy.
+  const electronModule = require('electron') as typeof ElectronMod;
+  const { contextBridge, ipcRenderer } = electronModule;
 
   const api = createShepElectronApi({
     contextBridge,
@@ -86,3 +108,4 @@ try {
 } catch {
   // Not running in Electron (e.g., tests) — skip
 }
+/* eslint-enable @typescript-eslint/no-require-imports */

--- a/specs/091-apps-only-surface/data-model.md
+++ b/specs/091-apps-only-surface/data-model.md
@@ -1,0 +1,64 @@
+# Data Model: apps-only-surface
+
+> Entity definitions for 091-apps-only-surface
+
+## Status
+
+- **Phase:** Planning
+- **Updated:** 2026-04-20
+
+## Overview
+
+{{DATA_MODEL_OVERVIEW}}
+
+## New Entities
+
+### {{ENTITY_NAME}}
+
+**Location:** `tsp/domain/entities/{{entity-name}}.tsp`
+
+| Property      | Type          | Required     | Description   |
+| ------------- | ------------- | ------------ | ------------- |
+| {{PROP_NAME}} | {{PROP_TYPE}} | {{REQUIRED}} | {{PROP_DESC}} |
+
+**Relationships:**
+
+- {{RELATIONSHIP_1}}
+
+## Modified Entities
+
+### {{EXISTING_ENTITY}}
+
+**Changes:**
+
+- Add: {{NEW_PROPERTY}}
+- Modify: {{MODIFIED_PROPERTY}}
+
+## Value Objects
+
+### {{VALUE_OBJECT_NAME}}
+
+**Location:** `tsp/domain/value-objects/{{value-object}}.tsp`
+
+| Property    | Type        | Description |
+| ----------- | ----------- | ----------- |
+| {{VO_PROP}} | {{VO_TYPE}} | {{VO_DESC}} |
+
+## Enums
+
+### {{ENUM_NAME}}
+
+**Location:** `tsp/common/enums/{{enum-name}}.tsp`
+
+| Value          | Description   |
+| -------------- | ------------- |
+| {{ENUM_VALUE}} | {{ENUM_DESC}} |
+
+<!-- If no data model changes, replace all with:
+## Overview
+No domain model changes required for this feature.
+-->
+
+---
+
+_Data model changes for TypeSpec compilation_

--- a/specs/091-apps-only-surface/feature.yaml
+++ b/specs/091-apps-only-surface/feature.yaml
@@ -1,0 +1,42 @@
+feature:
+  id: '091-apps-only-surface'
+  name: 'apps-only-surface'
+  number: 91
+  branch: 'feat/091-apps-only-surface'
+  lifecycle: 'implementation'
+  createdAt: '2026-04-20T16:42:44Z'
+
+status:
+  phase: 'ready-to-implement'
+  progress:
+    completed: 0
+    total: 6
+    percentage: 0
+  currentTask: null
+  lastUpdated: '2026-04-20T16:42:44Z'
+  lastUpdatedBy: 'shep-kit:new-feature-fast'
+
+validation:
+  lastRun: null
+  gatesPassed: []
+  autoFixesApplied: []
+
+tasks:
+  current: null
+  blocked: []
+  failed: []
+
+checkpoints:
+  - phase: 'feature-created'
+    completedAt: '2026-04-20T16:42:44Z'
+    completedBy: 'shep-kit:new-feature-fast'
+  - phase: 'research-complete'
+    completedAt: '2026-04-20T16:42:44Z'
+    completedBy: 'shep-kit:new-feature-fast'
+  - phase: 'plan-complete'
+    completedAt: '2026-04-20T16:42:44Z'
+    completedBy: 'shep-kit:new-feature-fast'
+
+errors:
+  current: null
+  history: []

--- a/specs/091-apps-only-surface/plan.yaml
+++ b/specs/091-apps-only-surface/plan.yaml
@@ -1,0 +1,193 @@
+# Implementation Plan (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: apps-only-surface
+summary: Implementation plan for 091-apps-only-surface
+
+# Relationships
+relatedFeatures:
+  - "085-electron-desktop-wrapper"
+technologies:
+  - TypeScript
+  - Next.js App Router
+  - React
+  - Electron
+relatedLinks: []
+
+# Structured implementation phases
+phases:
+  - id: phase-1
+    name: "Shell variant plumbing (cookie → AppShell prop)"
+    parallel: false
+    taskIds:
+      - task-1
+      - task-2
+
+  - id: phase-2
+    name: "Slim chrome + route guard (TDD)"
+    parallel: false
+    taskIds:
+      - task-3
+      - task-4
+
+  - id: phase-3
+    name: "Electron integration"
+    parallel: false
+    taskIds:
+      - task-5
+
+  - id: phase-4
+    name: "Verification"
+    parallel: false
+    taskIds:
+      - task-6
+
+# File change tracking
+filesToCreate:
+  - src/presentation/web/lib/shell-variant.ts
+  - src/presentation/web/hooks/use-apps-only-route-guard.ts
+  - src/presentation/web/components/layouts/app-shell/apps-only-shell.tsx
+  - tests/unit/presentation/web/layouts/app-shell-variant.test.tsx
+  - tests/unit/presentation/web/hooks/use-apps-only-route-guard.test.ts
+
+filesToModify:
+  - src/presentation/web/app/layout.tsx
+  - src/presentation/web/components/layouts/app-shell/app-shell.tsx
+  - src/presentation/web/components/layouts/app-shell/index.ts
+  - packages/electron/src/main.ts
+  - packages/electron/src/app.ts
+
+# Open questions (all resolved)
+openQuestions: []
+
+# Markdown content — architecture, strategy, and risks only.
+# Task-level detail lives in tasks.yaml (no duplication).
+content: |
+  ## Status
+
+  - **Phase:** Planning
+  - **Updated:** 2026-04-20
+
+  ## Architecture Overview
+
+  ```
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  Electron launcher                                               │
+  │  ────────────────                                                │
+  │  env: SHEP_SHELL_VARIANT=apps-only                               │
+  │         │                                                        │
+  │         ▼ before loadURL                                         │
+  │  session.defaultSession.cookies.set({                            │
+  │    url: http://localhost:<port>,                                 │
+  │    name: 'shep-shell-variant',                                   │
+  │    value: 'apps-only',                                           │
+  │  })                                                              │
+  │         │                                                        │
+  │         ▼ win.loadURL(`http://localhost:${port}/applications`)  │
+  └──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+  ┌──────────────────────────────────────────────────────────────────┐
+  │  Next.js server (same DI, same API, same SSE)                    │
+  │                                                                  │
+  │  app/layout.tsx                                                  │
+  │   └─ reads shep-shell-variant cookie → ShellVariant type         │
+  │       └─ passes variant prop to AppShell                         │
+  │                                                                  │
+  │  AppShell(variant)                                               │
+  │   ├─ providers (always): AgentEventsProvider, QueryProvider, …  │
+  │   ├─ if variant === 'apps-only':                                │
+  │   │    <AppsOnlyShell>{children}</AppsOnlyShell>                │
+  │   │       └─ thin top bar (logo + theme toggle)                 │
+  │   │       └─ useAppsOnlyRouteGuard() redirects disallowed paths │
+  │   └─ else:                                                       │
+  │        <SidebarProvider>…<AppSidebar/>…{children}…</…>           │
+  │        (full chrome — unchanged)                                 │
+  └──────────────────────────────────────────────────────────────────┘
+  ```
+
+  ## Implementation Strategy
+
+  **MANDATORY TDD** for tasks that ship runtime behavior (task-3 AppShell
+  variant + task-4 route guard). Config / wiring tasks (task-1 cookie
+  reader helper, task-2 AppShell prop threading, task-5 Electron) are
+  verified via the downstream tests + a dedicated Electron integration
+  probe.
+
+  **Phase ordering:**
+
+  1. **Variant plumbing first.** The `shell-variant.ts` helper + the
+     AppShell `variant` prop are the foundation — everything else
+     depends on them.
+  2. **Slim chrome + guard together.** Both only make sense once the
+     variant prop exists. They're built TDD in the same phase because
+     they share a test harness (renders AppShell with variant=apps-only
+     and asserts chrome + navigation behavior).
+  3. **Electron integration last.** No point wiring the Electron cookie
+     until the server-side variant handling is proven green.
+  4. **Verification.** lint + typecheck + tests + storybook, plus a
+     manual Electron launch with `SHEP_SHELL_VARIANT=apps-only`.
+
+  **Invariants:**
+
+  - Full-shell code path is untouched — the variant defaults to `full`
+    and every existing user sees no change.
+  - Providers (Agent events, Query, Feature flags, FabLayout, i18n,
+    etc.) stay ACTIVE in apps-only mode — only the visual chrome is
+    skipped. Applications surface relies on AgentEventsProvider for
+    real-time updates (spec 090), and that must keep working.
+  - Route guard does not intercept the initial landing path — it only
+    runs on client-side navigation changes. The Electron launcher is
+    responsible for loading a valid initial URL.
+
+  ## Files to Create/Modify
+
+  ### New Files
+
+  | File | Purpose |
+  | ---- | ------- |
+  | `src/presentation/web/lib/shell-variant.ts` | Exports `ShellVariant` type + `SHELL_VARIANT_COOKIE` constant + `parseShellVariant()` helper used by the root layout |
+  | `src/presentation/web/hooks/use-apps-only-route-guard.ts` | Client hook that watches pathname in apps-only mode and redirects disallowed paths to /applications |
+  | `src/presentation/web/components/layouts/app-shell/apps-only-shell.tsx` | Slim chrome: thin top bar (logo + theme toggle), bounded width content area; wraps children and installs the route guard |
+  | `tests/unit/presentation/web/layouts/app-shell-variant.test.tsx` | Renders AppShell with variant=apps-only, asserts no sidebar, no FAB, no control-center |
+  | `tests/unit/presentation/web/hooks/use-apps-only-route-guard.test.ts` | Asserts router.replace('/applications') is called when pathname is not allowed |
+
+  ### Modified Files
+
+  | File | Changes |
+  | ---- | ------- |
+  | `src/presentation/web/app/layout.tsx` | Read `shep-shell-variant` cookie, parse via `parseShellVariant`, pass `variant` prop to `<AppShell>` |
+  | `src/presentation/web/components/layouts/app-shell/app-shell.tsx` | Accept `variant` prop; branch on it after mounting providers |
+  | `src/presentation/web/components/layouts/app-shell/index.ts` | Export `AppsOnlyShell` alongside the existing AppShell |
+  | `packages/electron/src/main.ts` | Read `SHEP_SHELL_VARIANT` env; when `apps-only`, call `session.defaultSession.cookies.set` with the cookie before `loadURL`; alter `loadURL` path to `/applications` when apps-only |
+  | `packages/electron/src/app.ts` | Extend `AppDeps` to accept optional `shellVariant?: 'full' \| 'apps-only'`; thread through to window loader |
+
+  ## Testing Strategy (TDD: Tests FIRST)
+
+  **CRITICAL:** Tasks 3 and 4 land their failing tests before any
+  runtime code.
+
+  ### Unit Tests (RED → GREEN → REFACTOR)
+
+  - **AppShell variant rendering** — render `<AppShell variant="apps-only">{child}</AppShell>`; assert (a) no `[data-sidebar]` element, (b) no global chat FAB, (c) no control-center canvas, (d) child is still rendered inside the providers stack.
+  - **Route guard** — mount a test harness with `variant="apps-only"` and a mocked `useRouter`/`usePathname`; assert `router.replace('/applications')` fires for disallowed paths (`/features`, `/projects`, `/settings`) and does NOT fire for allowed paths (`/applications`, `/application/foo`).
+
+  ### Integration Tests
+
+  None — the Electron integration is covered by a manual launch probe
+  in task-6 because CI already runs the Electron build on three
+  platforms.
+
+  ## Risk Mitigation
+
+  | Risk | Mitigation |
+  | ---- | ---------- |
+  | User tampers with the cookie to force apps-only mode in the web browser | Non-authoritative cookie; all API endpoints remain fully functional. UI chrome gate only. |
+  | Providers not firing in apps-only mode break the applications surface | Conditional only wraps visual chrome; all providers stay in the tree above the conditional. |
+  | Route guard fires on initial render and races the page | Guard uses `useEffect` + `pathname` watch; initial render paints before the guard runs. Electron always launches at a valid path (`/applications`). |
+  | Electron cookie set races the first loadURL | `session.cookies.set` returns a Promise — await before calling `loadURL`. |
+  | Storybook stories mounting AppShell need variant fallback | AppShell defaults `variant="full"`; no story changes required. |
+
+  ---
+
+  _Updated by `/shep-kit:new-feature-fast` — task breakdown in tasks.yaml_

--- a/specs/091-apps-only-surface/research.yaml
+++ b/specs/091-apps-only-surface/research.yaml
@@ -1,0 +1,164 @@
+# Research Artifact (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: apps-only-surface
+summary: Technical analysis for 091-apps-only-surface
+
+# Relationships
+relatedFeatures:
+  - "085-electron-desktop-wrapper"
+technologies:
+  - TypeScript
+  - Next.js App Router
+  - React
+  - Electron
+relatedLinks:
+  - title: Next.js route groups
+    url: https://nextjs.org/docs/app/building-your-application/routing/route-groups
+  - title: Electron session.cookies
+    url: https://www.electronjs.org/docs/latest/api/cookies
+
+# Structured technology decisions
+decisions:
+  - title: "Shell variant transport: cookie vs query param vs separate route group"
+    chosen: "HTTP cookie (shep-shell-variant)"
+    rejected:
+      - "Query string ?shell=apps-only (would require every internal link to preserve it)"
+      - "New Next.js route group (apps-only) (route groups inherit root layout so AppShell still applies)"
+      - "New Next.js app workspace (double bundle size, fork maintenance)"
+    rationale: >
+      The root layout (app/layout.tsx) already reads cookies (sidebar
+      state), so cookie-based variant switching is a natural extension.
+      Cookies survive navigation and reload, are server-readable, and
+      let one Electron session.cookies.set call switch the entire
+      shell. Query strings leak into every client-side Link and break
+      on router.push. Route groups in Next.js cannot opt out of the
+      root layout — AppShell is applied unconditionally regardless of
+      (group) membership, so they don't help us here. A second Next.js
+      app would ship a duplicate bundle and fork the maintenance.
+
+  - title: "Chrome toggle strategy: full rewrite vs conditional render"
+    chosen: "Conditional render inside existing AppShell"
+    rejected:
+      - "Two separate shell components with a switch at root"
+      - "Server component split by variant"
+    rationale: >
+      AppShell already composes many subsystems (AgentEventsProvider,
+      DrawerCloseGuardProvider, SidebarFeaturesProvider, etc.). Some of
+      these MUST remain active even in apps-only mode (SSE for
+      applications, deployment status). Keeping one AppShell with a
+      `variant` prop that gates ONLY the visual chrome (sidebar, FAB,
+      chat, canvas) gives us minimal code churn and no risk of
+      divergence between the two surfaces.
+
+  - title: "Route-bounding: server middleware vs client guard"
+    chosen: "Client-side guard (useRouteGuard hook)"
+    rejected:
+      - "Next.js middleware redirect"
+      - "Server component redirect in layout"
+    rationale: >
+      Client-side guard keeps the decision close to the navigation
+      intent — any `router.push` or link click triggers the check and
+      redirects in the same tick. Middleware adds request latency for
+      every request and complicates local dev HMR. Server-side layout
+      redirect would force a full page load on every bounced nav.
+
+  - title: "Electron cookie injection: before vs after loadURL"
+    chosen: "Before loadURL (session.defaultSession.cookies.set)"
+    rejected:
+      - "After loadURL via webContents.executeJavaScript"
+      - "HTTP header injection via webRequest.onBeforeSendHeaders"
+    rationale: >
+      Setting the cookie BEFORE loadURL guarantees the very first
+      render of the page sees the correct variant — no "flash of full
+      shell" before the cookie lands. executeJavaScript races the
+      initial render. webRequest header injection works but is heavier
+      and applies to all requests (we only need the first HTML doc
+      request).
+
+# Open questions (all resolved)
+openQuestions: []
+
+# Markdown content (the full research document)
+content: |
+  ## Status
+
+  - **Phase:** Research
+  - **Updated:** 2026-04-20
+
+  ## Technology Decisions
+
+  ### Shell variant transport
+
+  **Decision:** HTTP cookie (`shep-shell-variant`).
+
+  **Rationale:** the root layout already reads cookies for sidebar
+  state. Adding another cookie is a zero-cost extension. Cookies
+  survive navigation and reload, are server-readable, and a single
+  Electron `session.cookies.set` call switches the whole shell. Query
+  strings leak into internal links and break on `router.push`. Next.js
+  route groups cannot opt out of the root layout, so moving the
+  Applications routes into a `(apps-only)` group would still apply
+  AppShell. A second Next.js app would ship a duplicate bundle.
+
+  ### Chrome toggle strategy
+
+  **Decision:** conditional render inside the existing AppShell, gated
+  by a new `variant` prop.
+
+  **Rationale:** AppShell composes providers that must remain active
+  in apps-only mode (SSE, deployment status). One shell with a prop
+  keeps the providers shared and eliminates the divergence risk of two
+  parallel shells.
+
+  ### Route-bounding
+
+  **Decision:** client-side guard via a `useRouteGuard(variant)` hook
+  that watches `usePathname()` and calls `router.replace('/applications')`
+  on any path outside the allowed list when `variant === 'apps-only'`.
+
+  **Rationale:** client-side decision happens in the same tick as the
+  navigation, no extra network hop, no middleware latency, no full-page
+  reloads. Middleware would add request latency and complicate HMR.
+
+  ### Electron cookie injection
+
+  **Decision:** `session.defaultSession.cookies.set` called BEFORE
+  `loadURL`, gated by the `SHEP_SHELL_VARIANT=apps-only` env var.
+
+  **Rationale:** first render sees the correct variant — no flash of
+  full shell. `executeJavaScript` races the first render;
+  `webRequest.onBeforeSendHeaders` is heavier and runs for every
+  request when we only need the first HTML doc.
+
+  ## Library Analysis
+
+  No new libraries. All infrastructure already exists: Next.js App
+  Router, React cookies (`next/headers`), and Electron
+  `session.defaultSession.cookies` are all already in use.
+
+  ## Security Considerations
+
+  The cookie is non-authoritative — it only controls UI chrome. Even
+  if a user tampers with the cookie to force apps-only mode in the
+  browser, all API endpoints and data access remain unchanged (same
+  DI, same auth, same authorization). The cookie does NOT bypass any
+  security control.
+
+  ## Performance Implications
+
+  - Zero overhead for full-shell users (cookie absent → same code path).
+  - Apps-only mode is actually LIGHTER: we skip mounting the
+    control-center canvas, sidebar, features tree, and FAB — measurable
+    reduction in initial React tree size.
+  - Client-side route guard is O(1) per navigation; no polling, no
+    timers.
+  - Electron cookie set is one async call during startup, imperceptible.
+
+  ## Open Questions
+
+  All resolved.
+
+  ---
+
+  _Updated by `/shep-kit:new-feature-fast` — proceed with plan/tasks_

--- a/specs/091-apps-only-surface/spec.yaml
+++ b/specs/091-apps-only-surface/spec.yaml
@@ -1,0 +1,127 @@
+# Feature Specification (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: apps-only-surface
+number: 091
+branch: feat/091-apps-only-surface
+oneLiner: Slim "Applications only" shell variant — desktop app surface without full chrome
+summary: >
+  Add a cookie-driven shell variant so the existing Next.js web UI can
+  render a focused "Applications only" experience (applications list +
+  application detail: chat, preview, deploy) without the full sidebar
+  chrome, features tree, projects, tools, or global chat FAB. Same
+  server, same API, same DI — only the outer AppShell's chrome
+  changes based on the `shep-shell-variant` cookie. The existing
+  `@shepai/electron` binary can set the cookie via
+  `session.cookies.set` before `loadURL('/applications')` to launch a
+  slim desktop experience without creating a new Electron package.
+  Navigation in apps-only mode is bounded to `/applications` and
+  `/application/[id]` via a client-side route guard that redirects
+  disallowed paths back to `/applications`.
+phase: Requirements
+sizeEstimate: M
+
+# Relationships
+relatedFeatures:
+  - "085-electron-desktop-wrapper"
+  - "089-one-click-cloud-deploy"
+  - "090-application-sse-deltas"
+
+technologies:
+  - TypeScript
+  - Next.js (App Router)
+  - React
+  - Electron (existing @shepai/electron)
+  - HTTP cookies
+
+relatedLinks:
+  - title: Existing AppShell
+    url: src/presentation/web/components/layouts/app-shell/app-shell.tsx
+  - title: Root layout (cookie reader)
+    url: src/presentation/web/app/layout.tsx
+  - title: Electron main
+    url: packages/electron/src/main.ts
+  - title: Applications page
+    url: src/presentation/web/app/applications/page.tsx
+  - title: Application detail page
+    url: src/presentation/web/app/application/[id]/page.tsx
+
+# Open questions (must be resolved before implementation)
+openQuestions: []
+
+# Markdown content (the actual spec)
+content: |
+  ## Problem Statement
+
+  Users who want a focused "desktop app launcher" experience don't need
+  the full Shep chrome (sidebar with features tree, projects, tools,
+  settings, global chat FAB, control-center canvas). They need ONLY the
+  Applications list and the Application detail surface (chat + preview +
+  deploy). Building a separate Electron package that ships a second
+  compiled Next.js app would double the binary size and fork the
+  maintenance surface. Adding a new Next.js route group can't help
+  because the root layout always applies — and that's where AppShell
+  lives.
+
+  The right shape is a cookie-driven **shell variant**: the same server,
+  the same routes, the same DI container, but a different outer chrome
+  when the cookie says so. The existing `@shepai/electron` binary can
+  set that cookie via `session.defaultSession.cookies.set(...)` before
+  `loadURL`, turning a single codebase into two product surfaces
+  depending on how you launch it.
+
+  ## Success Criteria
+
+  - [ ] Visiting any URL with cookie `shep-shell-variant=apps-only`
+        renders a slim shell (no sidebar, no global chat FAB, no
+        control-center canvas, no features tree, no projects nav).
+  - [ ] Visiting `/applications` in apps-only mode renders the existing
+        ApplicationsPageClient identically to the full mode.
+  - [ ] Visiting `/application/[id]` in apps-only mode renders the
+        existing ApplicationPageLoader identically.
+  - [ ] In apps-only mode, client-side navigation to any path OUTSIDE
+        `/applications` or `/application/[id]` is redirected to
+        `/applications`.
+  - [ ] Existing full-shell behavior is unchanged when the cookie is
+        absent or `full`.
+  - [ ] The existing `@shepai/electron` binary gains a startup env flag
+        `SHEP_SHELL_VARIANT=apps-only` that sets the cookie via
+        `session.cookies.set` before `loadURL`, and loads
+        `/applications` directly.
+  - [ ] `pnpm typecheck`, `pnpm lint`, `pnpm test:unit`, and
+        `pnpm build:storybook` all stay clean.
+  - [ ] Unit tests cover (a) AppShell renders slim chrome when variant
+        is apps-only, (b) route guard redirects disallowed paths, (c)
+        root layout reads the cookie correctly.
+
+  ## Affected Areas
+
+  | Area | Impact | Reasoning |
+  | ---- | ------ | --------- |
+  | `src/presentation/web/app/layout.tsx` | Low | Read cookie, pass variant prop to AppShell |
+  | `src/presentation/web/components/layouts/app-shell/app-shell.tsx` | Medium | Accept variant prop, conditionally render chrome |
+  | `src/presentation/web/components/layouts/app-shell/` (new slim subcomponent) | Medium | Wrap apps-only variant chrome (thin top bar, theme toggle) |
+  | `src/presentation/web/hooks/` (new route guard) | Low | Client-side redirect for disallowed paths in apps-only mode |
+  | `packages/electron/src/main.ts` | Low | Honor `SHEP_SHELL_VARIANT` env + set cookie + loadURL path |
+  | `tests/unit/presentation/web/layouts/` | Low | New AppShell variant tests + guard tests |
+
+  ## Dependencies
+
+  - `085-electron-desktop-wrapper` (provides the Electron binary that
+    this feature reuses)
+  - `089-one-click-cloud-deploy` (deploy surface reused in application
+    detail — no changes required)
+  - `090-application-sse-deltas` (real-time UX reused — no changes
+    required)
+
+  ## Size Estimate
+
+  **M** — Single-digit files touched, mostly presentation layer.
+  Core concept (cookie → AppShell branch) is simple; the only
+  non-trivial piece is the client-side route guard and the
+  Electron-side cookie set before `loadURL`. Bounded by the
+  existing AppShell architecture which already reads cookies.
+
+  ---
+
+  _Generated by `/shep-kit:new-feature-fast` — all phases written in one pass_

--- a/specs/091-apps-only-surface/tasks.yaml
+++ b/specs/091-apps-only-surface/tasks.yaml
@@ -1,0 +1,193 @@
+# Task Breakdown (YAML)
+# This is the source of truth. Markdown is auto-generated from this file.
+
+name: apps-only-surface
+summary: Task breakdown for 091-apps-only-surface
+
+# Relationships
+relatedFeatures:
+  - "085-electron-desktop-wrapper"
+technologies:
+  - TypeScript
+  - Next.js
+  - React
+  - Electron
+relatedLinks: []
+
+# Structured task list — this is the single source of truth for tasks.
+# The content field below is a summary only; it does NOT duplicate task details.
+tasks:
+  - id: task-1
+    title: "Add shell-variant helper + cookie constant"
+    description: >
+      Create `src/presentation/web/lib/shell-variant.ts` exporting the
+      `ShellVariant` type (`'full' | 'apps-only'`), the cookie name
+      constant `SHELL_VARIANT_COOKIE = 'shep-shell-variant'`, and a
+      `parseShellVariant(raw: string | undefined): ShellVariant` helper
+      that defaults to `'full'` on unknown / absent values.
+    state: Todo
+    dependencies: []
+    acceptanceCriteria:
+      - "`ShellVariant` type exported"
+      - "`SHELL_VARIANT_COOKIE` constant exported"
+      - "`parseShellVariant` returns 'full' for undefined, empty string, and unknown values"
+      - "`parseShellVariant('apps-only')` returns 'apps-only'"
+    tdd: null
+    estimatedEffort: XS
+
+  - id: task-2
+    title: "Thread variant prop through root layout + AppShell"
+    description: >
+      Modify `src/presentation/web/app/layout.tsx` to read the cookie
+      and call `parseShellVariant`. Pass `variant` as a prop to
+      `<AppShell>`. Extend `AppShellProps` to accept an optional
+      `variant?: ShellVariant` defaulting to `'full'`. No branching
+      logic yet — this task just wires the prop. Visual behavior
+      unchanged.
+    state: Todo
+    dependencies:
+      - task-1
+    acceptanceCriteria:
+      - "Root layout reads `shep-shell-variant` cookie"
+      - "AppShell accepts optional `variant` prop with default 'full'"
+      - "Typecheck + existing tests stay green"
+      - "No visual change with cookie absent or 'full'"
+    tdd: null
+    estimatedEffort: XS
+
+  - id: task-3
+    title: "AppsOnlyShell component + AppShell variant branch (TDD)"
+    description: >
+      Add `src/presentation/web/components/layouts/app-shell/apps-only-shell.tsx`
+      rendering a slim chrome (logo + theme toggle at top, bounded
+      content area). Modify `app-shell.tsx` so that when
+      `variant === 'apps-only'`, it renders `<AppsOnlyShell>{children}</AppsOnlyShell>`
+      INSTEAD OF the full sidebar / FAB / chat / canvas chrome —
+      while keeping ALL providers (AgentEventsProvider, QueryProvider,
+      FeatureFlagsProvider, FabLayoutProvider, I18nProvider, SidebarFeaturesProvider,
+      TurnStatusesProvider, DrawerCloseGuardProvider) mounted above the
+      conditional so real-time updates and deployment status still
+      flow into the applications surface.
+    state: Todo
+    dependencies:
+      - task-2
+    acceptanceCriteria:
+      - "When variant='full' the existing AppShell renders unchanged"
+      - "When variant='apps-only' the AppsOnlyShell renders without sidebar, FAB, chat, or canvas"
+      - "All providers remain mounted in both variants"
+      - "AppsOnlyShell renders children inside a bounded content region"
+    tdd:
+      red:
+        - "Write `tests/unit/presentation/web/layouts/app-shell-variant.test.tsx` rendering `<AppShell variant='apps-only'>{child}</AppShell>` and asserting: no `[data-sidebar]`, no `[data-fab]` or equivalent FAB selector, child is in the DOM, AgentEventsProvider is in the React tree (via a test-only probe component that reads `useOptionalAgentEventsContext`)"
+      green:
+        - "Create AppsOnlyShell; branch inside AppShell on variant after providers"
+      refactor:
+        - "Extract a `FullShell` subcomponent if it makes the conditional cleaner; reuse existing Tailwind classes"
+    estimatedEffort: M
+
+  - id: task-4
+    title: "Apps-only route guard hook (TDD)"
+    description: >
+      Add `src/presentation/web/hooks/use-apps-only-route-guard.ts`
+      exporting `useAppsOnlyRouteGuard(variant: ShellVariant): void`.
+      When variant is `'apps-only'` and `usePathname()` returns a path
+      NOT in the allowed list (`/applications`, `/application/<anything>`),
+      call `router.replace('/applications')`. No-op when variant is
+      `'full'`. Call the hook from inside `AppsOnlyShell`.
+    state: Todo
+    dependencies:
+      - task-3
+    acceptanceCriteria:
+      - "Does nothing when variant === 'full'"
+      - "Does nothing when pathname === '/applications'"
+      - "Does nothing when pathname matches `/application/<id>`"
+      - "Calls `router.replace('/applications')` for `/features`, `/projects`, `/settings`, `/tools`, `/skills`"
+      - "Does NOT call `router.replace` on initial render when pathname is already allowed"
+    tdd:
+      red:
+        - "Write `tests/unit/presentation/web/hooks/use-apps-only-route-guard.test.ts` mocking `next/navigation`'s `useRouter` + `usePathname`; render a harness component that calls the hook; change the pathname via rerender; assert `replace` is called with '/applications' only for disallowed paths"
+      green:
+        - "Implement the hook with a small allowlist array + `useEffect([pathname, variant])`"
+      refactor:
+        - "Export the allowlist array for reuse; consider test-only factory to simplify the harness"
+    estimatedEffort: S
+
+  - id: task-5
+    title: "Electron SHEP_SHELL_VARIANT integration"
+    description: >
+      Modify `packages/electron/src/main.ts` and
+      `packages/electron/src/app.ts` so that when
+      `process.env.SHEP_SHELL_VARIANT === 'apps-only'`, the main
+      process (a) calls `session.defaultSession.cookies.set({ url:
+      \`http://localhost:\${port}\`, name: 'shep-shell-variant', value:
+      'apps-only', path: '/' })` and AWAITS the promise BEFORE
+      `win.loadURL`, and (b) loads `/applications` instead of `/`.
+      Thread a `shellVariant` field through `AppDeps` so the app.ts
+      orchestrator receives the decision from main.ts.
+    state: Todo
+    dependencies:
+      - task-4
+    acceptanceCriteria:
+      - "When SHEP_SHELL_VARIANT is unset or 'full', electron behavior is unchanged"
+      - "When SHEP_SHELL_VARIANT='apps-only', the cookie is set BEFORE loadURL (verified by the order of awaits in the main process flow)"
+      - "When SHEP_SHELL_VARIANT='apps-only', the initial URL loaded is `http://localhost:<port>/applications`"
+      - "pnpm --filter @shepai/electron typecheck passes"
+    tdd: null
+    estimatedEffort: S
+
+  - id: task-6
+    title: "Full verification: lint / typecheck / tests / storybook / electron probe"
+    description: >
+      Run local CI gates and fix anything red: pnpm lint, pnpm typecheck,
+      pnpm test:unit, pnpm build:storybook, pnpm --filter
+      @shepai/electron typecheck. Then run a quick manual probe of
+      apps-only mode in the dev server: curl with
+      `Cookie: shep-shell-variant=apps-only` to `/applications` and
+      verify the response body doesn't contain sidebar markup
+      (`data-sidebar`). Full Electron launch is optional (requires
+      display).
+    state: Todo
+    dependencies:
+      - task-5
+    acceptanceCriteria:
+      - "pnpm lint clean"
+      - "pnpm typecheck clean"
+      - "pnpm test:unit clean (new variant + guard tests green)"
+      - "pnpm build:storybook clean"
+      - "curl with cookie to /applications returns HTML without sidebar markup"
+    tdd: null
+    estimatedEffort: S
+
+# Total effort estimate
+totalEstimate: S-M (~half day)
+
+# Open questions
+openQuestions: []
+
+# Markdown content — summary and acceptance checklist only.
+# Individual task details live in the tasks[] array above (no duplication).
+content: |
+  ## Summary
+
+  Cookie-driven shell variant for an Applications-only desktop-style
+  surface — 6 tasks across 4 phases. TDD required for task-3 (AppShell
+  variant branch) and task-4 (route guard). Plumbing / wiring / Electron
+  tasks carry `tdd: null` and are verified by downstream tests + the
+  manual curl probe in task-6.
+
+  ## Acceptance Checklist
+
+  Before marking feature complete:
+
+  - [ ] All tasks completed
+  - [ ] Tests passing (`pnpm test:unit`)
+  - [ ] Linting clean (`pnpm lint`)
+  - [ ] Types valid (`pnpm typecheck`)
+  - [ ] Storybook builds (`pnpm build:storybook`)
+  - [ ] Electron typecheck (`pnpm --filter @shepai/electron typecheck`)
+  - [ ] Curl probe confirms no sidebar markup when cookie is set
+  - [ ] PR created and reviewed
+
+  ---
+
+  _Task details are in the tasks[] array of tasks.yaml_

--- a/src/presentation/web/app/applications/page.tsx
+++ b/src/presentation/web/app/applications/page.tsx
@@ -2,7 +2,7 @@ import { ApplicationsPageClient } from '@/components/features/applications/appli
 
 export default function ApplicationsPage() {
   return (
-    <div className="flex h-full flex-col overflow-y-auto bg-[#eef0f3] p-6 dark:bg-[#111113]">
+    <div className="flex h-full flex-col overflow-y-auto bg-[#eef0f3] dark:bg-[#111113]">
       <ApplicationsPageClient />
     </div>
   );

--- a/src/presentation/web/app/layout.tsx
+++ b/src/presentation/web/app/layout.tsx
@@ -11,6 +11,7 @@ import { FabLayoutProvider } from '@/hooks/fab-layout-context';
 import { QueryProvider } from '@/components/providers/query-provider';
 import { I18nProvider } from '@/components/providers/i18n-provider';
 import { getLanguagePreference } from '@/lib/language';
+import { SHELL_VARIANT_COOKIE, parseShellVariant } from '@/lib/shell-variant';
 
 /** Force dynamic rendering for all pages since they depend on client-side context. */
 export const dynamic = 'force-dynamic';
@@ -42,6 +43,7 @@ export default async function RootLayout({
 }>) {
   const cookieStore = await cookies();
   const sidebarOpen = cookieStore.get('shep-sidebar-open')?.value === 'true';
+  const shellVariant = parseShellVariant(cookieStore.get(SHELL_VARIANT_COOKIE)?.value);
   const { language, dir } = getLanguagePreference();
 
   return (
@@ -50,16 +52,31 @@ export default async function RootLayout({
         {/* Theme init script — uses only hardcoded string literals, no user input */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var d=document.documentElement,t=localStorage.getItem('shep-theme'),s=window.matchMedia('(prefers-color-scheme: dark)').matches;if(t==='dark'||(t==='system'&&s)||(!t&&s)){d.classList.add('dark')}}catch(e){}})();`,
+            __html:
+              shellVariant === 'apps-only'
+                ? `(function(){try{var d=document.documentElement,t=localStorage.getItem('shep-theme');if(t==='dark'){d.classList.add('dark')}}catch(e){}})();`
+                : `(function(){try{var d=document.documentElement,t=localStorage.getItem('shep-theme'),s=window.matchMedia('(prefers-color-scheme: dark)').matches;if(t==='dark'||(t==='system'&&s)||(!t&&s)){d.classList.add('dark')}}catch(e){}})();`,
           }}
         />
       </head>
-      <body className="min-h-screen antialiased">
+      <body
+        className={
+          shellVariant === 'apps-only'
+            ? // Transparent body so the AppsOnlyShell's rounded wrapper
+              // clips the visible surface. The Electron window itself is
+              // transparent — the rounded corners let the OS compositor
+              // blend the desktop behind the corner cut-outs.
+              'h-screen overflow-hidden bg-transparent antialiased'
+            : 'min-h-screen antialiased'
+        }
+      >
         <I18nProvider initialLanguage={language}>
           <QueryProvider>
             <FeatureFlagsProvider flags={getFeatureFlags()}>
               <FabLayoutProvider layout={getFabLayout()}>
-                <AppShell sidebarOpen={sidebarOpen}>{children}</AppShell>
+                <AppShell sidebarOpen={sidebarOpen} variant={shellVariant}>
+                  {children}
+                </AppShell>
               </FabLayoutProvider>
             </FeatureFlagsProvider>
           </QueryProvider>

--- a/src/presentation/web/components/features/application-page/application-page.tsx
+++ b/src/presentation/web/components/features/application-page/application-page.tsx
@@ -122,7 +122,11 @@ export function ApplicationPage({ application, initialChatState }: ApplicationPa
       : null;
 
   return (
-    <div className="bg-background flex h-dvh flex-col">
+    // `h-full` (not `h-dvh`) so the page fills its shell's main area
+    // exactly — in the apps-only surface the main is `viewport - topbar`,
+    // and `h-dvh` would make this 40px taller than its container and
+    // trigger an outer scrollbar over the whole window.
+    <div className="bg-background flex h-full flex-col">
       <AppTopBar
         application={application}
         activeView={activeView}

--- a/src/presentation/web/components/features/applications/applications-page-client.tsx
+++ b/src/presentation/web/components/features/applications/applications-page-client.tsx
@@ -46,59 +46,71 @@ export function ApplicationsPageClient({ className }: ApplicationsPageClientProp
 
   return (
     <DeploymentStatusProvider initialDeployments={[]}>
-      <div data-testid="applications-page-client" className={cn('relative space-y-4', className)}>
-        {/* Compact header */}
-        <div className="flex items-center gap-2">
-          <LayoutGrid className="text-muted-foreground h-4 w-4" />
-          <h1 className="text-sm font-bold tracking-tight">Applications</h1>
-          {!isLoading ? (
-            <span className="text-muted-foreground text-[10px]">
-              {applications.length} {applications.length === 1 ? 'app' : 'apps'}
-            </span>
-          ) : null}
+      <div
+        data-testid="applications-page-client"
+        className={cn('relative flex min-h-full flex-col', className)}
+      >
+        {/* Content sits inside padding; the create-prompt overlay sits
+            OUTSIDE this inner padded div so it can cover edge-to-edge. */}
+        <div className="flex flex-1 flex-col gap-4 p-6">
+          {/* Compact header */}
+          <div className="flex items-center gap-2">
+            <LayoutGrid className="text-muted-foreground h-4 w-4" />
+            <h1 className="text-sm font-bold tracking-tight">Applications</h1>
+            {!isLoading ? (
+              <span className="text-muted-foreground text-[10px]">
+                {applications.length} {applications.length === 1 ? 'app' : 'apps'}
+              </span>
+            ) : null}
+          </div>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+            </div>
+          ) : (
+            <div
+              data-testid="applications-page-grid"
+              className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+            >
+              {/* New application placeholder card — always FIRST so the
+                  user can click immediately without scanning past their apps. */}
+              <NewApplicationCard
+                onDescribe={() => setShowCreatePrompt(true)}
+                onOpenLocalDirectory={async () => {
+                  const { pickFolder } = await import(
+                    '@/components/common/add-repository-button/pick-folder'
+                  );
+                  const path = await pickFolder();
+                  if (!path) return;
+                  const { adoptLocalDirectory } = await import(
+                    '@/app/actions/adopt-local-directory'
+                  );
+                  const result = await adoptLocalDirectory({ repositoryPath: path });
+                  if (result.applicationId) {
+                    router.push(`/application/${result.applicationId}`);
+                  }
+                }}
+                onImportGitHub={
+                  featureFlags.githubImport
+                    ? () => window.dispatchEvent(new CustomEvent('shep:open-github-import'))
+                    : undefined
+                }
+              />
+
+              {sorted.map((app) => (
+                <ApplicationCard key={app.id} application={app} />
+              ))}
+            </div>
+          )}
         </div>
 
-        {isLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
-          </div>
-        ) : (
-          <div
-            data-testid="applications-page-grid"
-            className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
-          >
-            {/* New application placeholder card — always FIRST so the
-                user can click immediately without scanning past their apps. */}
-            <NewApplicationCard
-              onDescribe={() => setShowCreatePrompt(true)}
-              onOpenLocalDirectory={async () => {
-                const { pickFolder } = await import(
-                  '@/components/common/add-repository-button/pick-folder'
-                );
-                const path = await pickFolder();
-                if (!path) return;
-                const { adoptLocalDirectory } = await import('@/app/actions/adopt-local-directory');
-                const result = await adoptLocalDirectory({ repositoryPath: path });
-                if (result.applicationId) {
-                  router.push(`/application/${result.applicationId}`);
-                }
-              }}
-              onImportGitHub={
-                featureFlags.githubImport
-                  ? () => window.dispatchEvent(new CustomEvent('shep:open-github-import'))
-                  : undefined
-              }
-            />
-
-            {sorted.map((app) => (
-              <ApplicationCard key={app.id} application={app} />
-            ))}
-          </div>
-        )}
-
-        {/* Full-screen create prompt overlay */}
+        {/* Edge-to-edge create-prompt overlay. `absolute` (not `fixed`)
+            so it stays contained within the page's relative root and
+            never covers the AppsOnlyShell top bar. Sibling of the padded
+            content div so it ignores the list's `p-6`. */}
         {showCreatePrompt ? (
-          <div className="fixed inset-0 z-50">
+          <div className="absolute inset-0 z-40">
             <ControlCenterEmptyState
               onApplicationCreated={(appId) => {
                 router.push(`/application/${appId}`);

--- a/src/presentation/web/components/layouts/app-shell/app-shell.tsx
+++ b/src/presentation/web/components/layouts/app-shell/app-shell.tsx
@@ -21,14 +21,22 @@ import { TurnStatusesProvider } from '@/hooks/turn-statuses-provider';
 
 import { useNotifications } from '@/hooks/use-notifications';
 import { useFeatureFlags } from '@/hooks/feature-flags-context';
+import type { ShellVariant } from '@/lib/shell-variant';
+import { AppsOnlyShell } from './apps-only-shell';
 
 interface AppShellProps {
   children: ReactNode;
   /** Server-read sidebar state from cookie. */
   sidebarOpen?: boolean;
+  /**
+   * Outer-chrome variant. `full` (default) renders the existing sidebar
+   * + FAB + canvas chrome. `apps-only` renders a slim shell with just a
+   * top bar — see spec 091-apps-only-surface.
+   */
+  variant?: ShellVariant;
 }
 
-function AppShellInner({ children, sidebarOpen }: AppShellProps) {
+function AppShellInner({ children, sidebarOpen, variant = 'full' }: AppShellProps) {
   const router = useRouter();
   const pathname = usePathname();
   const { guardedNavigate } = useDrawerCloseGuard();
@@ -120,6 +128,10 @@ function AppShellInner({ children, sidebarOpen }: AppShellProps) {
     }
   }, []);
 
+  if (variant === 'apps-only') {
+    return <AppsOnlyShell>{children}</AppsOnlyShell>;
+  }
+
   return (
     <SidebarProvider defaultOpen={sidebarOpen ?? false}>
       <AppSidebar
@@ -162,7 +174,7 @@ function TurnStatusesBridge({ children }: { children: ReactNode }) {
   return <TurnStatusesProvider>{children}</TurnStatusesProvider>;
 }
 
-export function AppShell({ children, sidebarOpen }: AppShellProps) {
+export function AppShell({ children, sidebarOpen, variant = 'full' }: AppShellProps) {
   const { i18n } = useTranslation();
   const dir = i18n.dir();
 
@@ -172,7 +184,9 @@ export function AppShell({ children, sidebarOpen }: AppShellProps) {
         <DrawerCloseGuardProvider>
           <SidebarFeaturesProvider>
             <TurnStatusesBridge>
-              <AppShellInner sidebarOpen={sidebarOpen}>{children}</AppShellInner>
+              <AppShellInner sidebarOpen={sidebarOpen} variant={variant}>
+                {children}
+              </AppShellInner>
             </TurnStatusesBridge>
           </SidebarFeaturesProvider>
         </DrawerCloseGuardProvider>

--- a/src/presentation/web/components/layouts/app-shell/apps-only-shell.tsx
+++ b/src/presentation/web/components/layouts/app-shell/apps-only-shell.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useEffect, useState, type CSSProperties, type ReactNode } from 'react';
+import Link from 'next/link';
+import { Copy, Minus, Square, X } from 'lucide-react';
+import { ShepLogo } from '@/components/common/shep-logo';
+import { ThemeToggle } from '@/components/common/theme-toggle';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useAppsOnlyRouteGuard } from '@/hooks/use-apps-only-route-guard';
+import { cn } from '@/lib/utils';
+
+interface AppsOnlyShellProps {
+  children: ReactNode;
+}
+
+/**
+ * Electron honors `-webkit-app-region` on the renderer to make the
+ * frameless window move when the user drags the header; interactive
+ * controls inside the draggable region need the inverse (`no-drag`)
+ * or the click gets swallowed by the move handler.
+ *
+ * `-webkit-app-region` is NOT inherited by default. It must be set on
+ * every interactive element explicitly — setting it only on the
+ * enclosing div let the compositor silently claim clicks on our
+ * buttons. The fix is: drag on the <header>, no-drag on the buttons.
+ */
+const DRAG_REGION: CSSProperties = { WebkitAppRegion: 'drag' } as CSSProperties;
+const NO_DRAG_REGION: CSSProperties = { WebkitAppRegion: 'no-drag' } as CSSProperties;
+
+interface ShepWindowControls {
+  minimize?: () => void;
+  maximizeToggle?: () => void;
+  close?: () => void;
+  onMaximizedChange?: (cb: (isMaximized: boolean) => void) => void;
+}
+
+function readWindowControls(): ShepWindowControls | null {
+  if (typeof window === 'undefined') return null;
+  const bridge = (window as unknown as { shepElectron?: { windowControls?: ShepWindowControls } })
+    .shepElectron;
+  return bridge?.windowControls ?? null;
+}
+
+export function AppsOnlyShell({ children }: AppsOnlyShellProps) {
+  useAppsOnlyRouteGuard('apps-only');
+
+  const [controls, setControls] = useState<ShepWindowControls | null>(null);
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    const c = readWindowControls();
+    setControls(c);
+    c?.onMaximizedChange?.((v) => setIsMaximized(v));
+  }, []);
+
+  return (
+    <TooltipProvider>
+      <div
+        className={cn(
+          'bg-background text-foreground relative flex h-screen flex-col overflow-hidden',
+          'rounded-xl border shadow-xl'
+        )}
+      >
+        <header
+          className={cn(
+            'relative z-20 flex h-10 shrink-0 items-center gap-3 border-b px-3 select-none',
+            'bg-background/80 supports-[backdrop-filter]:bg-background/60 backdrop-blur'
+          )}
+          style={DRAG_REGION}
+          onDoubleClick={() => controls?.maximizeToggle?.()}
+        >
+          <Link
+            href="/applications"
+            aria-label="Applications"
+            className="group flex items-center gap-2 rounded px-1 py-0.5 outline-none"
+            style={NO_DRAG_REGION}
+          >
+            <ShepLogo size={16} className="opacity-90 transition-opacity group-hover:opacity-100" />
+            <span className="flex items-baseline gap-1 text-[12.5px] font-semibold tracking-tight">
+              <span className="text-foreground">shep</span>
+              <span className="text-muted-foreground font-normal">·</span>
+              <span className="text-muted-foreground font-normal">ui</span>
+            </span>
+          </Link>
+
+          <div className="flex-1" aria-hidden />
+
+          {/* Every interactive element inside the draggable header
+              MUST set `no-drag` on itself — the property doesn't
+              inherit, so setting it only on the parent lets the
+              compositor steal clicks on children. */}
+          <div className="flex items-center gap-1" style={NO_DRAG_REGION}>
+            <div style={NO_DRAG_REGION}>
+              <ThemeToggle />
+            </div>
+            <div className="bg-border/70 mx-1 h-4 w-px" aria-hidden />
+            <WindowButton
+              label="Minimize"
+              onClick={() => controls?.minimize?.()}
+              icon={<Minus className="size-3" strokeWidth={2.25} />}
+            />
+            <WindowButton
+              label={isMaximized ? 'Restore' : 'Maximize'}
+              onClick={() => controls?.maximizeToggle?.()}
+              icon={
+                isMaximized ? (
+                  <Copy className="size-3 -rotate-90" strokeWidth={2.25} />
+                ) : (
+                  <Square className="size-[10px]" strokeWidth={2.25} />
+                )
+              }
+            />
+            <WindowButton
+              label="Close"
+              onClick={() => controls?.close?.()}
+              icon={<X className="size-3.5" strokeWidth={2.25} />}
+              variant="danger"
+            />
+          </div>
+        </header>
+        <main className="min-h-0 flex-1 overflow-y-auto">{children}</main>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * Small, sleek window-control button. Explicit `-webkit-app-region:
+ * no-drag` on the button element is required — without it the
+ * draggable header absorbs the click on Linux/Chromium frameless
+ * windows, which is why clicks silently did nothing despite the IPC
+ * chain being fully wired.
+ */
+function WindowButton({
+  label,
+  onClick,
+  icon,
+  variant = 'default',
+}: {
+  label: string;
+  onClick: () => void;
+  icon: ReactNode;
+  variant?: 'default' | 'danger';
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      style={NO_DRAG_REGION}
+      className={cn(
+        'text-muted-foreground inline-flex h-6 w-6 items-center justify-center rounded transition-colors duration-150 ease-out',
+        'hover:text-foreground active:scale-[0.95]',
+        variant === 'danger'
+          ? 'hover:bg-destructive hover:text-destructive-foreground'
+          : 'hover:bg-muted'
+      )}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/presentation/web/components/layouts/app-shell/index.ts
+++ b/src/presentation/web/components/layouts/app-shell/index.ts
@@ -1,1 +1,2 @@
 export { AppShell } from './app-shell';
+export { AppsOnlyShell } from './apps-only-shell';

--- a/src/presentation/web/hooks/use-apps-only-route-guard.ts
+++ b/src/presentation/web/hooks/use-apps-only-route-guard.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+
+import type { ShellVariant } from '@/lib/shell-variant';
+
+/**
+ * Allowed URL prefixes in apps-only mode. Anything outside this list
+ * is bounced to /applications on the next client-side navigation.
+ * Exported for reuse (e.g., a sibling link-guard component).
+ */
+export const APPS_ONLY_ALLOWED_PATHS = ['/applications', '/application/'] as const;
+export const APPS_ONLY_FALLBACK_PATH = '/applications';
+
+function isAllowed(pathname: string): boolean {
+  if (pathname === '/applications') return true;
+  if (pathname.startsWith('/application/')) return true;
+  return false;
+}
+
+/**
+ * Client-side route guard for apps-only mode. No-op when variant='full'.
+ * When variant='apps-only', redirects any path outside the allowed list
+ * back to /applications via router.replace on pathname change.
+ */
+export function useAppsOnlyRouteGuard(variant: ShellVariant): void {
+  const pathname = usePathname();
+  const router = useRouter();
+  useEffect(() => {
+    if (variant !== 'apps-only') return;
+    if (!pathname) return;
+    if (isAllowed(pathname)) return;
+    router.replace(APPS_ONLY_FALLBACK_PATH);
+  }, [variant, pathname, router]);
+}

--- a/src/presentation/web/lib/shell-variant.ts
+++ b/src/presentation/web/lib/shell-variant.ts
@@ -1,0 +1,30 @@
+/**
+ * Shell variant — controls which outer chrome the web UI renders.
+ *
+ * - `full` (default)   → existing AppShell with sidebar, FAB, global chat,
+ *                        control-center canvas, and every provider.
+ * - `apps-only`        → slim AppsOnlyShell with just a thin top bar and
+ *                        the applications surface. Providers stay mounted
+ *                        so real-time SSE and deployment status keep
+ *                        flowing; only the visual chrome is skipped.
+ *
+ * Transport: HTTP cookie `shep-shell-variant`. The root layout reads it
+ * server-side and passes the parsed value down as a prop; Electron sets
+ * it via `session.defaultSession.cookies.set(...)` before `loadURL` when
+ * launching in apps-only mode. See spec 091-apps-only-surface.
+ */
+
+export type ShellVariant = 'full' | 'apps-only';
+
+export const SHELL_VARIANT_COOKIE = 'shep-shell-variant';
+
+export const DEFAULT_SHELL_VARIANT: ShellVariant = 'full';
+
+/**
+ * Parse the raw cookie value into a `ShellVariant`. Unknown values and
+ * absent cookies fall back to `full` so existing users never see a
+ * regression when a new variant lands.
+ */
+export function parseShellVariant(raw: string | undefined): ShellVariant {
+  return raw === 'apps-only' ? 'apps-only' : DEFAULT_SHELL_VARIANT;
+}

--- a/tests/unit/electron/ipc/channels.test.ts
+++ b/tests/unit/electron/ipc/channels.test.ts
@@ -9,6 +9,9 @@ function createMockWindow() {
   return {
     minimize: vi.fn(),
     hide: vi.fn(),
+    maximize: vi.fn(),
+    unmaximize: vi.fn(),
+    isMaximized: vi.fn(() => false),
   };
 }
 

--- a/tests/unit/electron/main.test.ts
+++ b/tests/unit/electron/main.test.ts
@@ -103,6 +103,9 @@ function createMockWindow(): AppBrowserWindow & {
     hide: vi.fn(),
     close: vi.fn(),
     minimize: vi.fn(),
+    maximize: vi.fn(),
+    unmaximize: vi.fn(),
+    isMaximized: vi.fn(() => false),
     isDestroyed: vi.fn(() => false),
     isMinimized: vi.fn(() => false),
     restore: vi.fn(),
@@ -353,7 +356,9 @@ describe('createMainWindow', () => {
   it('loads localhost URL with the given port', () => {
     const { MockBW, instances } = createMockBrowserWindowClass();
     createMainWindow(MockBW, mockWindowState, 3456, '/mock/preload.js', makeState());
-    expect(instances[0].loadURL).toHaveBeenCalledWith('http://localhost:3456');
+    // `createMainWindow` appends the initialPath (default `/`) to the URL
+    // so the full URL is `http://localhost:3456/`.
+    expect(instances[0].loadURL).toHaveBeenCalledWith('http://localhost:3456/');
   });
 
   it('hides window on close when not quitting', () => {
@@ -535,7 +540,9 @@ describe('startApp', () => {
   it('loads localhost URL with discovered port', async () => {
     const { deps, bwInstances } = createMockDeps();
     await startApp(deps);
-    expect(bwInstances[1].loadURL).toHaveBeenCalledWith('http://localhost:3456');
+    // Default initialPath is `/`, so the resulting URL includes the slash.
+    // In apps-only mode this becomes `/applications`; covered separately.
+    expect(bwInstances[1].loadURL).toHaveBeenCalledWith('http://localhost:3456/');
   });
 
   it('registers before-quit handler that sets isQuitting', async () => {

--- a/tests/unit/infrastructure/services/scaffolding/template-overlay.test.ts
+++ b/tests/unit/infrastructure/services/scaffolding/template-overlay.test.ts
@@ -26,8 +26,8 @@ describe('applyTemplateOverlay', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('copies the fat template into an empty project root', () => {
-    const result = applyTemplateOverlay(root);
+  it('copies the fat template into an empty project root', async () => {
+    const result = await applyTemplateOverlay(root);
 
     // Sanity check a representative file from each layer of the template:
     //  - docs
@@ -52,19 +52,19 @@ describe('applyTemplateOverlay', () => {
     expect(result.templateFiles).toContain(join('src', 'lib', 'theme.ts'));
   });
 
-  it('overwrites a pre-existing file at the destination (template wins)', () => {
+  it('overwrites a pre-existing file at the destination (template wins)', async () => {
     // Pretend shadcn init wrote a stub TEMPLATE.md already — our
     // template version must replace it.
     writeFileSync(join(root, 'TEMPLATE.md'), 'STUB FROM SHADCN');
 
-    applyTemplateOverlay(root);
+    await applyTemplateOverlay(root);
 
     const content = readFileSync(join(root, 'TEMPLATE.md'), 'utf-8');
     expect(content).not.toBe('STUB FROM SHADCN');
     expect(content).toContain('Shep template cheat sheet');
   });
 
-  it('preserves files that live OUTSIDE the template tree', () => {
+  it('preserves files that live OUTSIDE the template tree', async () => {
     // Simulate shadcn output: package.json, vite.config.ts, src/main.tsx.
     // The overlay must not touch these.
     mkdirSync(join(root, 'src'));
@@ -72,7 +72,7 @@ describe('applyTemplateOverlay', () => {
     writeFileSync(join(root, 'vite.config.ts'), 'export default {}');
     writeFileSync(join(root, 'src', 'main.tsx'), 'console.log("hi")');
 
-    applyTemplateOverlay(root);
+    await applyTemplateOverlay(root);
 
     // Untouched by the overlay:
     expect(readFileSync(join(root, 'package.json'), 'utf-8')).toBe('{"name":"user-app"}');

--- a/tests/unit/presentation/web/hooks/use-apps-only-route-guard.test.ts
+++ b/tests/unit/presentation/web/hooks/use-apps-only-route-guard.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const mockReplace = vi.fn();
+const mockPathname = vi.fn((): string | null => '/applications');
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+  }),
+  usePathname: () => mockPathname(),
+}));
+
+const { useAppsOnlyRouteGuard } = await import(
+  '../../../../../src/presentation/web/hooks/use-apps-only-route-guard.js'
+);
+
+describe('useAppsOnlyRouteGuard', () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    mockPathname.mockReset();
+    mockPathname.mockReturnValue('/applications');
+  });
+
+  describe('variant=full (no-op)', () => {
+    it('does not redirect when on /applications', () => {
+      mockPathname.mockReturnValue('/applications');
+      renderHook(() => useAppsOnlyRouteGuard('full'));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when on /features (normally disallowed)', () => {
+      mockPathname.mockReturnValue('/features');
+      renderHook(() => useAppsOnlyRouteGuard('full'));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when on /settings', () => {
+      mockPathname.mockReturnValue('/settings');
+      renderHook(() => useAppsOnlyRouteGuard('full'));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('variant=apps-only (allowed paths)', () => {
+    it('does not redirect when on /applications', () => {
+      mockPathname.mockReturnValue('/applications');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when on /application/foo-123 (detail page)', () => {
+      mockPathname.mockReturnValue('/application/foo-123');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when pathname has trailing slash /application/', () => {
+      mockPathname.mockReturnValue('/application/');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('variant=apps-only (disallowed paths)', () => {
+    it('redirects from /features to /applications', () => {
+      mockPathname.mockReturnValue('/features');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      expect(mockReplace).toHaveBeenCalledWith('/applications');
+    });
+
+    it('redirects from /projects to /applications', () => {
+      mockPathname.mockReturnValue('/projects');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledWith('/applications');
+    });
+
+    it('redirects from /settings to /applications', () => {
+      mockPathname.mockReturnValue('/settings');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledWith('/applications');
+    });
+
+    it('redirects from /tools to /applications', () => {
+      mockPathname.mockReturnValue('/tools');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledWith('/applications');
+    });
+
+    it('redirects from /skills to /applications', () => {
+      mockPathname.mockReturnValue('/skills');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledWith('/applications');
+    });
+
+    it('redirects from / (root) to /applications', () => {
+      mockPathname.mockReturnValue('/');
+      renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledWith('/applications');
+    });
+  });
+
+  describe('rerender behavior', () => {
+    it('calls replace again when pathname changes to another disallowed path', () => {
+      mockPathname.mockReturnValue('/features');
+      const { rerender } = renderHook(() => useAppsOnlyRouteGuard('apps-only'));
+      expect(mockReplace).toHaveBeenCalledTimes(1);
+      expect(mockReplace).toHaveBeenLastCalledWith('/applications');
+
+      mockPathname.mockReturnValue('/settings');
+      rerender();
+      expect(mockReplace).toHaveBeenCalledTimes(2);
+      expect(mockReplace).toHaveBeenLastCalledWith('/applications');
+    });
+  });
+});

--- a/tests/unit/presentation/web/layouts/app-shell-variant.test.tsx
+++ b/tests/unit/presentation/web/layouts/app-shell-variant.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+let mockPathname = '/applications';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: mockPush, replace: mockReplace, refresh: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-turn-statuses', () => ({
+  useAllTurnStatuses: () => ({}),
+}));
+
+import { AppShell } from '@/components/layouts/app-shell';
+import { FeatureFlagsProvider } from '@/hooks/feature-flags-context';
+import { useOptionalAgentEventsContext } from '@/hooks/agent-events-provider';
+
+const defaultFlags = {
+  skills: false,
+  envDeploy: false,
+  debug: false,
+  githubImport: false,
+  adoptBranch: false,
+  gitRebaseSync: false,
+  reactFileManager: false,
+  inventory: false,
+  projects: false,
+};
+
+/**
+ * Test-only probe that reads the AgentEventsContext. If a provider is
+ * mounted above it (which is what we're verifying), the context value
+ * will be non-null and the probe renders a marker element.
+ */
+function AgentEventsProbe() {
+  const ctx = useOptionalAgentEventsContext();
+  return (
+    <div data-testid="agent-events-probe" data-has-context={ctx !== null ? 'yes' : 'no'}>
+      probe
+    </div>
+  );
+}
+
+describe('AppShell variant', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockPathname = '/applications';
+  });
+
+  describe("variant='full' (default)", () => {
+    it('renders sidebar markup (data-sidebar attribute present)', () => {
+      const { container } = render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell>
+            <div data-testid="child-marker">content</div>
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+
+      const sidebarEl = container.querySelector('[data-sidebar]');
+      expect(sidebarEl).not.toBeNull();
+    });
+
+    it('renders children', () => {
+      render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell>
+            <div data-testid="child-marker">content</div>
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      expect(screen.getByTestId('child-marker')).toBeInTheDocument();
+    });
+
+    it('mounts AgentEventsProvider (probe reads non-null context)', () => {
+      render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell>
+            <AgentEventsProbe />
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      const probe = screen.getByTestId('agent-events-probe');
+      expect(probe.getAttribute('data-has-context')).toBe('yes');
+    });
+  });
+
+  describe("variant='apps-only'", () => {
+    it('renders WITHOUT sidebar markup', () => {
+      const { container } = render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell variant="apps-only">
+            <div data-testid="child-marker">content</div>
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      const sidebarEl = container.querySelector('[data-sidebar]');
+      expect(sidebarEl).toBeNull();
+    });
+
+    it('renders WITHOUT the global chat FAB', () => {
+      render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell variant="apps-only">
+            <div data-testid="child-marker">content</div>
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      // GlobalChatPopup exposes a "Shep Chat" tooltip/label.
+      expect(screen.queryByText('Shep Chat')).not.toBeInTheDocument();
+    });
+
+    it('renders WITHOUT the control-center canvas / global search dialog', () => {
+      const { container } = render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell variant="apps-only">
+            <div data-testid="child-marker">content</div>
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      // GlobalSearchDialog renders a Radix Dialog with role="dialog" when
+      // open, but its trigger/placeholder remains in the DOM via a hidden
+      // command palette input with placeholder text.
+      expect(screen.queryByPlaceholderText(/search/i)).not.toBeInTheDocument();
+      // Canvas panels from control-center aren't rendered either.
+      expect(container.querySelector('.react-flow')).toBeNull();
+    });
+
+    it('renders children', () => {
+      render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell variant="apps-only">
+            <div data-testid="child-marker">content</div>
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      expect(screen.getByTestId('child-marker')).toBeInTheDocument();
+    });
+
+    it('mounts AgentEventsProvider (probe reads non-null context)', () => {
+      render(
+        <FeatureFlagsProvider flags={defaultFlags}>
+          <AppShell variant="apps-only">
+            <AgentEventsProbe />
+          </AppShell>
+        </FeatureFlagsProvider>
+      );
+      const probe = screen.getByTestId('agent-events-probe');
+      expect(probe.getAttribute('data-has-context')).toBe('yes');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Ships **spec 091 — apps-only-surface**: a focused "Applications only" desktop experience via the existing `@shepai/electron` binary. Same server, same API, same DI — only the outer shell's chrome changes based on the `shep-shell-variant` cookie.

- Cookie-driven shell variant (`shep-shell-variant=apps-only`) selects a slim `AppsOnlyShell` instead of the full sidebar chrome; parsing centralized in `lib/shell-variant.ts`.
- Frameless, rounded, transparent Electron window with custom top bar (`shep·ui` wordmark, theme toggle, minimize, maximize/restore, close). Window controls ride a typed IPC bridge (`shep:minimize`, `shep:maximize-toggle`, `shep:close`, `shep:window-maximized-changed`, `shep:get-version`) exposed via preload `contextBridge`.
- Client-side route guard (`useAppsOnlyRouteGuard`) bounds navigation to `/applications` and `/application/[id]`; any other path redirects to `/applications`.
- Preload converted to CJS + synchronous `require('electron')` so the bridge attaches at `document_start` and survives sandbox/frameless configs that silently broke the ESM preload.
- Main-process bundle fixes: esbuild emits CJS with a banner that defines `import.meta.url` for bundled `@shepai/core` modules using `fileURLToPath`; migrations pre-compiled to `dist/migrations/*.js` with a directory-local `{"type":"commonjs"}` override so Umzug finds them on a fresh `SHEP_HOME`; scaffolding templates copied to `dist/templates/` and resolved by a multi-candidate path finder (env override + three well-known layouts).
- Async template overlay: `applyTemplateOverlay` + `walkAndCopy` converted to `fs/promises` so libuv offloads recursive I/O — Electron main no longer blocks during scaffolding, eliminating the OS "not responding" watchdog.
- Applications list overlay fix: New-application prompt is `absolute` inside a padding-free sibling wrapper so it covers the grid edge-to-edge without ever escaping the shell and hiding the top bar.
- Application detail sizing: `h-dvh` → `h-full` so the page fits inside the apps-only shell (viewport − 40 px top bar) instead of forcing an outer scrollbar.
- Launch shortcut: `pnpm apps:dev` (`cross-env ELECTRON_RUN_AS_NODE= SHEP_SHELL_VARIANT=apps-only pnpm --filter @shepai/electron dev`).

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 6625/6625 passing (including new apps-only-shell variant + route guard tests and updated electron IPC/main tests)
- [x] `pnpm test:int` — 763/763 passing
- [x] `pnpm build` — CLI + web build green
- [x] Electron bundle rebuild (`pnpm electron:compile`) green
- [x] Manual smoke in `pnpm apps:dev` on a fresh `SHEP_HOME`: Applications list renders, New Application prompt covers edge-to-edge without hiding top bar, create-application flow completes without the scaffolding `workflow_steps` migration error and without main-thread freeze, window controls (minimize/maximize/close) all work, navigation outside `/apps-only/*` rejects.

Related: spec artifacts under `specs/091-apps-only-surface/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)