### PR TITLE
fix(agents): drop interface options param that broke tsyringe resolution

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,5 +1,20 @@
 # Lessons Learned
 
+## tsyringe `@injectable()` — every constructor param must be resolvable
+
+Symptom: worker boots crash with `Cannot inject the dependency at position #N of "X" constructor. Reason: TypeInfo not known for "Object"`.
+
+Root cause: tsyringe walks every constructor param via `reflect-metadata`. TS interfaces and inline object types erase to `Object` at runtime, so any param typed `MyOptions` (an interface) — even with a default value `= {}` — makes tsyringe try to resolve `Object` from the container and fail.
+
+Concrete instance: `SQLiteAgentMessageBus(repo, options: SQLiteAgentMessageBusOptions = {})`. Direct `new` from tests worked, but DI resolution from the worker container blew up the entire `IAgentMessageBus → SendAgentMessageUseCase → FeatureAgentLifecyclePublisher` chain.
+
+Rules for any class with `@injectable()`:
+
+1. Every constructor param must either have an `@inject(token)` decorator OR be a class type that tsyringe can introspect. No interface params, no inline `{}` types, no primitives without `@inject`.
+2. Default values do NOT save you — tsyringe still tries to resolve the param before the default kicks in.
+3. For test-only knobs (poll intervals, etc.), drop them from the constructor and expose a `setX(...)` method or a class-typed config object registered with `useValue`.
+4. Before adding a new `@injectable()` class, scan its constructor: any non-class type without `@inject` is a boot-time bomb that won't surface until something actually resolves the chain.
+
 ## Settings Is the Single Source of Truth for Agent + Model — Never Hardcode UI Defaults
 
 A user reported their newly-created application got stuck on bootstrap with `Agent type 'dev' does not support interactive sessions. Only 'claude-code' supports interactive mode.` They were certain they had selected "Claude Code · Sonnet 4.6" — and the picker DID show that as the default. The bug: the picker's displayed default was a hardcoded literal that lied about what the system would actually use.

--- a/packages/core/src/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.ts
+++ b/packages/core/src/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.ts
@@ -36,11 +36,6 @@ interface Subscription {
   delivered: Set<string>;
 }
 
-export interface SQLiteAgentMessageBusOptions {
-  /** Override the default 2_000ms poll interval (e.g. 500ms for tests). */
-  pollIntervalMs?: number;
-}
-
 function toMillis(value: AgentMessage['createdAt']): number {
   if (value instanceof Date) return value.getTime();
   if (typeof value === 'number') return value;
@@ -59,16 +54,22 @@ function matchesAgentRun(filter: AgentMessageBusFilter, message: AgentMessage): 
 @injectable()
 export class SQLiteAgentMessageBus implements IAgentMessageBus {
   private readonly subscriptions = new Set<Subscription>();
-  private readonly pollIntervalMs: number;
+  private pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS;
   private timer: NodeJS.Timeout | null = null;
   private polling = false;
 
   constructor(
     @inject('IAgentMessageRepository')
-    private readonly repository: IAgentMessageRepository,
-    options: SQLiteAgentMessageBusOptions = {}
-  ) {
-    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    private readonly repository: IAgentMessageRepository
+  ) {}
+
+  /** Test-only override; production code relies on {@link DEFAULT_POLL_INTERVAL_MS}. */
+  setPollIntervalMs(ms: number): void {
+    this.pollIntervalMs = ms;
+    if (this.timer !== null) {
+      this.stopPolling();
+      this.ensurePolling();
+    }
   }
 
   async publish(message: AgentMessage): Promise<void> {

--- a/tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts
+++ b/tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts
@@ -72,7 +72,8 @@ describe('SQLiteAgentMessageBus', () => {
     const readerRepo = new SQLiteAgentMessageRepository(readerDb);
 
     writerBus = new SQLiteAgentMessageBus(writerRepo);
-    readerBus = new SQLiteAgentMessageBus(readerRepo, { pollIntervalMs: 50 });
+    readerBus = new SQLiteAgentMessageBus(readerRepo);
+    readerBus.setPollIntervalMs(50);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- `SQLiteAgentMessageBus` had `options: SQLiteAgentMessageBusOptions = {}` as its second constructor param. TS interfaces erase to `Object` at runtime, so tsyringe's `@injectable()` reflection threw `TypeInfo not known for "Object"` while resolving `IAgentMessageBus`. That cascaded through `SendAgentMessageUseCase → FeatureAgentLifecyclePublisher` and crashed the feature-agent worker at boot in spec mode.
- Removed the interface, defaulted `pollIntervalMs` to the existing `DEFAULT_POLL_INTERVAL_MS` constant, and exposed a test-only `setPollIntervalMs(ms)` setter. The integration test now uses the setter instead of the constructor option.
- Added a `LESSONS.md` entry on the broader rule: every `@injectable()` constructor param must either carry `@inject(token)` or be a class type tsyringe can introspect — interface params and inline object types are boot-time bombs.

## Repro that hit production

Worker fatal error from a fresh spec-mode task before this PR:

```
Worker fatal error: Cannot inject the dependency "sendAgentMessage" at position #0 of "FeatureAgentLifecyclePublisher" constructor. Reason:
    Cannot inject the dependency "bus" at position #0 of "SendAgentMessageUseCase" constructor. Reason:
        Cannot inject the dependency at position #1 of "SQLiteAgentMessageBus" constructor. Reason:
            TypeInfo not known for "Object"
```

Verified post-fix by resolving `FeatureAgentLifecyclePublisher` from the real container — succeeds.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts` — 4/4 pass
- [x] DI smoke test: `container.resolve(FeatureAgentLifecyclePublisher)` resolves cleanly
- [ ] CI green on this branch
- [ ] Re-run a spec-mode feature task end-to-end to confirm the worker boots

🤖 Generated with [Claude Code](https://claude.com/claude-code)