### PR TITLE
fix(cli): drop fake graceful kill on windows in shep restart

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,5 +1,18 @@
 # Lessons Learned
 
+## Windows has no graceful kill — don't simulate one
+
+On Windows the `tree-kill` package always shells out to `taskkill /T /F`, regardless of which signal name you pass. There is no SIGTERM equivalent in the Windows kernel. So a "send SIGTERM, poll for graceful exit, then escalate to SIGKILL" pattern is theatrical on Windows: the very first call already force-killed the tree, and the polling loop is 5s of wasted budget waiting for a "graceful" exit that already happened forcefully.
+
+Concrete instance: `stopDaemon()` was paying up to 5s of poll budget on every Windows `shep restart`, which collided with a thin 20s e2e timeout on slow CI runners and broke main.
+
+Rules:
+
+1. Branch the kill flow on `process.platform === 'win32'`. On Windows do a single awaited `treeKill(pid, sig, cb)` call (the callback fires when `taskkill` actually returns), then one `isAlive` check. No poll loop, no escalation.
+2. Keep the SIGTERM-then-poll-then-SIGKILL flow on Unix — it's a real semantic, not theatre. Daemons may genuinely need time to flush state before exiting.
+3. `treeKill(pid, signal)` is fire-and-forget. If you care that the kill has actually been issued before you check liveness, pass a callback (or wrap it in a Promise). Otherwise you're polling against a kill that hasn't dispatched yet.
+4. Always check liveness *before* the first sleep in any poll-until-dead loop. Sleeping 200ms before the first check costs 200ms on every fast-exit path for no reason.
+
 ## tsyringe `@injectable()` — every constructor param must be resolvable
 
 Symptom: worker boots crash with `Cannot inject the dependency at position #N of "X" constructor. Reason: TypeInfo not known for "Object"`.

--- a/src/presentation/cli/commands/daemon/stop-daemon.ts
+++ b/src/presentation/cli/commands/daemon/stop-daemon.ts
@@ -1,20 +1,26 @@
 /**
  * stopDaemon() — Shared daemon-stop helper
  *
- * Contains the stop logic for gracefully terminating a running Shep daemon.
+ * Contains the stop logic for terminating a running Shep daemon.
  * Used by:
  *   - stop.command.ts (shep stop)
  *   - restart.command.ts (shep restart)
  *   - upgrade.command.ts (shep upgrade — stops before install)
  *
- * Stop sequence:
- *   1. Read daemon.json via IDaemonService
- *   2. If no daemon / PID not alive: silently clean up daemon.json and return
- *   3. Validate PID is a positive finite integer
- *   4. Send SIGTERM
- *   5. Poll process liveness every 200ms for up to 5000ms
- *   6. If still alive after 5s, send SIGKILL (errors suppressed — process may have exited)
- *   7. Always delete daemon.json (in finally block)
+ * Unix stop sequence (real graceful shutdown semantics):
+ *   1. Send SIGTERM to the process tree
+ *   2. Poll liveness every 200ms for up to 5000ms — the daemon may need
+ *      time to flush state, close DB connections, etc.
+ *   3. If still alive after 5s, escalate to SIGKILL
+ *
+ * Windows stop sequence (no graceful shutdown exists):
+ *   1. Run `taskkill /T /F` synchronously (always forceful — Windows has
+ *      no SIGTERM equivalent, and `tree-kill` always passes /F regardless
+ *      of which signal the caller specified)
+ *   2. Single liveness check; no polling loop, since the kill is already
+ *      forceful and synchronous
+ *
+ * In all paths, daemon.json is deleted in a `finally` block (NFR-2).
  *
  * @param daemonService - IDaemonService instance (injected by caller for testability, NFR-4)
  */
@@ -26,10 +32,14 @@ import { getCliI18n } from '../../i18n.js';
 
 const POLL_INTERVAL_MS = 200;
 const MAX_WAIT_MS = 5000;
+const isWindows = process.platform === 'win32';
 
 /**
  * Poll until the given PID is dead or the timeout expires.
  * Returns true if the process is dead, false if it survived the timeout.
+ *
+ * Checks before sleeping — a process that exits immediately should not pay
+ * a full poll-interval tax before being noticed.
  */
 async function pollUntilDead(
   daemonService: IDaemonService,
@@ -38,17 +48,30 @@ async function pollUntilDead(
   intervalMs: number
 ): Promise<boolean> {
   const deadline = Date.now() + maxMs;
-  while (Date.now() < deadline) {
+  while (true) {
+    if (!daemonService.isAlive(pid)) return true;
+    if (Date.now() >= deadline) return false;
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    if (!daemonService.isAlive(pid)) {
-      return true;
-    }
   }
-  return false;
 }
 
 /**
- * Stop the Shep daemon gracefully.
+ * Promise wrapper around `tree-kill`'s callback API. Resolves once the kill
+ * subprocess (`taskkill` on Windows, `kill`/`pgrep` on Unix) has finished.
+ * Errors are swallowed — the caller verifies death via `isAlive` afterwards.
+ */
+function awaitTreeKill(pid: number, signal: 'SIGTERM' | 'SIGKILL'): Promise<void> {
+  return new Promise((resolve) => {
+    try {
+      treeKill(pid, signal, () => resolve());
+    } catch {
+      resolve();
+    }
+  });
+}
+
+/**
+ * Stop the Shep daemon.
  * Safe to call when no daemon is running — silently cleans up stale daemon.json (NFR-2).
  */
 export async function stopDaemon(daemonService: IDaemonService): Promise<void> {
@@ -72,19 +95,24 @@ export async function stopDaemon(daemonService: IDaemonService): Promise<void> {
     const t = getCliI18n().t;
     messages.info(t('cli:ui.daemon.stoppingDaemon', { pid }));
 
-    // Send SIGTERM to process tree — request graceful shutdown
-    treeKill(pid, 'SIGTERM');
-
-    // Poll for up to 5s waiting for the process to exit
-    const died = await pollUntilDead(daemonService, pid, MAX_WAIT_MS, POLL_INTERVAL_MS);
-
-    if (!died) {
-      // Graceful shutdown timed out — force kill process tree
-      messages.info(t('cli:ui.daemon.sigkillFallback'));
-      try {
-        treeKill(pid, 'SIGKILL');
-      } catch {
-        // Process may have exited between the check and the kill — ignore
+    if (isWindows) {
+      // Windows: tree-kill resolves to `taskkill /T /F` regardless of the
+      // signal name, so SIGTERM and SIGKILL are identical here. Wait for
+      // taskkill to actually return before checking liveness — no polling
+      // loop, no escalation step.
+      await awaitTreeKill(pid, 'SIGTERM');
+    } else {
+      // Unix: SIGTERM gives the daemon a chance to shut down gracefully.
+      // Poll for up to 5s, then escalate to SIGKILL if needed.
+      treeKill(pid, 'SIGTERM');
+      const died = await pollUntilDead(daemonService, pid, MAX_WAIT_MS, POLL_INTERVAL_MS);
+      if (!died) {
+        messages.info(t('cli:ui.daemon.sigkillFallback'));
+        try {
+          treeKill(pid, 'SIGKILL');
+        } catch {
+          // Process may have exited between the check and the kill — ignore
+        }
       }
     }
 

--- a/tests/unit/commands/daemon/stop-daemon.test.ts
+++ b/tests/unit/commands/daemon/stop-daemon.test.ts
@@ -2,12 +2,16 @@
  * stopDaemon() Helper Unit Tests
  *
  * Tests for the shared daemon-stop helper.
- * Covers: SIGTERM path, SIGKILL fallback, not-running path, invalid PID path.
- * Uses tree-kill for cross-platform process tree termination.
+ * Covers: SIGTERM path, SIGKILL fallback (Unix only), not-running path,
+ * invalid PID path. Uses tree-kill for cross-platform process tree
+ * termination — the Windows path awaits the kill subprocess via callback,
+ * so the mock invokes the callback if one is supplied.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IDaemonService } from '@/application/ports/output/services/daemon-service.interface.js';
+
+const isWindows = process.platform === 'win32';
 
 // Mock tree-kill wrapper (must use vi.hoisted for factory reference)
 const { mockTreeKill } = vi.hoisted(() => ({ mockTreeKill: vi.fn() }));
@@ -42,6 +46,11 @@ describe('stopDaemon()', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    // The Windows code path awaits a callback-style treeKill. Default mock
+    // invokes the callback synchronously so promises resolve in tests.
+    mockTreeKill.mockImplementation((_pid: number, _sig: string, cb?: () => void) => {
+      if (typeof cb === 'function') cb();
+    });
   });
 
   afterEach(() => {
@@ -162,7 +171,11 @@ describe('stopDaemon()', () => {
       await vi.runAllTimersAsync();
       await p;
 
-      expect(mockTreeKill).toHaveBeenCalledWith(pid, 'SIGTERM');
+      // Windows path passes a third callback arg; Unix path is fire-and-forget.
+      // Check arg-by-arg so the test passes on both.
+      expect(mockTreeKill).toHaveBeenCalled();
+      expect(mockTreeKill.mock.calls[0]?.[0]).toBe(pid);
+      expect(mockTreeKill.mock.calls[0]?.[1]).toBe('SIGTERM');
     });
 
     it('does NOT send SIGKILL when process dies before grace window expires', async () => {
@@ -201,7 +214,10 @@ describe('stopDaemon()', () => {
     });
   });
 
-  describe('SIGKILL fallback path (grace window expires)', () => {
+  // Windows uses an always-forceful taskkill /T /F and skips the
+  // graceful-then-escalate dance entirely — the SIGKILL fallback path only
+  // exists on Unix.
+  describe.skipIf(isWindows)('SIGKILL fallback path (grace window expires)', () => {
     it('sends SIGKILL via tree-kill after 5s when process does not respond to SIGTERM', async () => {
       const pid = 12345;
       // Always alive — never responds to SIGTERM

--- a/tests/unit/commands/stop.command.test.ts
+++ b/tests/unit/commands/stop.command.test.ts
@@ -8,6 +8,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Command } from 'commander';
 
+const isWindows = process.platform === 'win32';
+
 // Mock tree-kill wrapper (must use vi.hoisted for factory reference)
 const { mockTreeKill } = vi.hoisted(() => ({ mockTreeKill: vi.fn() }));
 vi.mock('@/infrastructure/services/process/tree-kill', () => ({ treeKill: mockTreeKill }));
@@ -48,6 +50,11 @@ describe('stop command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    // The Windows code path awaits a callback-style treeKill. Default mock
+    // invokes the callback synchronously so promises resolve in tests.
+    mockTreeKill.mockImplementation((_pid: number, _sig: string, cb?: () => void) => {
+      if (typeof cb === 'function') cb();
+    });
   });
 
   afterEach(() => {
@@ -125,7 +132,11 @@ describe('stop command', () => {
       await vi.runAllTimersAsync();
       await parsePromise;
 
-      expect(mockTreeKill).toHaveBeenCalledWith(pid, 'SIGTERM');
+      // Windows path passes a third callback arg; Unix path is fire-and-forget.
+      // Check arg-by-arg so the test passes on both.
+      expect(mockTreeKill).toHaveBeenCalled();
+      expect(mockTreeKill.mock.calls[0]?.[0]).toBe(pid);
+      expect(mockTreeKill.mock.calls[0]?.[1]).toBe('SIGTERM');
     });
 
     it('does NOT send SIGKILL when process dies before 5s timeout', async () => {
@@ -168,7 +179,10 @@ describe('stop command', () => {
     });
   });
 
-  describe('SIGKILL fallback path', () => {
+  // Windows uses an always-forceful taskkill /T /F and skips the
+  // graceful-then-escalate dance entirely — the SIGKILL fallback path only
+  // exists on Unix.
+  describe.skipIf(isWindows)('SIGKILL fallback path', () => {
     it('sends SIGKILL after 5s when process does not respond to SIGTERM', async () => {
       const pid = 12345;
       mockDaemonService.read.mockResolvedValue({


### PR DESCRIPTION
## Summary

`stopDaemon()` was paying a "graceful kill then escalate" tax on Windows that doesn't make sense there. The `tree-kill` package on Windows always shells out to `taskkill /T /F` regardless of which signal you pass — there is no SIGTERM equivalent in the Windows kernel. So our existing flow:

1. fire `tree-kill` with `'SIGTERM'` → already force-killed the tree
2. poll `isAlive` every 200ms for up to **5 seconds**, "waiting for graceful exit"
3. fall back to `tree-kill` with `'SIGKILL'` → the same `taskkill /T /F` again

…was theatrical on Windows: step 2 spent up to 5s waiting for a graceful exit that does not exist on the platform. That collided with the 20s budget for the `shep restart` e2e on `windows-latest` and broke main on the post-#603 run.

This PR branches the kill flow on `process.platform`:

- **Windows:** one awaited `treeKill(pid, sig, cb)` (the callback fires when `taskkill` actually returns), then a single `isAlive` check. No poll loop, no escalation.
- **Unix:** unchanged semantics — SIGTERM, poll up to 5s, escalate to SIGKILL. Real graceful shutdown matters here; daemons may need to flush state.
- **All platforms:** `pollUntilDead` now checks liveness *before* the first sleep, saving 200ms on every fast-exit path.

Real users on Windows also get a faster `shep restart` as a side effect.

## Why this isn't bending the code to fit a test

The poll-then-escalate logic was wrong-on-Windows long before today's CI. Pretending `'SIGTERM'` does something distinct from `'SIGKILL'` on Windows is a category error — the test happened to be the messenger. Added a [LESSONS.md](LESSONS.md) entry so this stays fixed.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm vitest run tests/unit/commands/daemon/stop-daemon.test.ts` — 16/16 pass
- [x] `pnpm vitest run tests/unit/presentation/cli/commands/restart.command.test.ts` — 14/14 pass
- [x] Full daemon-lifecycle e2e on macOS (`SHEP_E2E_USE_DIST=1`) — 16/16 pass in 31s, restart test in 5994ms (unchanged)
- [ ] CI green on this branch — `E2E CLI (windows-latest)` is the one to watch; expect the failing restart test back under ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)