### PR TITLE
test(web): replace networkidle wait with element wait in i18n e2e

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,5 +1,18 @@
 # Lessons Learned
 
+## Playwright E2E — never use `waitForLoadState('networkidle')` in this app
+
+Symptom: random timeouts on `await page.waitForLoadState('networkidle')` after `page.goto(...)` — usually the first test in a suite, sometimes flaky-passing on retry.
+
+Root cause: every page in the web UI mounts inside `AppShell`, which wraps the tree in `AgentEventsProvider` (`src/presentation/web/components/layouts/app-shell/app-shell.tsx`). That provider opens a long-lived SSE connection to `/api/agent-events`, which polls SQLite every 500ms and emits a heartbeat / delta. `networkidle` requires zero network activity for 500ms — with a 500ms-cadence stream open, that condition is a coin flip and frequently never fires within the 30s test timeout.
+
+Rules:
+
+1. **Never call `page.waitForLoadState('networkidle')` in this codebase.** It will eventually break.
+2. Wait for an actual element instead: `await expect(page.getByTestId('foo')).toBeVisible()`. Playwright's `expect`/`click` already auto-waits for actionability, so a separate load-state wait is rarely needed at all.
+3. If you must gate on the page being "ready", pick a deterministic UI signal — a heading, a known testid, a data-loaded attribute — never the network.
+4. The same trap applies to any future test that hits `/api/agent-events`, `/api/interactive/chat/.../stream`, or `/api/terminal/.../stream` either directly or transitively through the shell.
+
 ## tsyringe `@injectable()` — every constructor param must be resolvable
 
 Symptom: worker boots crash with `Cannot inject the dependency at position #N of "X" constructor. Reason: TypeInfo not known for "Object"`.

--- a/tests/e2e/web/i18n-language-switching.spec.ts
+++ b/tests/e2e/web/i18n-language-switching.spec.ts
@@ -9,9 +9,10 @@ import { test, expect } from '@playwright/test';
 
 test.describe('i18n: language switching', () => {
   test('switching to Russian updates UI text immediately', async ({ page }) => {
-    // Navigate to settings page
+    // Navigate to settings page. Don't wait for `networkidle` — the app shell
+    // opens a long-lived SSE stream to /api/agent-events that keeps the
+    // network busy indefinitely, so `networkidle` never fires.
     await page.goto('/settings');
-    await page.waitForLoadState('networkidle');
 
     // Verify English text is shown initially
     const languageTitle = page.getByTestId('language-settings-section');
@@ -44,9 +45,9 @@ test.describe('i18n: language switching', () => {
 
   test('switching to Arabic sets RTL direction', async ({ page }) => {
     await page.goto('/settings');
-    await page.waitForLoadState('networkidle');
 
     const languageSelect = page.getByTestId('language-select');
+    await expect(languageSelect).toBeVisible();
     await languageSelect.click();
 
     await page.getByRole('option', { name: 'العربية' }).click();
@@ -62,9 +63,9 @@ test.describe('i18n: language switching', () => {
 
   test('switching to Spanish updates navigation text', async ({ page }) => {
     await page.goto('/settings');
-    await page.waitForLoadState('networkidle');
 
     const languageSelect = page.getByTestId('language-select');
+    await expect(languageSelect).toBeVisible();
     await languageSelect.click();
 
     await page.getByRole('option', { name: 'Español' }).click();


### PR DESCRIPTION
## Summary

Main is red on `E2E (Web)` because `tests/e2e/web/i18n-language-switching.spec.ts` calls `await page.waitForLoadState('networkidle')` after navigating to `/settings`. Every page in this app mounts inside [AppShell](src/presentation/web/components/layouts/app-shell/app-shell.tsx#L213) which opens a long-lived SSE stream to `/api/agent-events`, polling sqlite every 500ms. `networkidle` requires 500ms of zero network activity, so it can never fire deterministically while the stream is open — the test passed previously by luck and started timing out at 30s on [run 25431785018](https://github.com/shep-ai/shep/actions/runs/25431785018).

Replace `networkidle` with element-based waits in all three tests. The first test already asserts visibility on `language-settings-section`; the Arabic and Spanish tests now `expect(languageSelect).toBeVisible()` before clicking. Added a `LESSONS.md` entry banning `networkidle` in this codebase for future tests so this doesn't recur.

## Failing run

- [Run 25431785018](https://github.com/shep-ai/shep/actions/runs/25431785018), `E2E (Web)` job
- `i18n-language-switching.spec.ts:14` — `page.waitForLoadState: Test timeout of 30000ms exceeded.`
- Russian test failed all 3 retries, Arabic test was flaky-passing on retry — both share the same root cause.

## Test plan

- [x] `grep -rn "waitForLoadState.*networkidle" tests/` returns no other hits — single point of regression
- [x] Typecheck clean (run by lint-staged)
- [ ] CI green on this branch (`E2E (Web)` job is the one to watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)