### PR TITLE
fix(web): seed applications page deployment provider with live data

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -533,3 +533,16 @@ The user ran `pnpm dev` and got an infinite Tailwind/Webpack rebuild loop spammi
 2. **Same rule applies to any `@import 'pkg'` in `app/globals.css`, `*.module.css`, or any CSS pulled into the Next.js graph.** It is NOT enough that the package is reachable from the importing CSS file's filesystem location — Tailwind v4's PostCSS plugin uses the Node process CWD-anchored resolver, not a CSS-file-anchored one, when run via the root `pnpm dev` script.
 3. **Sanity check after adding a CSS import:** `ls node_modules/<pkg>` must succeed at the repo root. If the symlink is missing, hoist by adding the dep to root `package.json` and running `pnpm install`.
 4. **Symptom to recognize fast:** repeating `Error: Can't resolve '<pkg>' in '/.../src/presentation'` (note the path stops at `src/presentation`, not `src/presentation/web/app`) interleaved with Tailwind rebuild timing logs. That path mismatch is the tell — it means the resolver is using the wrong base directory.
+
+## Per-Page DeploymentStatusProvider Mounts MUST Seed Real Data, Never `[]`
+
+The user reported that the live web preview status of an application was lost on refresh, and disappeared when navigating from `/application/[id]` back to `/applications`.
+
+**Root cause:** Each route mounts its own `<DeploymentStatusProvider>` (separate React contexts). The `/applications` page seeded the provider with `initialDeployments={[]}`. After hydrate, the store sets `fullyHydrated = true`. Then every `<ApplicationCard>` calls `useDeployAction(...)` → `ensureHydrated(appId)`, which short-circuits when `store.isFullyHydrated()` is true (intentional: it kills the burst of N server-action POSTs on canvas mount). With an empty seed, that short-circuit means NO card ever fetches its deployment status — so even running dev servers render with no preview iframe.
+
+**Rules for any route that mounts `<DeploymentStatusProvider>`:**
+
+1. **`initialDeployments={[]}` is a footgun.** The provider treats "first hydrate ran" as "I now know the full universe of deployments". An empty seed locks in "there are none" until the next prop change. Always seed with the actual list (from `ListDeploymentsUseCase` server-side, or via `listDeployments` server action in a `useQuery`).
+2. **Per-page providers do not share state across navigations.** A deployment started on `/application/[id]` does NOT carry over to `/applications`. Each route's provider is independent and MUST do its own hydration. The `(dashboard)/layout.tsx` flow seeds via `getGraphData()`; `application-page-loader.tsx` seeds via `/api/applications/[id]`; `/applications` was the missing case.
+3. **If you need polling for cross-tab/cross-page changes, drive it from the page's `useQuery` (`refetchInterval`) and pass the result as `initialDeployments` — the provider's `useEffect([initialDeployments])` re-runs `hydrate()`, which nulls out entries that disappeared and updates ones that changed.** Do NOT try to expand `ensureHydrated` to bypass the `fullyHydrated` flag — that re-introduces the per-node POST burst the flag exists to prevent.
+4. **Symptom to recognise fast:** "preview shows on app page but is gone on apps list / after refresh" → check the page's provider mount and look for `initialDeployments={[]}`.

--- a/src/presentation/web/components/features/applications/applications-page-client.tsx
+++ b/src/presentation/web/components/features/applications/applications-page-client.tsx
@@ -8,7 +8,9 @@ import { cn } from '@/lib/utils';
 import { DeploymentStatusProvider } from '@/hooks/deployment-status-provider';
 import { ControlCenterEmptyState } from '@/components/features/control-center/control-center-empty-state';
 import { ApplicationCard } from './application-card';
+import { listDeployments } from '@/app/actions/list-deployments';
 import type { ApplicationWithStatus } from '@shepai/core/application/use-cases/applications/list-applications.use-case';
+import type { DeploymentStatusEntry } from '@shepai/core/application/ports/output/services/deployment-service.interface';
 
 export interface ApplicationsPageClientProps {
   className?: string;
@@ -34,6 +36,18 @@ export function ApplicationsPageClient({ className }: ApplicationsPageClientProp
     staleTime: 30_000,
   });
 
+  // Live dev-server deployments — seeds the DeploymentStatusProvider so the
+  // app cards reflect previews started on /application/[id] (or another tab)
+  // instead of resetting every time this page mounts. Without this seed the
+  // provider's `fullyHydrated` flag (set by the empty SSR hydrate) blocks
+  // each card's `ensureHydrated` from fetching, leaving previews invisible.
+  const { data: deployments = [] } = useQuery<DeploymentStatusEntry[]>({
+    queryKey: ['deployments', 'all'],
+    queryFn: () => listDeployments(),
+    staleTime: 0,
+    refetchInterval: 3_000,
+  });
+
   const sorted = useMemo(
     () =>
       [...applications].sort(
@@ -43,7 +57,7 @@ export function ApplicationsPageClient({ className }: ApplicationsPageClientProp
   );
 
   return (
-    <DeploymentStatusProvider initialDeployments={[]}>
+    <DeploymentStatusProvider initialDeployments={deployments}>
       <div
         data-testid="applications-page-client"
         className={cn('relative flex min-h-full flex-col', className)}


### PR DESCRIPTION
## Summary

- `/applications` mounted `<DeploymentStatusProvider initialDeployments={[]}>`. The empty seed flips the store's `fullyHydrated` flag to `true`, which makes every `<ApplicationCard>`'s `ensureHydrated()` short-circuit and skip fetching real deployment status — so live previews never appeared on the apps grid, and state didn't survive refresh or navigation back from `/application/[id]`.
- Fix: fetch the live deployment list via the existing `listDeployments` server action with a 3 s `refetchInterval` and pass the result as `initialDeployments`. The provider's existing `useEffect([initialDeployments])` re-hydrates as data arrives, so cards reflect running previews on first paint, after refresh, after returning from the app detail page, and when started in another tab.
- Documented the per-page-provider seeding requirement in `LESSONS.md` so it doesn't regress.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm eslint` clean on the modified file
- [x] `deployment-status-store` + `useDeployAction` unit tests pass (16/16)
- [ ] Manual: start a dev server on `/application/[id]`, navigate to `/applications`, confirm the live preview iframe appears on the card
- [ ] Manual: refresh `/applications` while a preview is running, confirm it survives
- [ ] Manual: stop the dev server externally and confirm the card transitions back within ~3 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)