### PR TITLE
fix(web): auto-start dev server after every agent turn

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -576,3 +576,20 @@ Tsyringe walks every `@inject(token)` decorator on a class and resolves the **en
 1. When adding a new output port `IFoo` under `application/ports/output/`, register a concrete adapter under that string token in the appropriate `register-*.ts` module **in the same commit** as the first use case that injects it.
 2. Add the new token to `CRITICAL_INFRA_TOKENS` in `container-bootstrap.test.ts`. If the token is consumed only by background workers (feature-agent, supervisor, deployment), it MUST appear there — web routes alone do not exercise worker constructor trees.
 3. When adding any `registerSingleton(SomeWorkerHelper)` in `register-agents.ts`, mentally trace its full `@inject` graph and confirm every leaf token is registered. The tsyringe error message _names_ the missing token, but the full chain only shows up at runtime, never at build time.
+
+## Auto-Deploy Must Trigger on Agent-Finishes Transition, Not on `setupComplete` SSE Race
+
+The user reported that the web preview did not start automatically after the initial build finished, and did not restart after a chat iteration.
+
+**Two compounding bugs:**
+
+1. `useDevServerCoordinator` only restarted the dev server after the agent finished IF it was running BEFORE the agent started (`wasRunningBeforeAgentRef`). On the very first build, the server was never running → ref stayed `false` → no auto-start. On any subsequent iteration where the user hadn't manually started the preview, same story.
+2. The fallback in `ApplicationPage.onAllStepsComplete` was gated on `application.setupComplete === false` (the SSR prop). But `setupComplete` is flipped to `true` by an SSE-driven `useApplicationUpdate` cache patch. The "workflow done" SSE event and the "setupComplete=true" SSE event arrive close together — when the latter races ahead, the gate blocks the auto-deploy.
+
+**Rules for any "auto-start the dev server when X completes" logic:**
+
+1. **Drive auto-deploy off the `agentRunning` transition (`true → false`), not off a derived/SSR'd "completed" flag.** The agent transition is observable directly from the chat-state cache and doesn't depend on which SSE event arrived first.
+2. **Never gate auto-deploy on "was the server running BEFORE the agent started?"** — that's a presence test for an irrelevant prior state. The user wants to see the result of the iteration regardless of whether they had manually clicked "Run" earlier.
+3. **Single source of truth.** If you have two effects firing `deploy.deploy()` on the same event (e.g. `useDevServerCoordinator` AND a `onAllStepsComplete` callback), kill one — `deploymentService.start()` is NOT idempotent (see `deployment.service.ts` line 231-238: it kills any existing deployment and starts a new one), so two parallel calls can race and tear down the in-flight spawn.
+4. **Always status-guard before calling `deploy.deploy()`:** skip when `deploy.status === Ready || Booting || deploy.deployLoading`. This is the only protection against a stray double-fire that would kill an in-progress spawn.
+5. **Do NOT add "respect explicit user stop" complexity unless the user asks for it.** The simpler invariant — "after the agent finishes, the preview is up" — matches what users want 99% of the time. Manual stop is a transient user action; it does not need to persist across iterations.

--- a/src/presentation/web/components/features/application-page/application-page.tsx
+++ b/src/presentation/web/components/features/application-page/application-page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { Application } from '@shepai/core/domain/generated/output';
-import { ApplicationStatus, DeploymentState } from '@shepai/core/domain/generated/output';
+import type { Application, DeploymentState } from '@shepai/core/domain/generated/output';
+import { ApplicationStatus } from '@shepai/core/domain/generated/output';
 import type { ChatState } from '@shepai/core/application/ports/output/services/interactive-session-service.interface';
 import { featureIdForApplication } from '@shepai/core/domain/shared/feature-id';
 
@@ -152,38 +152,6 @@ export function ApplicationPage({ application, initialChatState }: ApplicationPa
               void fetch(`/api/applications/${application.id}/resume`, { method: 'POST' });
             }}
             applicationError={applicationError}
-            onAllStepsComplete={() => {
-              // CRITICAL: only auto-deploy on the VERY FIRST completion
-              // of the setup workflow. `application.setupComplete` is
-              // set to `true` by the use case right after the workflow
-              // finishes, and persists on the Application row forever.
-              //
-              //   - Fresh app: SSR prop is `false` (workflow hasn't
-              //     completed yet) → we auto-fire → dev server starts →
-              //     use case later sets setupComplete = true.
-              //   - Revisit: SSR prop is `true` → we skip. If the user
-              //     explicitly stopped the dev server before leaving,
-              //     they stay stopped. Respect the explicit state — do
-              //     NOT silently re-start the preview on every return
-              //     to the app page.
-              //
-              // This gate replaces an earlier "once per mount" ref
-              // guard that reset on every remount (React remounts the
-              // ChatTab when the user navigates back), which caused
-              // the auto-deploy to fire on every revisit.
-              if (application.setupComplete) return;
-
-              // First-ever completion path. Guard against double-fires
-              // mid-transition (Ready/Booting/in-flight deployLoading)
-              // just in case something else kicks the deploy before us.
-              if (
-                deploy.status !== DeploymentState.Ready &&
-                deploy.status !== DeploymentState.Booting &&
-                !deploy.deployLoading
-              ) {
-                void deploy.deploy();
-              }
-            }}
           />
         }
         right={

--- a/src/presentation/web/components/features/application-page/use-dev-server-coordinator.ts
+++ b/src/presentation/web/components/features/application-page/use-dev-server-coordinator.ts
@@ -8,9 +8,15 @@
  *
  *   - Stop the dev server when the agent starts a turn (because the code
  *     it's about to change is exactly what the dev server is running).
- *   - Remember whether the dev server was running before the agent
- *     started so we can RESTART it (not cold-start it) when the turn
- *     finishes.
+ *   - When the agent finishes a turn, ensure the dev server is up so the
+ *     user immediately sees the result of the iteration. This covers the
+ *     initial build (agent ran during scaffolding/codegen, finishes →
+ *     auto-start) AND every subsequent edit iteration. We deliberately
+ *     do NOT gate this on "was the dev server running BEFORE the agent
+ *     started?" — that gate (the old `wasRunningBeforeAgentRef`) left
+ *     the user with no preview after the very first build (server was
+ *     never running) and after any iteration where the user had not yet
+ *     started the preview.
  *   - Auto-switch the right pane to the Web tab the first time the dev
  *     server reaches Ready after a cold start, so the user lands on
  *     their running app with zero clicks.
@@ -56,19 +62,14 @@ export function useDevServerCoordinator({
   // detect the start/end transitions.
   const prevAgentRunningRef = useRef(false);
 
-  // Track whether the dev server was running before the agent started,
-  // so we only restart it (not cold-start) after the agent finishes.
-  const wasRunningBeforeAgentRef = useRef(false);
-
   useEffect(() => {
     const wasRunning = prevAgentRunningRef.current;
     prevAgentRunningRef.current = agentRunning;
 
     if (agentRunning && !wasRunning) {
-      // Agent just started — stop the dev server if running, remember
-      // that it was running so we can restart after.
+      // Agent just started — stop the dev server if running so the
+      // code it's about to change isn't being served stale.
       if (deploy.status === DeploymentState.Ready || deploy.status === DeploymentState.Booting) {
-        wasRunningBeforeAgentRef.current = true;
         void deploy.stop();
       }
       // Intentionally no longer auto-switch away from the Web tab —
@@ -77,10 +78,18 @@ export function useDevServerCoordinator({
     }
 
     if (!agentRunning && wasRunning) {
-      // Agent just finished — restart the dev server if it was
-      // previously running.
-      if (wasRunningBeforeAgentRef.current) {
-        wasRunningBeforeAgentRef.current = false;
+      // Agent just finished — ensure the dev server is up so the user
+      // immediately sees the result. We always try to start it (no
+      // "was it running before?" gate), and rely on the status guard
+      // below to avoid double-firing when the server is already
+      // coming up. This is the single source of truth for auto-deploy
+      // on agent transitions; it covers the initial build AND every
+      // iteration, both of which end with this transition.
+      if (
+        deploy.status !== DeploymentState.Ready &&
+        deploy.status !== DeploymentState.Booting &&
+        !deploy.deployLoading
+      ) {
         void deploy.deploy();
       }
     }


### PR DESCRIPTION
## Summary

Web preview wasn't starting automatically after the initial build, and wasn't restarting after a chat iteration. Two compounding bugs:

- `useDevServerCoordinator` only restarted the dev server after the agent finished IF it was running BEFORE the agent started (`wasRunningBeforeAgentRef` gate). Initial build → server was never running → no auto-start. Iterations where the user hadn't manually started the preview → same.
- The fallback in `ApplicationPage.onAllStepsComplete` was gated on `application.setupComplete === false` (SSR prop). That prop is flipped to `true` by an SSE-driven `useApplicationUpdate` cache patch — when the "setupComplete" SSE event raced ahead of the "workflow done" SSE event, the gate blocked the auto-deploy.

## Fix

- Drop the `wasRunningBeforeAgentRef` gate. Agent-finishes transition (`agentRunning: true → false`) now always tries to start the dev server, with the existing `!Ready && !Booting && !deployLoading` status guard preventing double-fires.
- Remove the racy `onAllStepsComplete` auto-deploy block from `ApplicationPage`. The coordinator is now the single source of truth — important because `deploymentService.start()` is NOT idempotent (it kills any existing deployment), so two parallel `deploy.deploy()` calls can tear down the in-flight spawn.
- Documented the rules in `LESSONS.md`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm eslint` clean on changed files
- [x] `application-page-loader-patch` + `use-deploy-action` unit tests pass (11/11)
- [ ] Manual: create a fresh application, wait for build to finish — preview should auto-start without user interaction
- [ ] Manual: send a chat iteration ("change the title") — agent edits code, finishes, preview should restart automatically
- [ ] Manual: stop the dev server manually, send a chat iteration — preview restarts after agent finishes (intentional behavior change vs old code)
- [ ] Manual: revisit `/application/[id]` with no agent activity — no auto-deploy on every revisit (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)