### PR TITLE
[codex] add DoctorSummary state stories

### DIFF
--- a/src/presentation/web/components/contributors/DoctorSummary.stories.tsx
+++ b/src/presentation/web/components/contributors/DoctorSummary.stories.tsx
@@ -77,16 +77,33 @@ const hasFail: DoctorSummaryReport = {
   ],
 };
 
+const doctorError: DoctorSummaryReport = {
+  overallStatus: DiagnosticStatus.Fail,
+  summary: { ok: 0, warn: 0, fail: 1 },
+  results: [
+    {
+      name: 'doctor-runner',
+      status: DiagnosticStatus.Fail,
+      detail: 'Doctor diagnostics failed before all checks completed',
+      fixHint: 'Run `shep doctor --verbose` and retry after resolving the reported error',
+    },
+  ],
+};
+
 export const AllOk: Story = {
   args: { report: allOk },
 };
 
-export const MixedWarn: Story = {
+export const WithWarnings: Story = {
   args: { report: mixedWarn },
 };
 
-export const HasFail: Story = {
+export const WithFailures: Story = {
   args: { report: hasFail },
+};
+
+export const ErrorState: Story = {
+  args: { report: doctorError },
 };
 
 export const Loading: Story = {


### PR DESCRIPTION
## Summary
- rename the existing warning and failure stories to the requested `WithWarnings` and `WithFailures` exports
- add an `ErrorState` story using a failed doctor-run report
- keep the component unchanged and preserve the existing `AllOk` and `Loading` stories

Closes #620

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm install --frozen-lockfile
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec prettier --check src/presentation/web/components/contributors/DoctorSummary.stories.tsx
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec eslint src/presentation/web/components/contributors/DoctorSummary.stories.tsx --max-warnings 0
- git diff --check
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm build:storybook

Note: Node 22 was used because the project CI and engines target Node >=22, while local Node 26 cannot compile the locked better-sqlite3 version.