### PR TITLE
fix(ci): exclude .next/node_modules and fix eslint pages dir

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -276,7 +276,7 @@ export default tseslint.config(
       'react-hooks/exhaustive-deps': 'warn',
 
       // Next.js rules
-      '@next/next/no-html-link-for-pages': 'error',
+      '@next/next/no-html-link-for-pages': ['error', 'src/presentation/web/app'],
       '@next/next/no-img-element': 'warn',
       '@next/next/no-sync-scripts': 'error',
 

--- a/packages/electron/electron-builder.apps-only.yml
+++ b/packages/electron/electron-builder.apps-only.yml
@@ -58,6 +58,7 @@ extraResources:
     filter:
       - '**/*'
       - '!**/*.map'
+      - '!**/.next/node_modules/**'
 
 # Artifact filenames include the variant so the two installers are
 # visually distinct when they land in the same release folder.

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -53,6 +53,7 @@ extraResources:
     filter:
       - '**/*'
       - '!**/*.map'
+      - '!**/.next/node_modules/**'
 
 # macOS configuration
 mac:


### PR DESCRIPTION
## Summary

- **Electron macOS build**: adds `!**/.next/node_modules/**` to `extraResources` filter in both `electron-builder.yml` and `electron-builder.apps-only.yml`. On macOS arm64, electron-builder stats every file it copies — hashed symlink paths inside Next.js's internal `.next/node_modules` cache (e.g. `reflect-metadata-f94622ce1e77a0c0`) don't resolve, causing `ENOENT` and a failed build.
- **ESLint `no-html-link-for-pages`**: configures the rule with `src/presentation/web/app` so it resolves the App Router root instead of defaulting to a non-existent `pages/` directory, eliminating the warning that surfaces when running `eslint . --max-warnings 0`.

## Test plan

- [ ] CI Electron (macos-latest) builds pass
- [ ] CI Electron Apps-Only (macos-latest) builds pass
- [ ] `pnpm lint` exits 0 with no warnings locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)