### PR TITLE
ci(release): mirror npm publish to @shep.bot scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,10 @@ jobs:
           pattern: electron-*
           merge-multiple: true
 
+      - name: Capture pre-release version
+        id: pre
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Run semantic-release
         id: semantic
         env:
@@ -401,6 +405,33 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run: npx semantic-release
+
+      # ===========================================================================
+      # Mirror publish to @shep.bot scope (additive, fully backward compatible)
+      #
+      # semantic-release bumps package.json's version in-place when it publishes;
+      # if the version is unchanged, no release happened and we skip the mirror.
+      # continue-on-error keeps the canonical @shepai/cli release authoritative
+      # — a failed mirror publish is reported but does not fail the release job.
+      # ===========================================================================
+      - name: Mirror publish to @shep.bot scope
+        continue-on-error: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_SHEPBOT }}
+          PRE_VERSION: ${{ steps.pre.outputs.version }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::warning::NPM_TOKEN_SHEPBOT secret not set — skipping @shep.bot mirror publish"
+            exit 0
+          fi
+          POST_VERSION=$(node -p "require('./package.json').version")
+          if [ "${POST_VERSION}" = "${PRE_VERSION}" ]; then
+            echo "No version bump (pre=${PRE_VERSION} post=${POST_VERSION}) — semantic-release did not publish. Skipping mirror."
+            exit 0
+          fi
+          echo "Mirror-publishing @shep.bot/cli@${POST_VERSION} (was ${PRE_VERSION})"
+          npm pkg set name='@shep.bot/cli'
+          npm publish --access public
 
   # ===========================================================================
   # Dev Release (PRs only, after ALL jobs pass)
@@ -473,3 +504,83 @@ jobs:
 
             ---
             <sub>Published from commit ${{ github.event.pull_request.head.sha }} | [View CI](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>
+
+  # ===========================================================================
+  # Dev Release Mirror — @shep.bot scope (PRs only, parallel to dev-release)
+  # Independent job so a misconfigured/missing NPM_TOKEN_SHEPBOT cannot block
+  # PRs while the new org's publishing stabilizes. continue-on-error keeps it
+  # additive: failure here is reported but does not fail the PR check.
+  # ===========================================================================
+  dev-release-shepbot:
+    name: Dev Release (shep.bot mirror)
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - typecheck
+      - test-unit
+      - test-e2e-cli
+      - test-e2e-tui
+      - test-e2e-web
+      - storybook-build
+      - build-electron
+      - security-gitleaks
+      - security-semgrep
+    if: github.event_name == 'pull_request'
+    continue-on-error: true
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute dev version
+        id: devver
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          DEV_VERSION="${BASE_VERSION}-pr${PR_NUMBER}.${SHORT_SHA}"
+          echo "version=$DEV_VERSION" >> $GITHUB_OUTPUT
+          echo "Dev version (shep.bot): $DEV_VERSION"
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build:release
+
+      - name: Publish npm dev release to @shep.bot scope
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_SHEPBOT }}
+          DEV_VERSION: ${{ steps.devver.outputs.version }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::warning::NPM_TOKEN_SHEPBOT secret not set — skipping @shep.bot mirror publish"
+            exit 0
+          fi
+          npm version "$DEV_VERSION" --no-git-tag-version
+          npm pkg set name='@shep.bot/cli'
+          npm publish --tag dev --access public
+
+      - name: Post PR comment with @shep.bot dev version
+        uses: peter-evans/create-or-update-comment@v5
+        env:
+          DEV_VERSION: ${{ steps.devver.outputs.version }}
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-tag: dev-release-shepbot
+          body: |
+            ## Dev Release Published — @shep.bot mirror
+
+            | Artifact | Version | Install |
+            |----------|---------|---------|
+            | **npm** | `${{ steps.devver.outputs.version }}` | `npm install -g @shep.bot/cli@${{ steps.devver.outputs.version }}` |
+
+            ---
+            <sub>Mirror publish from commit ${{ github.event.pull_request.head.sha }} | [View CI](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})</sub>


### PR DESCRIPTION
## Summary

Mirrors every npm publish (dev prerelease + production stable release) to a second scope, `@shep.bot/cli`, alongside the canonical `@shepai/cli`. Fully additive and backward compatible — existing users keep installing `@shepai/cli` unchanged.

This is also a hedge against the current dev-release outage (the primary `NPM_TOKEN` was revoked sometime between 14:57 and 17:00 UTC on 2026-05-03, blocking all dev releases until rotated). With this PR, even when one token misbehaves, the other keeps publishing.

## What changed

`.github/workflows/ci.yml` — purely additive (111 inserts, 0 deletes):

1. **New parallel job `dev-release-shepbot`** (PRs only)
   - Same `needs:` list as `dev-release`, runs in parallel.
   - Uses a separate secret `NPM_TOKEN_SHEPBOT`.
   - Swaps the package name in-job via `npm pkg set name='@shep.bot/cli'`, then publishes with `--tag dev`.
   - `continue-on-error: true` at the job level — a misconfigured token cannot block PR merges.
   - Posts its own PR comment with `comment-tag: dev-release-shepbot` (independent from the existing `@shepai` comment).

2. **Final mirror step in the existing `release` job** (main pushes only)
   - Captures the pre-release version, runs semantic-release as today, then mirror-publishes if and only if the version actually bumped (so PRs that merge with no releasable changes do not re-publish).
   - `continue-on-error: true` — a failed mirror does not break the canonical `@shepai/cli` release.

Both publish paths guard against an unset `NPM_TOKEN_SHEPBOT` secret with a warning + clean exit, so the workflow does not break on first run before the secret is configured.

## Required follow-up (not in this PR)

- [ ] On [npmjs.com](https://www.npmjs.com), generate a granular access token with publish access to the `@shep.bot` org.
- [ ] Add it to repo secrets as `NPM_TOKEN_SHEPBOT`.
- [ ] Separately, rotate `NPM_TOKEN` to fix the canonical `@shepai/cli` outage.

## Test plan

- [ ] Open this PR — confirm the new `Dev Release (shep.bot mirror)` check appears and passes (or warns + exits cleanly if `NPM_TOKEN_SHEPBOT` is unset).
- [ ] Confirm the existing `Dev Release` check is unchanged.
- [ ] After merge to main, confirm the production `Release` job runs the new mirror step and either publishes `@shep.bot/cli@<version>` or warns + exits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)