### PR TITLE
fix(agents): auto-trust workspace in gemini-cli headless executor

### DIFF
--- a/packages/core/src/infrastructure/services/agents/common/executors/gemini-cli-executor.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/executors/gemini-cli-executor.service.ts
@@ -404,11 +404,17 @@ export class GeminiCliExecutorService implements IAgentExecutor {
     // is invoked from within a Claude Code session.
     const { CLAUDECODE: _, ...cleanEnv } = process.env;
 
+    // Auto-trust the workspace. Recent gemini-cli versions exit (code 55) in
+    // headless mode when the cwd isn't on the user's trusted-folders list,
+    // even with -y (YOLO) — the trust check overrides YOLO. shep always runs
+    // gemini against worktrees we just created, so the trust prompt is moot.
+    const baseEnv = { ...cleanEnv, GEMINI_CLI_TRUST_WORKSPACE: 'true' };
+
     // Inject GEMINI_API_KEY when using token auth
     if (this.authConfig?.authMethod === 'token' && this.authConfig.token) {
-      spawnOpts.env = { ...cleanEnv, GEMINI_API_KEY: this.authConfig.token };
+      spawnOpts.env = { ...baseEnv, GEMINI_API_KEY: this.authConfig.token };
     } else {
-      spawnOpts.env = cleanEnv;
+      spawnOpts.env = baseEnv;
     }
 
     return spawnOpts;


### PR DESCRIPTION
## Summary
- Sets `GEMINI_CLI_TRUST_WORKSPACE=true` in the gemini subprocess env so the trusted-folders gate doesn't kill headless feature runs

## Background
Recent gemini-cli releases exit with code 55 when the cwd isn't on the user's trusted-folders list, even when `-y` (YOLO) is passed — the trust check supersedes YOLO. The error from prod:

> Gemini CLI is not running in a trusted directory. To proceed, either use `--skip-trust`, set the GEMINI_CLI_TRUST_WORKSPACE=true environment variable, or trust this directory in interactive mode.

Headless workers (fast-implement, etc.) always run against worktrees shep itself just created, so the trust prompt is meaningless — we already implicitly trust them.

## Test plan
- [ ] Run a feature with `gemini-cli` agent type on the server; confirm subprocess no longer exits with code 55
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)