### PR TITLE
fix(web): add code-review flag to app-shell test fixtures

### DIFF
--- a/tests/unit/presentation/web/layouts/app-shell-variant.test.tsx
+++ b/tests/unit/presentation/web/layouts/app-shell-variant.test.tsx
@@ -29,6 +29,7 @@ const defaultFlags = {
   reactFileManager: false,
   inventory: false,
   projects: false,
+  codeReview: false,
 };
 
 /**


### PR DESCRIPTION
## Summary
- `FeatureFlagsState` gained a `codeReview` field in #568 but the `defaultFlags` fixture in `tests/unit/presentation/web/layouts/app-shell-variant.test.tsx` was not updated, producing 8 `TS2741` errors on main and breaking the [typecheck job](https://github.com/shep-ai/shep/actions/runs/24961710198/job/73089516903).
- Adds `codeReview: false` to the test fixture to match the type. Mirrors the fix already applied in the sibling `app-shell.test.tsx` file.

## Test plan
- [x] `pnpm typecheck` passes locally
- [x] `pnpm vitest run tests/unit/presentation/web/layouts/app-shell-variant.test.tsx` — 8/8 pass
- [x] `pnpm lint` on the changed file passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)