### PR TITLE
fix(agents): register isupervisoragent token so worker boots

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -546,3 +546,19 @@ The user ran `pnpm dev` and got an infinite Tailwind/Webpack rebuild loop spammi
 2. **Same rule applies to any `@import 'pkg'` in `app/globals.css`, `*.module.css`, or any CSS pulled into the Next.js graph.** It is NOT enough that the package is reachable from the importing CSS file's filesystem location — Tailwind v4's PostCSS plugin uses the Node process CWD-anchored resolver, not a CSS-file-anchored one, when run via the root `pnpm dev` script.
 3. **Sanity check after adding a CSS import:** `ls node_modules/<pkg>` must succeed at the repo root. If the symlink is missing, hoist by adding the dep to root `package.json` and running `pnpm install`.
 4. **Symptom to recognize fast:** repeating `Error: Can't resolve '<pkg>' in '/.../src/presentation'` (note the path stops at `src/presentation`, not `src/presentation/web/app`) interleaved with Tailwind rebuild timing logs. That path mismatch is the tell — it means the resolver is using the wrong base directory.
+
+## Every New Output-Port Token MUST Be Registered AND Listed in the Bootstrap Test
+
+Tsyringe walks every `@inject(token)` decorator on a class and resolves the **entire** constructor tree before any method on the resolved instance runs. That means:
+
+- A feature-flag short-circuit inside a use case (e.g. `if (!collaborationEnabled) return`) does NOT save you from a missing DI registration. The flag check runs in `execute()`, but the missing token blows up at `container.resolve(...)` — strictly before that.
+- An "optional, only-used-in-some-modes" port is still mandatory at construction time the moment any registered singleton transitively `@inject`s it.
+
+**How this failed in production (spec 093):** `ISupervisorAgent` was added as a port and wired through `EvaluateSupervisorDecisionUseCase` → `AgentQuestionSupervisorRouter` → `AskAgentQuestionUseCase` → `FeatureAgentGateQuestionPublisher` (registerSingleton in `register-agents.ts`). The token was never registered in any production DI module. Every feature-agent worker crashed at boot with `Attempted to resolve unregistered dependency token: "ISupervisorAgent"`, regardless of whether the user had ever enabled the supervisor.
+
+**Why CI didn't catch it:** `tests/integration/infrastructure/di/container-bootstrap.test.ts` only resolves tokens listed explicitly in `WEB_ROUTE_TOKENS` and `CRITICAL_INFRA_TOKENS`. A new port token that is only resolved transitively from a worker (not from a web route) will pass CI even when its registration is missing.
+
+**Rule:**
+1. When adding a new output port `IFoo` under `application/ports/output/`, register a concrete adapter under that string token in the appropriate `register-*.ts` module **in the same commit** as the first use case that injects it.
+2. Add the new token to `CRITICAL_INFRA_TOKENS` in `container-bootstrap.test.ts`. If the token is consumed only by background workers (feature-agent, supervisor, deployment), it MUST appear there — web routes alone do not exercise worker constructor trees.
+3. When adding any `registerSingleton(SomeWorkerHelper)` in `register-agents.ts`, mentally trace its full `@inject` graph and confirm every leaf token is registered. The tsyringe error message *names* the missing token, but the full chain only shows up at runtime, never at build time.

--- a/packages/core/src/infrastructure/di/modules/register-agents.ts
+++ b/packages/core/src/infrastructure/di/modules/register-agents.ts
@@ -13,6 +13,7 @@ import type { ISpecInitializerService } from '../../../application/ports/output/
 import type { ISpecArtifactParser } from '../../../application/ports/output/services/spec-artifact-parser.interface.js';
 import type { ISettingsRepository } from '../../../application/ports/output/repositories/settings.repository.interface.js';
 import type { IAgentSessionRepositoryRegistry } from '../../../application/ports/output/agents/agent-session-repository-registry.interface.js';
+import type { ISupervisorAgent } from '../../../application/ports/output/agents/supervisor-agent.interface.js';
 
 import { AgentExecutorFactory } from '../../services/agents/common/agent-executor-factory.service.js';
 import { AgentExecutorProvider } from '../../services/agents/common/agent-executor-provider.service.js';
@@ -32,6 +33,7 @@ import { AgentType } from '../../../domain/generated/output.js';
 import { FeatureAgentLifecyclePublisher } from '../../services/agents/feature-agent/feature-agent-lifecycle-publisher.js';
 import { FeatureAgentGateQuestionPublisher } from '../../services/agents/feature-agent/feature-agent-gate-question-publisher.js';
 import { FeatureAgentSupervisorGateEvaluator } from '../../services/agents/feature-agent/feature-agent-supervisor-gate-evaluator.js';
+import { LangGraphSupervisorAgent } from '../../services/agents/supervisor-agent/langgraph-supervisor-agent.js';
 
 /**
  * Register agent-execution infrastructure: executor factory/provider, runner,
@@ -147,4 +149,12 @@ export function registerAgents(container: DependencyContainer): void {
   // advisory / co-sign modes the decision is recorded but the gate
   // stays in waiting_approval for the user.
   container.registerSingleton(FeatureAgentSupervisorGateEvaluator);
+
+  // ISupervisorAgent — production adapter behind the supervisor port (spec 093).
+  // Tsyringe eagerly resolves the entire constructor tree of every singleton
+  // it builds, so AskAgentQuestionUseCase → AgentQuestionSupervisorRouter →
+  // EvaluateSupervisorDecisionUseCase needs this token to exist *before* any
+  // feature-flag short-circuit can run. Forgetting this registration crashes
+  // every feature-agent worker on boot, even when the collaboration flag is off.
+  container.registerSingleton<ISupervisorAgent>('ISupervisorAgent', LangGraphSupervisorAgent);
 }

--- a/packages/core/src/infrastructure/services/agents/supervisor-agent/langgraph-supervisor-agent.ts
+++ b/packages/core/src/infrastructure/services/agents/supervisor-agent/langgraph-supervisor-agent.ts
@@ -1,0 +1,42 @@
+/**
+ * LangGraphSupervisorAgent — production adapter for {@link ISupervisorAgent}.
+ *
+ * Wraps {@link createSupervisorAgent} and resolves the underlying
+ * {@link IAgentExecutor} lazily through {@link IAgentExecutorProvider}, so a
+ * change to the user's default agent (settings) is honored on the next
+ * evaluation without a process restart.
+ *
+ * Side-effect free: persistence, audit-log mirroring, and policy lookup are
+ * all owned by {@link EvaluateSupervisorDecisionUseCase}. This adapter is
+ * just the LLM-facing surface behind the port.
+ */
+
+import { injectable, inject } from 'tsyringe';
+
+import type {
+  ISupervisorAgent,
+  SupervisorDecisionResult,
+  SupervisorEvaluateInput,
+} from '../../../../application/ports/output/agents/supervisor-agent.interface.js';
+import type { IAgentExecutorProvider } from '../../../../application/ports/output/agents/agent-executor-provider.interface.js';
+import type { IAgentPromptResolver } from '../../../../application/ports/output/agents/agent-prompt-resolver.interface.js';
+import { createSupervisorAgent } from './supervisor-graph.js';
+
+@injectable()
+export class LangGraphSupervisorAgent implements ISupervisorAgent {
+  constructor(
+    @inject('IAgentExecutorProvider')
+    private readonly executorProvider: IAgentExecutorProvider,
+    @inject('IAgentPromptResolver')
+    private readonly promptResolver: IAgentPromptResolver
+  ) {}
+
+  async evaluate(input: SupervisorEvaluateInput): Promise<SupervisorDecisionResult> {
+    const executor = await this.executorProvider.getExecutor();
+    const inner = createSupervisorAgent({
+      executor,
+      promptResolver: this.promptResolver,
+    });
+    return inner.evaluate(input);
+  }
+}

--- a/tests/integration/infrastructure/di/container-bootstrap.test.ts
+++ b/tests/integration/infrastructure/di/container-bootstrap.test.ts
@@ -149,6 +149,16 @@ const CRITICAL_INFRA_TOKENS: readonly string[] = [
   'IAgentExecutorProvider',
   'IOperationLogRepository',
   'IOperationLogService',
+  // Supervisor pipeline (spec 093). The feature-agent worker eagerly
+  // constructs FeatureAgentGateQuestionPublisher → AskAgentQuestionUseCase →
+  // AgentQuestionSupervisorRouter → EvaluateSupervisorDecisionUseCase, which
+  // injects 'ISupervisorAgent'. A missing registration here crashes the worker
+  // at boot — list the token explicitly so any future deletion fails this test
+  // instead of feature runs.
+  'ISupervisorAgent',
+  'IAgentPromptResolver',
+  'ISupervisorPolicyRepository',
+  'ISupervisorDecisionRepository',
 ] as const;
 
 describe('DI container bootstrap (integration)', () => {


### PR DESCRIPTION
## Summary

- Every recent feature crashed at worker boot with `Attempted to resolve unregistered dependency token: "ISupervisorAgent"`. Spec 093 added the port and threaded it through `EvaluateSupervisorDecisionUseCase` → `AgentQuestionSupervisorRouter` → `AskAgentQuestionUseCase` → `FeatureAgentGateQuestionPublisher` (registered as a singleton in `register-agents.ts`), but the token itself was never registered. Tsyringe walks the entire `@inject` tree at construction, so the worker died before the collaboration feature flag could short-circuit anything.
- Added a production adapter `LangGraphSupervisorAgent` that wraps `createSupervisorAgent` and lazily resolves `IAgentExecutor` through `IAgentExecutorProvider` per call (so settings changes are honored without a restart). Registered it under `'ISupervisorAgent'` in `register-agents.ts`.
- Extended the `container-bootstrap` regression test with `ISupervisorAgent`, `IAgentPromptResolver`, `ISupervisorPolicyRepository`, `ISupervisorDecisionRepository`. The test was supposed to catch this class of regression but only listed web-route tokens — worker-only chains slipped through.
- New `LESSONS.md` entry capturing why feature-flag short-circuits don't save you from missing DI and why bootstrap tests need to cover worker-only tokens.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run tests/integration/infrastructure/di/container-bootstrap.test.ts` (75/75)
- [x] `pnpm vitest run tests/unit/application/use-cases/agents/evaluate-supervisor-decision.use-case.test.ts tests/unit/application/use-cases/agents/agent-question-supervisor-router.test.ts` (16/16)
- [x] `shep feat resume <crashed-feature>` — worker boots past `Initializing container...`, runs `fast-implement`, spawns the claude subprocess
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)