### PR TITLE
fix(agents): kill claude subprocess if it hangs after result event

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -324,3 +324,10 @@ When the user asks to restore "the original" or "the version we had before", che
 
 **How this came up:** A user asked to restore the "original getting started" in the control center. The first attempt restored the prompt version (recent), but the user clarified there was an even older version. Always trace the file back through `git log --follow --oneline` and look at the version BEFORE the major UX rewrites (e.g. commits with "replace onboarding with prompt-first experience").
 
+
+## Subprocess Executor Must Not Trust Natural Exit After `[result]`
+
+The `claude` CLI emits a final `result` event over stream-json and is supposed to tear down its MCP servers and exit — but in practice it can hang for hours. Confirmed offenders, all spawned by the agent itself: `npm exec @playwright/mcp`, `npm exec @upstash/context7-mcp`, `typescript-language-server --stdio`, and any backgrounded `pnpm dev:web` / shell the agent forgot to kill. They keep stdio open and the parent claude process never closes. A worker that resolves only on `proc.on('close')` then sleeps forever — feature 92701aa8 was stuck `fast-implement` for 3+ hours after the agent had finished, committed, and pushed.
+
+**Rule:** any executor that depends on a subprocess emitting a final event must enforce a grace timer once that event is observed and SIGKILL the subprocess if it fails to exit. Don't trust the child to clean up its own children. Implemented in `claude-code-executor.service.ts` via `RESULT_TO_CLOSE_GRACE_MS = 30_000`: after seeing `type: 'result'` in stream-json, schedule a SIGKILL; the existing `proc.on('close')` handler then resolves with the already-captured result data.
+

--- a/packages/core/src/infrastructure/services/agents/common/executors/claude-code-executor.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/executors/claude-code-executor.service.ts
@@ -31,6 +31,17 @@ const SUPPORTED_FEATURES = new Set<string>([
 ]);
 
 /**
+ * Maximum time to wait for the `claude` subprocess to exit on its own
+ * after it has emitted its final `result` event. The CLI is supposed to
+ * tear down its MCP servers and exit, but in practice it can hang
+ * indefinitely if MCP children (e.g. Playwright) or background bash tools
+ * (e.g. `pnpm dev:web`) keep stdio open. After this grace period we send
+ * SIGKILL so the close handler fires and execute() resolves with the
+ * captured result instead of leaving the worker stuck for hours.
+ */
+const RESULT_TO_CLOSE_GRACE_MS = 30_000;
+
+/**
  * Executor service for Claude Code agent.
  * Uses subprocess spawning to interact with the `claude` CLI.
  */
@@ -78,6 +89,7 @@ export class ClaudeCodeExecutorService implements IAgentExecutor {
       let stderr = '';
       let timedOut = false;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      let postResultKillTimer: ReturnType<typeof setTimeout> | undefined;
 
       // Collected from the stream — only the final result line matters
       let resultText = '';
@@ -103,6 +115,22 @@ export class ClaudeCodeExecutorService implements IAgentExecutor {
 
             const { type: _t, result: _r, session_id: _s, usage: _u, ...rest } = parsed;
             if (Object.keys(rest).length > 0) metadata = rest;
+
+            // The CLI emitted its final result. Give it a grace period to tear
+            // down MCP servers and exit on its own; if it still hasn't closed,
+            // send SIGKILL so the close handler runs and we resolve. Without
+            // this, leaked MCP/background children (issue: feature 92701aa8
+            // hung 3+ hours after [result]) trap the worker forever.
+            postResultKillTimer ??= setTimeout(() => {
+              this.log(
+                `Subprocess did not exit within ${RESULT_TO_CLOSE_GRACE_MS / 1000}s of [result] — sending SIGKILL`
+              );
+              try {
+                proc.kill('SIGKILL');
+              } catch {
+                /* already dead — close handler will resolve */
+              }
+            }, RESULT_TO_CLOSE_GRACE_MS);
           }
         } catch {
           /* not JSON — already logged by logStreamEvent */
@@ -145,6 +173,7 @@ export class ClaudeCodeExecutorService implements IAgentExecutor {
 
         this.log(`Process closed with code ${code}, result=${resultText.length} chars`);
         if (timeoutId) clearTimeout(timeoutId);
+        if (postResultKillTimer) clearTimeout(postResultKillTimer);
 
         if (timedOut) {
           reject(new Error('Agent execution timed out'));

--- a/tests/unit/infrastructure/services/agents/executors/claude-code-executor.test.ts
+++ b/tests/unit/infrastructure/services/agents/executors/claude-code-executor.test.ts
@@ -263,6 +263,59 @@ describe('ClaudeCodeExecutorService', () => {
       await expect(executePromise).rejects.toThrow('Authentication failed');
     });
 
+    it('should kill subprocess and resolve when result is received but process never exits', async () => {
+      // Regression: feature 92701aa8 hung 3+ hours after `[result]` because
+      // MCP servers and a leaked `pnpm dev:web` background process kept the
+      // claude CLI subprocess alive. The executor must not depend on natural
+      // exit — once we have the result, we must enforce a grace period and
+      // kill the subprocess so proc.on('close') fires and we resolve.
+      vi.useFakeTimers();
+      try {
+        const mockProc = createMockChildProcess();
+        vi.mocked(mockSpawn).mockReturnValue(mockProc as any);
+
+        // Make kill() actually emit close so the executor resolves.
+        mockProc.kill.mockImplementation(() => {
+          setImmediate(() => {
+            mockProc.stdout.end();
+            mockProc.stderr.end();
+            mockProc.emit('close', null);
+          });
+          return true;
+        });
+
+        const resultLine = buildStreamResult({
+          result: 'Implementation complete',
+          session_id: 'sess-stuck-1',
+        });
+
+        const executePromise = executor.execute('Long-running task');
+
+        // Emit the result line but never close the process (mimicking the
+        // real-world hang where MCP children pin the parent open).
+        await Promise.resolve();
+        mockProc.stdout.write(`${resultLine}\n`);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Before the grace period elapses, kill must NOT have been called.
+        expect(mockProc.kill).not.toHaveBeenCalled();
+
+        // Advance past the 30s post-result grace period.
+        await vi.advanceTimersByTimeAsync(31_000);
+
+        // Executor must have force-killed the subprocess.
+        expect(mockProc.kill).toHaveBeenCalled();
+
+        // And the captured result data must be returned, not lost.
+        await vi.runAllTimersAsync();
+        const result = await executePromise;
+        expect(result.result).toBe('Implementation complete');
+        expect(result.sessionId).toBe('sess-stuck-1');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should handle spawn error event', async () => {
       // Arrange
       const mockProc = createMockChildProcess();


### PR DESCRIPTION
## Summary

- The `claude` CLI emits a final `[result]` event over stream-json and is supposed to tear down its MCP servers and exit. In practice it can hang for hours when MCP children (Playwright, context7), language servers, or backgrounded bash tools (e.g. `pnpm dev:web` left over from agent work) keep stdio open. The worker is then blocked on `proc.on('close')` that never fires.
- Real-world impact: feature `92701aa8` stayed in `fast-implement` for 3+ hours after the agent had already finished, committed, and pushed — claude PID was still alive (`STAT S`) with `npm exec @playwright/mcp@latest`, `npm exec @upstash/context7-mcp`, `pnpm dev:web`, and `typescript-language-server` as living children.
- Fix: once the executor observes a `result` event in stream-json, schedule a 30s SIGKILL safety net. The existing `proc.on('close')` handler then runs and `execute()` resolves with the already-captured result. Timer is cleared on natural close, so happy-path runs are unchanged.
- Adds a regression test that emits `result` without ever closing the process and asserts the subprocess is killed and the result data is returned.
- Adds a LESSONS.md entry so the same shape of bug isn't repeated in other executors that wait on a final event.

## Test plan

- [x] `pnpm test:unit` — 6837/6837 pass
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean
- [x] New regression test fails on `main`, passes with the fix (verified RED → GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)