### PR TITLE
feat(domain): connect github via pat, auto-inject gh_token in terminals

### DIFF
--- a/.storybook/mocks/app/actions/github-integration.ts
+++ b/.storybook/mocks/app/actions/github-integration.ts
@@ -1,0 +1,19 @@
+import type { GithubIntegrationStatus } from '@shepai/core/application/ports/output/repositories/github-integration.repository.interface';
+
+export interface ConnectGithubResult {
+  success: boolean;
+  login?: string;
+  error?: string;
+}
+
+export async function connectGithubAction(_token: string): Promise<ConnectGithubResult> {
+  return { success: true, login: 'mock-user' };
+}
+
+export async function disconnectGithubAction(): Promise<{ success: boolean; error?: string }> {
+  return { success: true };
+}
+
+export async function getGithubStatusAction(): Promise<GithubIntegrationStatus> {
+  return { connected: false, connectedAt: null, updatedAt: null };
+}

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -437,3 +437,21 @@ const args = rest.map(t => t.replace('{dir}', actualPath));
 The `claude` CLI emits a final `result` event over stream-json and is supposed to tear down its MCP servers and exit — but in practice it can hang for hours. Confirmed offenders, all spawned by the agent itself: `npm exec @playwright/mcp`, `npm exec @upstash/context7-mcp`, `typescript-language-server --stdio`, and any backgrounded `pnpm dev:web` / shell the agent forgot to kill. They keep stdio open and the parent claude process never closes. A worker that resolves only on `proc.on('close')` then sleeps forever — feature 92701aa8 was stuck `fast-implement` for 3+ hours after the agent had finished, committed, and pushed.
 
 **Rule:** any executor that depends on a subprocess emitting a final event must enforce a grace timer once that event is observed and SIGKILL the subprocess if it fails to exit. Don't trust the child to clean up its own children. Implemented in `claude-code-executor.service.ts` via `RESULT_TO_CLOSE_GRACE_MS = 30_000`: after seeing `type: 'result'` in stream-json, schedule a SIGKILL; the existing `proc.on('close')` handler then resolves with the already-captured result data.
+
+## New DI Module → Add to BOTH Production Container AND Bootstrap Test
+
+When adding a new `register<Foo>(container)` module to `packages/core/src/infrastructure/di/modules/`, the production wiring lives in `container.ts`. The integration test `tests/integration/infrastructure/di/container-bootstrap.test.ts` has its OWN parallel list of `register*()` calls — it does NOT import `initializeContainer()`. Forgetting to add your new module there causes downstream resolution failures (e.g. "Cannot inject the dependency 'X' at position #N of YUseCase") only at CI time, not locally for the affected use case.
+
+**Rule:** any new `register<Foo>(container)` module must be added in TWO places at once: (1) `container.ts` and (2) the `beforeAll()` block in `container-bootstrap.test.ts`. Add the import alongside the others in alphabetical order to make missing entries visually obvious in PR diffs.
+
+## New Server Action → Add Storybook Mock at .storybook/mocks/app/actions/
+
+The Vite-based Storybook config aliases `@/app/actions/*` to `.storybook/mocks/app/actions/*`. Any web component that imports `@/app/actions/<new-action>` will break the Storybook build with `[vite:load-fallback] Could not load ./.storybook/mocks/app/actions/<new-action>` unless a mock file with the same name and the same exported function signatures exists. The runtime app does not need this — only Storybook does.
+
+**Rule:** when you add `src/presentation/web/app/actions/<name>.ts` AND any component imports from it, immediately create `.storybook/mocks/app/actions/<name>.ts` exporting stubbed versions of every function the component uses. Match exported names exactly; types can be re-imported from the same domain interfaces. See `.storybook/mocks/app/actions/load-settings.ts` for the canonical pattern.
+
+## New Translation Key → Add to ALL 9 Locales in the Same Commit
+
+Adding a key to `translations/en/web.json` without mirroring it in `ar, de, es, fr, he, pt, ru, uk` fails the `tests/unit/translations/translation-completeness.test.ts` parity check on CI. The full locale set is enumerated by the `Language` enum in `packages/core/src/domain/generated/output.ts`. Test failure looks like: `AssertionError: Keys missing in <locale>/web.json: expected ['settings.x.y'] to deeply equal []`.
+
+**Rule:** every new `t('foo.bar')` call requires a key added to ALL nine `translations/*/web.json` files in the same commit, including a real translation (not a copy of the English string). Run `pnpm test:unit -- tests/unit/translations/translation-completeness.test.ts` before pushing — it completes in under a minute and catches all missing keys at once.

--- a/packages/core/src/application/ports/output/repositories/github-integration.repository.interface.ts
+++ b/packages/core/src/application/ports/output/repositories/github-integration.repository.interface.ts
@@ -1,0 +1,30 @@
+/**
+ * GitHub Integration Repository (port)
+ *
+ * Stores a single GitHub Personal Access Token, encrypted-at-rest using
+ * LocalSecretBox. Used by the terminal-spawn path to inject GH_TOKEN /
+ * GITHUB_TOKEN env vars so `gh`, `git`, and other git-aware tools auth
+ * automatically inside shep.
+ */
+
+export interface GithubIntegrationStatus {
+  connected: boolean;
+  /** When the token was first stored (ms epoch). null when not connected. */
+  connectedAt: number | null;
+  /** When the token was last replaced (ms epoch). null when not connected. */
+  updatedAt: number | null;
+}
+
+export interface IGithubIntegrationRepository {
+  /** Return the decrypted PAT, or null if no token is stored. */
+  get(): Promise<string | null>;
+
+  /** Store (or replace) the PAT. Encrypted before write. */
+  set(token: string): Promise<void>;
+
+  /** Remove the stored PAT. No-op if none exists. */
+  remove(): Promise<void>;
+
+  /** Cheap status read — does not decrypt the token. */
+  getStatus(): Promise<GithubIntegrationStatus>;
+}

--- a/packages/core/src/application/ports/output/services/terminal-session-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/terminal-session-service.interface.ts
@@ -14,6 +14,12 @@ export interface CreateTerminalSessionInput {
   cols?: number;
   /** Initial terminal size in rows. */
   rows?: number;
+  /**
+   * Extra environment variables merged into the PTY's env at spawn. Used by
+   * the use case to inject integration tokens (GH_TOKEN, etc.) without
+   * coupling the terminal service to specific integrations.
+   */
+  extraEnv?: Record<string, string>;
 }
 
 export interface CreatedTerminalSession {

--- a/packages/core/src/application/use-cases/integrations/connect-github.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/connect-github.use-case.ts
@@ -1,0 +1,57 @@
+import { inject, injectable } from 'tsyringe';
+
+import type { IGithubIntegrationRepository } from '../../ports/output/repositories/github-integration.repository.interface.js';
+
+export interface ConnectGithubInput {
+  /** GitHub Personal Access Token (classic or fine-grained). */
+  token: string;
+}
+
+export class InvalidGithubTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidGithubTokenError';
+  }
+}
+
+const VALIDATE_URL = 'https://api.github.com/user';
+
+@injectable()
+export class ConnectGithubUseCase {
+  constructor(
+    @inject('IGithubIntegrationRepository')
+    private readonly repo: IGithubIntegrationRepository
+  ) {}
+
+  async execute(input: ConnectGithubInput): Promise<{ login: string }> {
+    const token = input.token?.trim();
+    if (!token) throw new InvalidGithubTokenError('Token is required');
+
+    // Probe the token before persisting — never store an invalid token.
+    const res = await fetch(VALIDATE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'shep-github-integration',
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (res.status === 401) {
+      throw new InvalidGithubTokenError(
+        'GitHub rejected the token (401). Check that the PAT is correct and has not expired.'
+      );
+    }
+    if (!res.ok) {
+      throw new InvalidGithubTokenError(
+        `Could not validate token: GitHub returned ${res.status} ${res.statusText}`
+      );
+    }
+    const body = (await res.json().catch(() => ({}))) as { login?: string };
+    if (!body.login) {
+      throw new InvalidGithubTokenError(
+        'GitHub did not return a user — token may lack `read:user` scope'
+      );
+    }
+    await this.repo.set(token);
+    return { login: body.login };
+  }
+}

--- a/packages/core/src/application/use-cases/integrations/disconnect-github.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/disconnect-github.use-case.ts
@@ -1,0 +1,15 @@
+import { inject, injectable } from 'tsyringe';
+
+import type { IGithubIntegrationRepository } from '../../ports/output/repositories/github-integration.repository.interface.js';
+
+@injectable()
+export class DisconnectGithubUseCase {
+  constructor(
+    @inject('IGithubIntegrationRepository')
+    private readonly repo: IGithubIntegrationRepository
+  ) {}
+
+  async execute(): Promise<void> {
+    await this.repo.remove();
+  }
+}

--- a/packages/core/src/application/use-cases/integrations/get-github-integration-status.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/get-github-integration-status.use-case.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+
+import type {
+  GithubIntegrationStatus,
+  IGithubIntegrationRepository,
+} from '../../ports/output/repositories/github-integration.repository.interface.js';
+
+@injectable()
+export class GetGithubIntegrationStatusUseCase {
+  constructor(
+    @inject('IGithubIntegrationRepository')
+    private readonly repo: IGithubIntegrationRepository
+  ) {}
+
+  async execute(): Promise<GithubIntegrationStatus> {
+    return this.repo.getStatus();
+  }
+}

--- a/packages/core/src/application/use-cases/terminal/create-terminal-session.use-case.ts
+++ b/packages/core/src/application/use-cases/terminal/create-terminal-session.use-case.ts
@@ -4,6 +4,11 @@
  * Opens a new interactive PTY session rooted at an application's working
  * directory (or any caller-supplied cwd). Returns an opaque session id
  * that presentation layers use for subsequent input/output/resize calls.
+ *
+ * Also enriches the spawn env with integration credentials when configured
+ * (e.g. GH_TOKEN / GITHUB_TOKEN from the GitHub integration) so tools like
+ * `gh` and `git push https://...` authenticate without the user having to
+ * paste tokens into the terminal.
  */
 
 import { inject, injectable } from 'tsyringe';
@@ -11,6 +16,7 @@ import type {
   CreatedTerminalSession,
   ITerminalSessionService,
 } from '../../ports/output/services/terminal-session-service.interface.js';
+import type { IGithubIntegrationRepository } from '../../ports/output/repositories/github-integration.repository.interface.js';
 
 export interface CreateTerminalSessionCommand {
   cwd: string;
@@ -22,17 +28,29 @@ export interface CreateTerminalSessionCommand {
 export class CreateTerminalSessionUseCase {
   constructor(
     @inject('ITerminalSessionService')
-    private readonly terminals: ITerminalSessionService
+    private readonly terminals: ITerminalSessionService,
+    @inject('IGithubIntegrationRepository')
+    private readonly github: IGithubIntegrationRepository
   ) {}
 
-  execute(command: CreateTerminalSessionCommand): CreatedTerminalSession {
+  async execute(command: CreateTerminalSessionCommand): Promise<CreatedTerminalSession> {
     if (!command.cwd || command.cwd.trim().length === 0) {
       throw new Error('cwd is required to create a terminal session');
+    }
+    const extraEnv: Record<string, string> = {};
+    const ghToken = await this.github.get().catch(() => null);
+    if (ghToken) {
+      // Both names are honored by gh CLI and many other tools; setting both
+      // covers `gh`, `hub`, `git -c credential.helper=...`, and anything
+      // else that reads the standard env.
+      extraEnv.GH_TOKEN = ghToken;
+      extraEnv.GITHUB_TOKEN = ghToken;
     }
     return this.terminals.create({
       cwd: command.cwd,
       cols: command.cols,
       rows: command.rows,
+      extraEnv,
     });
   }
 }

--- a/packages/core/src/infrastructure/di/container.ts
+++ b/packages/core/src/infrastructure/di/container.ts
@@ -52,6 +52,7 @@ import { registerServices } from './modules/register-services.js';
 import { registerTools } from './modules/register-tools.js';
 import { registerAgents } from './modules/register-agents.js';
 import { registerCloudDeploy } from './modules/register-cloud-deploy.js';
+import { registerIntegrations } from './modules/register-integrations.js';
 import { registerDeployment } from './modules/register-deployment.js';
 import { registerUseCases } from './modules/register-use-cases.js';
 import { registerInteractive } from './modules/register-interactive.js';
@@ -85,6 +86,7 @@ export async function initializeContainer(): Promise<typeof container> {
   registerTools(container);
   registerAgents(container);
   registerCloudDeploy(container);
+  registerIntegrations(container);
   registerDeployment(container);
   registerUseCases(container);
   registerInteractive(container);

--- a/packages/core/src/infrastructure/di/modules/register-integrations.ts
+++ b/packages/core/src/infrastructure/di/modules/register-integrations.ts
@@ -1,0 +1,41 @@
+import type { DependencyContainer } from 'tsyringe';
+import type Database from 'better-sqlite3';
+
+import type { IGithubIntegrationRepository } from '../../../application/ports/output/repositories/github-integration.repository.interface.js';
+import { SQLiteGithubIntegrationRepository } from '../../repositories/sqlite-github-integration.repository.js';
+import { LocalSecretBox } from '../../services/crypto/local-secret-box.js';
+
+import { ConnectGithubUseCase } from '../../../application/use-cases/integrations/connect-github.use-case.js';
+import { DisconnectGithubUseCase } from '../../../application/use-cases/integrations/disconnect-github.use-case.js';
+import { GetGithubIntegrationStatusUseCase } from '../../../application/use-cases/integrations/get-github-integration-status.use-case.js';
+
+/**
+ * Third-party developer-tool integrations (GitHub, etc.).
+ *
+ * LocalSecretBox is registered by registerCloudDeploy — these registrations
+ * just resolve it. registerCloudDeploy must run before this module.
+ */
+export function registerIntegrations(container: DependencyContainer): void {
+  container.register<IGithubIntegrationRepository>('IGithubIntegrationRepository', {
+    useFactory: (c) => {
+      const db = c.resolve<Database.Database>('Database');
+      const box = c.resolve(LocalSecretBox);
+      return new SQLiteGithubIntegrationRepository(db, box);
+    },
+  });
+
+  container.registerSingleton(ConnectGithubUseCase);
+  container.register('ConnectGithubUseCase', {
+    useFactory: (c) => c.resolve(ConnectGithubUseCase),
+  });
+
+  container.registerSingleton(DisconnectGithubUseCase);
+  container.register('DisconnectGithubUseCase', {
+    useFactory: (c) => c.resolve(DisconnectGithubUseCase),
+  });
+
+  container.registerSingleton(GetGithubIntegrationStatusUseCase);
+  container.register('GetGithubIntegrationStatusUseCase', {
+    useFactory: (c) => c.resolve(GetGithubIntegrationStatusUseCase),
+  });
+}

--- a/packages/core/src/infrastructure/persistence/sqlite/migrations/096-create-github-integration-table.ts
+++ b/packages/core/src/infrastructure/persistence/sqlite/migrations/096-create-github-integration-table.ts
@@ -1,0 +1,36 @@
+/**
+ * Migration 096: github_integration table.
+ *
+ * Stores a single encrypted GitHub Personal Access Token. Mirrors the
+ * cloud_provider_tokens schema (LocalSecretBox AES-256-GCM blob), but
+ * with a single fixed row (id = 1) since there's only ever one GitHub
+ * integration per shep instance.
+ *
+ * Idempotent.
+ */
+
+import type { MigrationParams } from 'umzug';
+import type Database from 'better-sqlite3';
+
+export async function up({ context: db }: MigrationParams<Database.Database>): Promise<void> {
+  const existing = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='github_integration'")
+    .get();
+
+  if (!existing) {
+    db.exec(`
+      CREATE TABLE github_integration (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        token_ciphertext BLOB NOT NULL,
+        token_iv BLOB NOT NULL,
+        token_tag BLOB NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+  }
+}
+
+export async function down(_params: MigrationParams<Database.Database>): Promise<void> {
+  // Keep the table on rollback to avoid silent token loss.
+}

--- a/packages/core/src/infrastructure/repositories/sqlite-github-integration.repository.ts
+++ b/packages/core/src/infrastructure/repositories/sqlite-github-integration.repository.ts
@@ -1,0 +1,90 @@
+/**
+ * SQLite GitHub Integration Repository
+ *
+ * Mirrors SQLiteCloudProviderTokensRepository but for a single fixed row
+ * (id = 1) — there's only one GitHub integration per shep instance.
+ */
+
+import type Database from 'better-sqlite3';
+import { injectable } from 'tsyringe';
+
+import type {
+  GithubIntegrationStatus,
+  IGithubIntegrationRepository,
+} from '../../application/ports/output/repositories/github-integration.repository.interface.js';
+import { LocalSecretBox } from '../services/crypto/local-secret-box.js';
+
+interface GithubIntegrationRow {
+  id: number;
+  token_ciphertext: Buffer;
+  token_iv: Buffer;
+  token_tag: Buffer;
+  created_at: number;
+  updated_at: number;
+}
+
+const ROW_ID = 1;
+
+@injectable()
+export class SQLiteGithubIntegrationRepository implements IGithubIntegrationRepository {
+  constructor(
+    private readonly db: Database.Database,
+    private readonly secretBox: LocalSecretBox
+  ) {}
+
+  async get(): Promise<string | null> {
+    const row = this.db
+      .prepare<
+        [number],
+        GithubIntegrationRow
+      >('SELECT id, token_ciphertext, token_iv, token_tag, created_at, updated_at FROM github_integration WHERE id = ?')
+      .get(ROW_ID);
+    if (!row) return null;
+    return this.secretBox.decrypt({
+      ciphertext: row.token_ciphertext,
+      iv: row.token_iv,
+      tag: row.token_tag,
+    });
+  }
+
+  async set(token: string): Promise<void> {
+    const now = Date.now();
+    const blob = this.secretBox.encrypt(token);
+    this.db
+      .prepare(
+        `INSERT INTO github_integration (
+           id, token_ciphertext, token_iv, token_tag, created_at, updated_at
+         ) VALUES (
+           @id, @token_ciphertext, @token_iv, @token_tag, @created_at, @updated_at
+         )
+         ON CONFLICT(id) DO UPDATE SET
+           token_ciphertext = excluded.token_ciphertext,
+           token_iv = excluded.token_iv,
+           token_tag = excluded.token_tag,
+           updated_at = excluded.updated_at`
+      )
+      .run({
+        id: ROW_ID,
+        token_ciphertext: blob.ciphertext,
+        token_iv: blob.iv,
+        token_tag: blob.tag,
+        created_at: now,
+        updated_at: now,
+      });
+  }
+
+  async remove(): Promise<void> {
+    this.db.prepare('DELETE FROM github_integration WHERE id = ?').run(ROW_ID);
+  }
+
+  async getStatus(): Promise<GithubIntegrationStatus> {
+    const row = this.db
+      .prepare<
+        [number],
+        { created_at: number; updated_at: number }
+      >('SELECT created_at, updated_at FROM github_integration WHERE id = ?')
+      .get(ROW_ID);
+    if (!row) return { connected: false, connectedAt: null, updatedAt: null };
+    return { connected: true, connectedAt: row.created_at, updatedAt: row.updated_at };
+  }
+}

--- a/packages/core/src/infrastructure/services/terminal/pty-terminal-session.service.ts
+++ b/packages/core/src/infrastructure/services/terminal/pty-terminal-session.service.ts
@@ -81,6 +81,7 @@ export class PtyTerminalSessionService implements ITerminalSessionService {
         TERM: 'xterm-256color',
         COLORTERM: 'truecolor',
         FORCE_COLOR: '1',
+        ...(input.extraEnv ?? {}),
       },
     });
 

--- a/src/presentation/web/app/actions/github-integration.ts
+++ b/src/presentation/web/app/actions/github-integration.ts
@@ -1,0 +1,39 @@
+'use server';
+
+import { resolve } from '@/lib/server-container';
+import type { ConnectGithubUseCase } from '@shepai/core/application/use-cases/integrations/connect-github.use-case';
+import type { DisconnectGithubUseCase } from '@shepai/core/application/use-cases/integrations/disconnect-github.use-case';
+import type { GetGithubIntegrationStatusUseCase } from '@shepai/core/application/use-cases/integrations/get-github-integration-status.use-case';
+import type { GithubIntegrationStatus } from '@shepai/core/application/ports/output/repositories/github-integration.repository.interface';
+
+export interface ConnectGithubResult {
+  success: boolean;
+  /** GitHub login that the token authenticated as. Present on success. */
+  login?: string;
+  error?: string;
+}
+
+export async function connectGithubAction(token: string): Promise<ConnectGithubResult> {
+  try {
+    const useCase = resolve<ConnectGithubUseCase>('ConnectGithubUseCase');
+    const { login } = await useCase.execute({ token });
+    return { success: true, login };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function disconnectGithubAction(): Promise<{ success: boolean; error?: string }> {
+  try {
+    const useCase = resolve<DisconnectGithubUseCase>('DisconnectGithubUseCase');
+    await useCase.execute();
+    return { success: true };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function getGithubStatusAction(): Promise<GithubIntegrationStatus> {
+  const useCase = resolve<GetGithubIntegrationStatusUseCase>('GetGithubIntegrationStatusUseCase');
+  return useCase.execute();
+}

--- a/src/presentation/web/app/api/terminal/route.ts
+++ b/src/presentation/web/app/api/terminal/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest): Promise<Response> {
     }
 
     const useCase = resolve<CreateTerminalSessionUseCase>('CreateTerminalSessionUseCase');
-    const session = useCase.execute({
+    const session = await useCase.execute({
       cwd: body.cwd,
       cols: typeof body.cols === 'number' ? body.cols : undefined,
       rows: typeof body.rows === 'number' ? body.rows : undefined,

--- a/src/presentation/web/components/features/settings/github-integration-section.tsx
+++ b/src/presentation/web/components/features/settings/github-integration-section.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/**
+ * GitHub Integration settings section.
+ *
+ * Stores a single Personal Access Token (encrypted at rest via LocalSecretBox).
+ * When set, every new terminal session shep spawns gets GH_TOKEN /
+ * GITHUB_TOKEN injected automatically — so `gh`, `git push`, etc. authenticate
+ * without the user having to run `gh auth login` interactively.
+ *
+ * The token is only sent to the server once (on Connect). After that, the
+ * client only ever knows whether one is stored, never its value.
+ */
+
+import { useEffect, useState, useTransition } from 'react';
+import { Eye, EyeOff, CheckCircle2, ExternalLink } from 'lucide-react';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  connectGithubAction,
+  disconnectGithubAction,
+  getGithubStatusAction,
+} from '@/app/actions/github-integration';
+import type { GithubIntegrationStatus } from '@shepai/core/application/ports/output/repositories/github-integration.repository.interface';
+
+const PAT_DOCS_URL = 'https://github.com/settings/tokens?type=beta';
+
+export function GithubIntegrationSection() {
+  const [status, setStatus] = useState<GithubIntegrationStatus | null>(null);
+  const [token, setToken] = useState('');
+  const [showToken, setShowToken] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    let cancelled = false;
+    void getGithubStatusAction()
+      .then((s) => {
+        if (!cancelled) setStatus(s);
+      })
+      .catch(() => {
+        if (!cancelled) setStatus({ connected: false, connectedAt: null, updatedAt: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function handleConnect() {
+    const trimmed = token.trim();
+    if (!trimmed) {
+      toast.error('Paste a GitHub Personal Access Token first');
+      return;
+    }
+    startTransition(async () => {
+      const result = await connectGithubAction(trimmed);
+      if (result.success) {
+        toast.success(`Connected to GitHub${result.login ? ` as @${result.login}` : ''}`);
+        setToken('');
+        setShowToken(false);
+        const next = await getGithubStatusAction();
+        setStatus(next);
+      } else {
+        toast.error(result.error ?? 'Failed to connect to GitHub');
+      }
+    });
+  }
+
+  function handleDisconnect() {
+    startTransition(async () => {
+      const result = await disconnectGithubAction();
+      if (result.success) {
+        toast.success('GitHub disconnected');
+        const next = await getGithubStatusAction();
+        setStatus(next);
+      } else {
+        toast.error(result.error ?? 'Failed to disconnect');
+      }
+    });
+  }
+
+  if (status === null) {
+    return (
+      <div className="text-muted-foreground py-4 text-xs" data-testid="github-integration-loading">
+        Checking GitHub integration…
+      </div>
+    );
+  }
+
+  if (status.connected) {
+    return (
+      <div className="space-y-3 py-3" data-testid="github-integration-connected">
+        <div className="flex items-center gap-2">
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          <span className="text-sm">Connected</span>
+          {status.updatedAt ? (
+            <span className="text-muted-foreground text-[11px]">
+              · last updated {new Date(status.updatedAt).toLocaleDateString()}
+            </span>
+          ) : null}
+        </div>
+        <p className="text-muted-foreground text-[11px] leading-relaxed">
+          Every terminal opened in shep now has <code>GH_TOKEN</code> and <code>GITHUB_TOKEN</code>{' '}
+          set automatically. <code>gh</code>, <code>git push</code>, and other tools that read those
+          env vars will authenticate as your GitHub user.
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDisconnect}
+            disabled={isPending}
+            data-testid="github-disconnect-button"
+          >
+            {isPending ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 py-3" data-testid="github-integration-disconnected">
+      <div className="space-y-1.5">
+        <Label htmlFor="github-pat" className="text-xs">
+          Personal Access Token
+        </Label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Input
+              id="github-pat"
+              data-testid="github-pat-input"
+              type={showToken ? 'text' : 'password'}
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="github_pat_… or ghp_…"
+              autoComplete="off"
+              className="pr-9 font-mono text-xs"
+              disabled={isPending}
+            />
+            <button
+              type="button"
+              onClick={() => setShowToken((v) => !v)}
+              className="text-muted-foreground hover:text-foreground absolute top-1/2 right-2 -translate-y-1/2"
+              aria-label={showToken ? 'Hide token' : 'Show token'}
+              tabIndex={-1}
+            >
+              {showToken ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </button>
+          </div>
+          <Button
+            size="sm"
+            onClick={handleConnect}
+            disabled={isPending || !token.trim()}
+            data-testid="github-connect-button"
+          >
+            {isPending ? 'Connecting…' : 'Connect'}
+          </Button>
+        </div>
+      </div>
+      <p className="text-muted-foreground text-[11px] leading-relaxed">
+        Create a fine-grained PAT with <code>contents: read/write</code> and{' '}
+        <code>pull requests: read/write</code> on the repos you want shep to access. Token is
+        encrypted at rest and never leaves this machine.
+      </p>
+      <a
+        href={PAT_DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-[11px] transition-colors"
+      >
+        <ExternalLink className="h-3 w-3" />
+        Generate a token on github.com
+      </a>
+    </div>
+  );
+}

--- a/src/presentation/web/components/features/settings/settings-page-client.tsx
+++ b/src/presentation/web/components/features/settings/settings-page-client.tsx
@@ -21,6 +21,7 @@ import {
   Home,
   Eye,
   EyeOff,
+  Github,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
@@ -46,6 +47,7 @@ import {
 } from '@shepai/core/domain/generated/output';
 import { getEditorTypeIcon } from '@/components/common/editor-type-icons';
 import { AgentModelPicker } from '@/components/features/settings/AgentModelPicker';
+import { GithubIntegrationSection } from '@/components/features/settings/github-integration-section';
 const LANGUAGE_OPTIONS = [
   { value: Language.English, nativeName: 'English' },
   { value: Language.Ukrainian, nativeName: 'Українська' },
@@ -105,6 +107,7 @@ const SECTIONS = [
   { id: 'interactive-agent', labelKey: 'settings.sections.chat', icon: MessageSquare },
   { id: 'home-page', labelKey: 'settings.sections.homePage', icon: Home },
   { id: 'fab-layout', labelKey: 'settings.sections.layout', icon: LayoutGrid },
+  { id: 'integrations', labelKey: 'settings.sections.integrations', icon: Github },
   { id: 'database', labelKey: 'settings.sections.database', icon: Database },
 ] as const;
 
@@ -1919,6 +1922,25 @@ export function SettingsPageClient({
             />
           </SettingsSection>
           <SectionHint>{t('settings.fabLayout.hint')}</SectionHint>
+        </div>
+
+        {/* ── Integrations ── */}
+        <div
+          id="section-integrations"
+          className="grid scroll-mt-18 grid-cols-1 gap-x-5 rounded-lg lg:grid-cols-[1fr_280px]"
+        >
+          <SettingsSection
+            icon={Github}
+            title="GitHub"
+            description="Connect a Personal Access Token so gh, git push, and other tools authenticate automatically in shep terminals."
+            testId="github-integration-section"
+          >
+            <GithubIntegrationSection />
+          </SettingsSection>
+          <SectionHint>
+            The token is encrypted with your local LocalSecretBox and only injected into terminal
+            sessions you start from shep. It never leaves this machine.
+          </SectionHint>
         </div>
 
         {/* ── Database ── */}

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -35,6 +35,7 @@ import { registerServices } from '@/infrastructure/di/modules/register-services.
 import { registerTools } from '@/infrastructure/di/modules/register-tools.js';
 import { registerAgents } from '@/infrastructure/di/modules/register-agents.js';
 import { registerCloudDeploy } from '@/infrastructure/di/modules/register-cloud-deploy.js';
+import { registerIntegrations } from '@/infrastructure/di/modules/register-integrations.js';
 import { registerDeployment } from '@/infrastructure/di/modules/register-deployment.js';
 import { registerUseCases } from '@/infrastructure/di/modules/register-use-cases.js';
 import { registerInteractive } from '@/infrastructure/di/modules/register-interactive.js';
@@ -184,6 +185,7 @@ describe('DI container bootstrap (integration)', () => {
     registerTools(scopedContainer);
     registerAgents(scopedContainer);
     registerCloudDeploy(scopedContainer);
+    registerIntegrations(scopedContainer);
     registerDeployment(scopedContainer);
     registerUseCases(scopedContainer);
     registerInteractive(scopedContainer);

--- a/tests/unit/application/use-cases/terminal/create-terminal-session.use-case.test.ts
+++ b/tests/unit/application/use-cases/terminal/create-terminal-session.use-case.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { describe, it, expect, vi } from 'vitest';
 import { CreateTerminalSessionUseCase } from '../../../../../packages/core/src/application/use-cases/terminal/create-terminal-session.use-case.js';
 import type { ITerminalSessionService } from '../../../../../packages/core/src/application/ports/output/services/terminal-session-service.interface.js';
+import type { IGithubIntegrationRepository } from '../../../../../packages/core/src/application/ports/output/repositories/github-integration.repository.interface.js';
 
 function makeService(): ITerminalSessionService {
   return {
@@ -16,36 +17,69 @@ function makeService(): ITerminalSessionService {
   };
 }
 
+function makeGithub(token: string | null = null): IGithubIntegrationRepository {
+  return {
+    get: vi.fn(async () => token),
+    set: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined),
+    getStatus: vi.fn(async () => ({
+      connected: token !== null,
+      connectedAt: token !== null ? 1 : null,
+      updatedAt: token !== null ? 1 : null,
+    })),
+  };
+}
+
 describe('CreateTerminalSessionUseCase', () => {
-  it('delegates to the terminal service with the provided cwd and size', () => {
+  it('delegates to the terminal service with the provided cwd and size', async () => {
     const service = makeService();
-    const useCase = new CreateTerminalSessionUseCase(service);
+    const useCase = new CreateTerminalSessionUseCase(service, makeGithub());
 
-    const result = useCase.execute({ cwd: '/tmp', cols: 120, rows: 30 });
+    const result = await useCase.execute({ cwd: '/tmp', cols: 120, rows: 30 });
 
-    expect(service.create).toHaveBeenCalledWith({ cwd: '/tmp', cols: 120, rows: 30 });
+    expect(service.create).toHaveBeenCalledWith({
+      cwd: '/tmp',
+      cols: 120,
+      rows: 30,
+      extraEnv: {},
+    });
     expect(result).toEqual({ id: 'sess-1', shell: '/bin/bash', cwd: '/tmp' });
   });
 
-  it('rejects blank cwd values', () => {
+  it('rejects blank cwd values', async () => {
     const service = makeService();
-    const useCase = new CreateTerminalSessionUseCase(service);
+    const useCase = new CreateTerminalSessionUseCase(service, makeGithub());
 
-    expect(() => useCase.execute({ cwd: '' })).toThrow(/cwd is required/);
-    expect(() => useCase.execute({ cwd: '   ' })).toThrow(/cwd is required/);
+    await expect(useCase.execute({ cwd: '' })).rejects.toThrow(/cwd is required/);
+    await expect(useCase.execute({ cwd: '   ' })).rejects.toThrow(/cwd is required/);
     expect(service.create).not.toHaveBeenCalled();
   });
 
-  it('forwards undefined size when omitted', () => {
+  it('forwards undefined size when omitted', async () => {
     const service = makeService();
-    const useCase = new CreateTerminalSessionUseCase(service);
+    const useCase = new CreateTerminalSessionUseCase(service, makeGithub());
 
-    useCase.execute({ cwd: '/work' });
+    await useCase.execute({ cwd: '/work' });
 
     expect(service.create).toHaveBeenCalledWith({
       cwd: '/work',
       cols: undefined,
       rows: undefined,
+      extraEnv: {},
+    });
+  });
+
+  it('injects GH_TOKEN/GITHUB_TOKEN when a github PAT is stored', async () => {
+    const service = makeService();
+    const useCase = new CreateTerminalSessionUseCase(service, makeGithub('ghp_secret'));
+
+    await useCase.execute({ cwd: '/work' });
+
+    expect(service.create).toHaveBeenCalledWith({
+      cwd: '/work',
+      cols: undefined,
+      rows: undefined,
+      extraEnv: { GH_TOKEN: 'ghp_secret', GITHUB_TOKEN: 'ghp_secret' },
     });
   });
 });

--- a/translations/ar/web.json
+++ b/translations/ar/web.json
@@ -16,7 +16,8 @@
       "chat": "المحادثة",
       "homePage": "Home page",
       "layout": "التخطيط",
-      "database": "قاعدة البيانات"
+      "database": "قاعدة البيانات",
+      "integrations": "التكاملات"
     },
     "language": {
       "title": "اللغة",

--- a/translations/de/web.json
+++ b/translations/de/web.json
@@ -16,7 +16,8 @@
       "chat": "Chat",
       "homePage": "Home page",
       "layout": "Layout",
-      "database": "Datenbank"
+      "database": "Datenbank",
+      "integrations": "Integrationen"
     },
     "language": {
       "title": "Sprache",

--- a/translations/en/web.json
+++ b/translations/en/web.json
@@ -16,7 +16,8 @@
       "chat": "Chat",
       "homePage": "Home page",
       "layout": "Layout",
-      "database": "Database"
+      "database": "Database",
+      "integrations": "Integrations"
     },
     "language": {
       "title": "Language",

--- a/translations/es/web.json
+++ b/translations/es/web.json
@@ -16,7 +16,8 @@
       "chat": "Chat",
       "homePage": "Home page",
       "layout": "Diseño",
-      "database": "Base de datos"
+      "database": "Base de datos",
+      "integrations": "Integraciones"
     },
     "language": {
       "title": "Idioma",

--- a/translations/fr/web.json
+++ b/translations/fr/web.json
@@ -16,7 +16,8 @@
       "chat": "Chat",
       "homePage": "Home page",
       "layout": "Disposition",
-      "database": "Base de données"
+      "database": "Base de données",
+      "integrations": "Intégrations"
     },
     "language": {
       "title": "Langue",

--- a/translations/he/web.json
+++ b/translations/he/web.json
@@ -16,7 +16,8 @@
       "chat": "צ'אט",
       "homePage": "Home page",
       "layout": "פריסה",
-      "database": "מסד נתונים"
+      "database": "מסד נתונים",
+      "integrations": "אינטגרציות"
     },
     "language": {
       "title": "שפה",

--- a/translations/pt/web.json
+++ b/translations/pt/web.json
@@ -16,7 +16,8 @@
       "chat": "Chat",
       "homePage": "Home page",
       "layout": "Layout",
-      "database": "Banco de Dados"
+      "database": "Banco de Dados",
+      "integrations": "Integrações"
     },
     "language": {
       "title": "Idioma",

--- a/translations/ru/web.json
+++ b/translations/ru/web.json
@@ -16,7 +16,8 @@
       "chat": "Чат",
       "homePage": "Home page",
       "layout": "Расположение",
-      "database": "База данных"
+      "database": "База данных",
+      "integrations": "Интеграции"
     },
     "language": {
       "title": "Язык",

--- a/translations/uk/web.json
+++ b/translations/uk/web.json
@@ -16,7 +16,8 @@
       "chat": "Чат",
       "homePage": "Home page",
       "layout": "Розташування",
-      "database": "База даних"
+      "database": "База даних",
+      "integrations": "Інтеграції"
     },
     "language": {
       "title": "Мова",


### PR DESCRIPTION
## Summary

Adds a **GitHub** section to `/settings` where the user pastes a Personal Access Token once. Shep stores it encrypted (LocalSecretBox / AES-256-GCM) and injects `GH_TOKEN` + `GITHUB_TOKEN` into every terminal it spawns, so `gh`, `git push`, and other tools authenticate automatically — no `gh auth login` needed, and the auth survives org-pod restarts in cloud (because the SQLite db lives on the per-org PVC).

## What's added
- `github_integration` table (single fixed row, mirrors the `cloud_provider_tokens` schema). Migration 096.
- `IGithubIntegrationRepository` port + SQLite impl.
- `ConnectGithubUseCase` (validates PAT against `api.github.com/user` before persisting), `DisconnectGithubUseCase`, `GetGithubIntegrationStatusUseCase`.
- `register-integrations` DI module, wired into the container after `cloud-deploy` (which registers `LocalSecretBox`).
- New `extraEnv` field on `CreateTerminalSessionInput` so the use case injects env without coupling the pty service to integrations.
- `CreateTerminalSessionUseCase` is now async — reads the stored PAT on each spawn.
- Server actions: `connectGithubAction` / `disconnectGithubAction` / `getGithubStatusAction`.
- `GithubIntegrationSection` React component (token-paste / connected / disconnect states), slotted into the settings page above Database.

## Out of scope (future)
- True OAuth flow (replace paste-PAT). Needs a registered GitHub OAuth app and callback proxy through shep-cloud.
- Migrate `github-repository.service.ts` (currently uses `gh auth token` subprocess) to read from this repo. Both can coexist for now.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (`--max-warnings 0`)
- [x] `CreateTerminalSessionUseCase` unit tests updated, all 4 tests pass (including new test verifying GH_TOKEN/GITHUB_TOKEN injection when a PAT is stored)
- [ ] Manual: paste a PAT in `/settings`, open a terminal, run `gh auth status` — expect "Logged in to github.com as &lt;login&gt;"
- [ ] Manual: `git push https://github.com/...` from the shep terminal — expect success without prompting
- [ ] Manual: disconnect, open new terminal, `echo $GH_TOKEN` — expect empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)