### PR TITLE
docs(cli): add help examples to user commands

### DIFF
--- a/src/presentation/cli/commands/contributors/groom-issue.command.ts
+++ b/src/presentation/cli/commands/contributors/groom-issue.command.ts
@@ -40,6 +40,14 @@ function parseIssuesEvent(raw: unknown): IssuesEventPayload {
 export function createGroomIssueCommand(): Command {
   return new Command('groom-issue')
     .description('Groom a newly opened GitHub issue (GitHub Actions entry).')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep contributors groom-issue                                                   Run from GitHub Actions event context
+  $ GITHUB_EVENT_PATH=event.json shep contributors groom-issue                       Read a local issue event payload
+  $ GITHUB_EVENT_PATH=event.json GITHUB_REPOSITORY=shep-ai/shep shep contributors groom-issue`
+    )
     .action(async () => {
       try {
         const payload = parseIssuesEvent(loadGitHubEvent());

--- a/src/presentation/cli/commands/contributors/welcome-pr.command.ts
+++ b/src/presentation/cli/commands/contributors/welcome-pr.command.ts
@@ -45,6 +45,14 @@ function parsePullRequestEvent(raw: unknown): PullRequestEventPayload {
 export function createWelcomePrCommand(): Command {
   return new Command('welcome-pr')
     .description('Welcome a first-time contributor on pull_request.opened (GitHub Actions entry).')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep contributors welcome-pr                                                   Run from GitHub Actions event context
+  $ GITHUB_EVENT_PATH=event.json shep contributors welcome-pr                       Read a local pull_request event payload
+  $ GITHUB_EVENT_PATH=event.json GITHUB_REPOSITORY=shep-ai/shep shep contributors welcome-pr`
+    )
     .action(async () => {
       try {
         const payload = parsePullRequestEvent(loadGitHubEvent());

--- a/src/presentation/cli/commands/doctor.command.ts
+++ b/src/presentation/cli/commands/doctor.command.ts
@@ -32,6 +32,14 @@ const NAME_WIDTH = 24;
 export function createDoctorCommand(options: DoctorOptions = {}): Command {
   return new Command('doctor')
     .description('Diagnose the local Shep contributor environment')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep doctor                         Check local contributor setup
+  $ SHEP_HOME=/tmp/shep-home shep doctor Check an isolated Shep home
+  $ shep doctor && pnpm test            Run tests only when diagnostics pass`
+    )
     .action(async () => {
       try {
         const useCase = options.resolveUseCase

--- a/src/presentation/cli/commands/status.command.ts
+++ b/src/presentation/cli/commands/status.command.ts
@@ -192,6 +192,15 @@ export function createStatusCommand(): Command {
     .description(t('cli:commands.status.description'))
     .option('--logs [lines]', t('cli:commands.status.logsOption'))
     .option('-f, --follow', t('cli:commands.status.followOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep status                 Show daemon status and resource usage
+  $ shep status --logs          Print the last 50 daemon log lines
+  $ shep status --logs 100      Print the last 100 daemon log lines
+  $ shep status --logs --follow Follow daemon logs in real time`
+    )
     .action(async (options: { logs?: string | true; follow?: boolean }) => {
       const logPath = getDaemonLogPath();
 

--- a/src/presentation/cli/commands/stop.command.ts
+++ b/src/presentation/cli/commands/stop.command.ts
@@ -19,17 +19,27 @@ import { getCliI18n } from '../i18n.js';
  */
 export function createStopCommand(): Command {
   const t = getCliI18n().t;
-  return new Command('stop').description(t('cli:commands.stop.description')).action(async () => {
-    const daemonService = container.resolve<IDaemonService>('IDaemonService');
+  return new Command('stop')
+    .description(t('cli:commands.stop.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep stop          Stop the running Shep daemon
+  $ shep status        Check daemon state before stopping
+  $ shep restart       Restart the daemon after stopping`
+    )
+    .action(async () => {
+      const daemonService = container.resolve<IDaemonService>('IDaemonService');
 
-    const state = await daemonService.read();
+      const state = await daemonService.read();
 
-    // Print a user-facing message when no daemon state is recorded at all.
-    // The alive-but-stale case (state exists, PID dead) is handled silently by stopDaemon.
-    if (!state) {
-      messages.info(t('cli:commands.stop.noDaemonRunning'));
-    }
+      // Print a user-facing message when no daemon state is recorded at all.
+      // The alive-but-stale case (state exists, PID dead) is handled silently by stopDaemon.
+      if (!state) {
+        messages.info(t('cli:commands.stop.noDaemonRunning'));
+      }
 
-    await stopDaemon(daemonService);
-  });
+      await stopDaemon(daemonService);
+    });
 }

--- a/src/presentation/cli/commands/tools.command.ts
+++ b/src/presentation/cli/commands/tools.command.ts
@@ -17,7 +17,14 @@ import { getCliI18n } from '../i18n.js';
  */
 export function createToolsCommand(): Command {
   const t = getCliI18n().t;
-  const tools = new Command('tools').description(t('cli:commands.tools.description'));
+  const tools = new Command('tools').description(t('cli:commands.tools.description')).addHelpText(
+    'after',
+    `
+Examples:
+  $ shep tools                 Show available tools subcommands
+  $ shep tools list            List tools and installation status
+  $ shep tools list | grep missing`
+  );
 
   tools
     .command('list')


### PR DESCRIPTION
Closes #622.

## Summary
- adds `Examples:` help blocks to the six user-facing CLI commands named in the issue
- covers doctor, status, stop, tools, contributors groom-issue, and contributors welcome-pr
- keeps behavior unchanged; this only extends Commander help output

## Verification
- `pnpm exec prettier --write src/presentation/cli/commands/doctor.command.ts src/presentation/cli/commands/status.command.ts src/presentation/cli/commands/stop.command.ts src/presentation/cli/commands/tools.command.ts src/presentation/cli/commands/contributors/groom-issue.command.ts src/presentation/cli/commands/contributors/welcome-pr.command.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- spot-checked rendered help via `pnpm cli <command> --help` for all six commands
- commit hook: `pnpm generate`, ESLint, Prettier, typecheck
