### PR TITLE
test(agents): hoist sqlite migrations to beforeall on bus suite

### DIFF
--- a/tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts
+++ b/tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts
@@ -11,7 +11,7 @@
  */
 
 import 'reflect-metadata';
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from 'vitest';
 import Database from 'better-sqlite3';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -51,22 +51,33 @@ describe('SQLiteAgentMessageBus', () => {
   let writerBus: SQLiteAgentMessageBus;
   let readerBus: SQLiteAgentMessageBus;
 
-  beforeEach(async () => {
+  // Run migrations once per file. The shep schema is now ~80 migrations,
+  // and re-running them in beforeEach pushed the Windows CI runner past
+  // the 20s hookTimeout. Each test gets fresh connections + a clean
+  // agent_message table instead.
+  beforeAll(async () => {
     dbDir = mkdtempSync(join(tmpdir(), 'shep-bus-it-'));
     dbPath = join(dbDir, 'shep.db');
 
-    // Configure WAL mode on the file-backed DB so multiple connections work.
     const setupDb = new Database(dbPath);
     setupDb.pragma('journal_mode = WAL');
     setupDb.pragma('foreign_keys = ON');
     await runSQLiteMigrations(setupDb);
     setupDb.close();
+  });
 
+  afterAll(() => {
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
     writerDb = new Database(dbPath);
     writerDb.pragma('foreign_keys = ON');
 
     readerDb = new Database(dbPath);
     readerDb.pragma('foreign_keys = ON');
+
+    writerDb.exec('DELETE FROM agent_messages');
 
     const writerRepo = new SQLiteAgentMessageRepository(writerDb);
     const readerRepo = new SQLiteAgentMessageRepository(readerDb);
@@ -81,7 +92,6 @@ describe('SQLiteAgentMessageBus', () => {
     writerBus.shutdown();
     writerDb.close();
     readerDb.close();
-    rmSync(dbDir, { recursive: true, force: true });
   });
 
   it('publish + listFor across two connections (cross-process round-trip)', async () => {


### PR DESCRIPTION
## Summary

Main went red on `windows-latest` after #602 merged: the 4-test `SQLiteAgentMessageBus` integration suite was running all ~80 sqlite migrations once per test in `beforeEach`, which pushed the hook past the 20s `hookTimeout` configured in [vitest.config.ts](vitest.config.ts#L88). The first test's hook timed out at 20s; the rest passed against a now-warm filesystem cache.

Hoisting migrations into `beforeAll` (run once per file) makes the per-test setup cheap — each test still opens fresh writer/reader connections and clears `agent_messages` for isolation. Local run drops from ~780ms to ~550ms total. The cross-process publish/listFor contract (NFR-7) is still exercised end-to-end through two distinct file-backed connections.

## Failing run that prompted this

Job: `Unit Tests (windows-latest)` in run `25428385786` on `main` (post-#602 merge). Failure mode:

```
FAIL tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts > SQLiteAgentMessageBus > publish + listFor across two connections (cross-process round-trip)
Error: Hook timed out in 20000ms.
 ❯ tests/integration/infrastructure/services/agents/agent-message-bus/sqlite-agent-message-bus.test.ts:54:3   (beforeEach)
```

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run tests/integration/.../sqlite-agent-message-bus.test.ts` — 4/4 pass
- [ ] CI green on this branch (incl. `windows-latest` Unit Tests job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)