### PR TITLE
docs: add contributor use case jsdoc

### DIFF
--- a/packages/core/src/application/use-cases/contributors/award-recognition.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/award-recognition.use-case.ts
@@ -33,9 +33,15 @@ const CONTRIBUTOR_THRESHOLD_PRS = 1;
 const CORE_THRESHOLD_PRS = 5;
 const MAINTAINER_THRESHOLD_PRS = 25;
 
+/**
+ * Command input for recording a recognition event for one contributor.
+ */
 export interface AwardRecognitionInput {
+  /** Stable contributor UUID that must already exist in the contributor repository. */
   contributorId: string;
+  /** Recognition category that drives idempotency and all-contributors contribution type. */
   kind: RecognitionKind;
+  /** GitHub pull request number associated with PR-based recognition; repository-local count. */
   prNumber: number;
   /** ISO 8601 timestamp the recognition occurred at. Defaults to "now". */
   occurredAt?: string;
@@ -43,7 +49,11 @@ export interface AwardRecognitionInput {
   monthRecapId?: string;
 }
 
+/**
+ * Outcome of an attempted recognition insert and any resulting contributor mutation.
+ */
 export interface AwardRecognitionResult {
+  /** True only when the recognition row was newly inserted, not replayed. */
   awarded: boolean;
   /** Recognition event row — only meaningful when `awarded` is true. */
   event?: RecognitionEvent;
@@ -122,6 +132,9 @@ function isPrKind(kind: RecognitionKind): boolean {
   return kind === RecognitionKind.FirstPR || kind === RecognitionKind.NthPR;
 }
 
+/**
+ * Returns the highest contributor ladder level reached by the current level and PR count.
+ */
 export function nextLevel(current: ContributorLevel, prCount: number): ContributorLevel {
   if (prCount >= MAINTAINER_THRESHOLD_PRS)
     return highestLevel(current, ContributorLevel.Maintainer);

--- a/packages/core/src/application/use-cases/contributors/classify-into-lane.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/classify-into-lane.use-case.ts
@@ -17,6 +17,9 @@ import { inject, injectable } from 'tsyringe';
 import { ContributorLane } from '../../../domain/generated/output.js';
 import type { IAgentExecutorProvider } from '../../ports/output/agents/agent-executor-provider.interface.js';
 
+/**
+ * Issue content and label context used to route a contributor task to one lane.
+ */
 export interface ClassifyIntoLaneInput {
   /** Issue title — usually the strongest signal via prefix conventions. */
   title: string;
@@ -26,7 +29,11 @@ export interface ClassifyIntoLaneInput {
   existingLabels?: readonly string[];
 }
 
+/**
+ * Lane classification result, including how the decision was made.
+ */
 export interface ClassifyIntoLaneResult {
+  /** Single TypeSpec-defined lane selected for the issue. */
   lane: ContributorLane;
   /** Source of the decision — useful for audit, opt-out, and tests. */
   source: 'rules' | 'agent';

--- a/packages/core/src/application/use-cases/contributors/detect-stale-good-first-issue.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/detect-stale-good-first-issue.use-case.ts
@@ -16,10 +16,19 @@ import type {
 
 const DEFAULT_STALE_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Canonical label queried when looking for stale newcomer-friendly issues.
+ */
 export const GOOD_FIRST_ISSUE_LABEL = 'good-first-issue';
 
+/**
+ * Repository and threshold parameters for stale good-first-issue detection.
+ */
 export interface DetectStaleGoodFirstIssueInput {
+  /** GitHub repository owner or organization login. */
   owner: string;
+  /** GitHub repository name within `owner`. */
   repo: string;
   /** Stale threshold in days. Defaults to 30. Must be > 0. */
   staleDays?: number;
@@ -27,11 +36,19 @@ export interface DetectStaleGoodFirstIssueInput {
   now?: Date;
 }
 
+/**
+ * Good-first issue whose last activity is at or older than the stale cutoff.
+ */
 export interface StaleIssue {
+  /** GitHub repository owner or organization login. */
   owner: string;
+  /** GitHub repository name within `owner`. */
   repo: string;
+  /** GitHub issue number scoped to the repository. */
   issueNumber: number;
+  /** Current issue title returned by the external issue fetcher. */
   title: string;
+  /** Browser URL for the issue. */
   url: string;
   /** ISO 8601 timestamp the fetcher reported as the last activity. */
   lastActivityAt: string;
@@ -39,8 +56,13 @@ export interface StaleIssue {
   staleForDays: number;
 }
 
+/**
+ * Stale issue query result with the effective threshold used for the run.
+ */
 export interface DetectStaleGoodFirstIssueResult {
+  /** Effective stale threshold in days after defaults and validation. */
   thresholdDays: number;
+  /** Issues whose last activity is outside the effective threshold. */
   stale: readonly StaleIssue[];
 }
 

--- a/packages/core/src/application/use-cases/contributors/draft-outreach-post.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/draft-outreach-post.use-case.ts
@@ -24,8 +24,14 @@ const SYSTEM_PROMPT = [
   `Hard limit: ${DRAFT_TARGET_LENGTH} characters; the channel rejects anything past 2000.`,
 ].join(' ');
 
+/**
+ * Outreach prompt category used to frame the generated Discord draft.
+ */
 export type OutreachDraftKind = 'release' | 'recap' | 'milestone';
 
+/**
+ * Input facts used to draft one outbound community announcement.
+ */
 export interface DraftOutreachPostInput {
   /** Drives prompt framing — release vs recap vs milestone. */
   kind: OutreachDraftKind;
@@ -37,8 +43,13 @@ export interface DraftOutreachPostInput {
   link?: string;
 }
 
+/**
+ * Pure draft payload for the supported outreach channel.
+ */
 export interface DraftOutreachPost {
+  /** Delivery channel for v1 outreach drafts; currently Discord only. */
   channel: 'discord';
+  /** Discord-flavored markdown body capped below Discord's 2000-character hard limit. */
   body: string;
 }
 

--- a/packages/core/src/application/use-cases/contributors/generate-monthly-recap.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/generate-monthly-recap.use-case.ts
@@ -21,6 +21,9 @@ import type { RecapArtifact } from '../../ports/output/services/recap-publisher.
 
 const YEAR_MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
 
+/**
+ * Query parameters for building a contributor recap for one UTC month.
+ */
 export interface GenerateMonthlyRecapInput {
   /** UTC year-month bucket (e.g. `2026-04`). */
   yearMonth: string;
@@ -28,16 +31,29 @@ export interface GenerateMonthlyRecapInput {
   projectName?: string;
 }
 
+/**
+ * Aggregate counters and highlights computed for a monthly contributor recap.
+ */
 export interface RecapStats {
+  /** Count of recognition events included in the month. */
   totalEvents: number;
+  /** Count of first-PR or first-issue recognitions in the month. */
   newContributors: number;
+  /** Count of PR-based recognitions in the month. */
   prsRecognized: number;
+  /** Lane with the most recognized contributors, when contributors have lane data. */
   topLane?: ContributorLane;
+  /** GitHub login with the most recognition events in the month. */
   topContributorLogin?: string;
 }
 
+/**
+ * Rendered recap artifact plus the stats used to produce and summarize it.
+ */
 export interface GenerateMonthlyRecapResult {
+  /** Markdown recap artifact ready for downstream publishers. */
   artifact: RecapArtifact;
+  /** Aggregate statistics for dashboard display and recap metadata. */
   stats: RecapStats;
 }
 

--- a/packages/core/src/application/use-cases/contributors/get-contributor-leaderboard.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/get-contributor-leaderboard.use-case.ts
@@ -22,23 +22,43 @@ import type {
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
 
+/**
+ * Leaderboard query scope and optional row limit.
+ */
 export interface GetContributorLeaderboardInput {
+  /** Time window for repository aggregation, for example month or all-time. */
   scope: ContributorLeaderboardScope;
+  /** Maximum number of rows to return; defaults to 10 and is capped at 100. */
   limit?: number;
 }
 
+/**
+ * Display-ready contributor row for leaderboard UI and API consumers.
+ */
 export interface ContributorLeaderboardEntry {
+  /** GitHub login for the contributor. */
   login: string;
+  /** Optional display name from the contributor profile. */
   displayName?: string;
+  /** Optional avatar URL suitable for browser display. */
   avatarUrl?: string;
+  /** Number of merged pull requests counted for the selected scope. */
   prCount: number;
+  /** Current contributor ladder level. */
   level: ContributorLevel;
+  /** Primary contributor lane, when known. */
   lane?: ContributorLane;
 }
 
+/**
+ * Leaderboard result with the effective scope, limit, and ordered entries.
+ */
 export interface GetContributorLeaderboardResult {
+  /** Scope used for repository aggregation. */
   scope: ContributorLeaderboardScope;
+  /** Effective row limit after defaulting and clamping. */
   limit: number;
+  /** Ordered leaderboard entries, highest PR count first. */
   entries: readonly ContributorLeaderboardEntry[];
 }
 

--- a/packages/core/src/application/use-cases/contributors/get-curated-issues-by-lane.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/get-curated-issues-by-lane.use-case.ts
@@ -19,9 +19,15 @@ const GOOD_FIRST_ISSUE_LABEL = 'good-first-issue';
 const DEFAULT_STALE_DAYS = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+/**
+ * Repository, lane, and freshness filters for curated newcomer issues.
+ */
 export interface GetCuratedIssuesByLaneInput {
+  /** GitHub repository owner or organization login. */
   owner: string;
+  /** GitHub repository name within `owner`. */
   repo: string;
+  /** Contributor lane that must be represented by issue labels. */
   lane: ContributorLane;
   /** Threshold past which an issue is considered stale and excluded. */
   staleDays?: number;
@@ -29,20 +35,35 @@ export interface GetCuratedIssuesByLaneInput {
   now?: Date;
 }
 
+/**
+ * Good-first issue prepared for the lane-specific contributor picker.
+ */
 export interface CuratedIssue {
+  /** GitHub repository owner or organization login. */
   owner: string;
+  /** GitHub repository name within `owner`. */
   repo: string;
+  /** GitHub issue number scoped to the repository. */
   issueNumber: number;
+  /** Current issue title returned by the external issue fetcher. */
   title: string;
+  /** Browser URL for the issue. */
   url: string;
+  /** Lane used to curate this issue. */
   lane: ContributorLane;
+  /** Difficulty inferred from issue labels. */
   difficulty: ContributionDifficulty;
   /** Markdown-style acceptance criteria carried verbatim if present in labels. */
   acceptanceCriteria?: string;
 }
 
+/**
+ * Curated issue result for one requested contributor lane.
+ */
 export interface GetCuratedIssuesByLaneResult {
+  /** Requested lane represented by every issue in `issues`. */
   lane: ContributorLane;
+  /** Fresh, good-first issues matching the requested lane. */
   issues: readonly CuratedIssue[];
 }
 

--- a/packages/core/src/application/use-cases/contributors/groom-issue.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/groom-issue.use-case.ts
@@ -26,13 +26,21 @@ const DIFFICULTY_LABEL_HINTS: readonly (readonly [string, ContributionDifficulty
   ['hard', ContributionDifficulty.Hard],
 ];
 
+/**
+ * GitHub issue reference to fetch and groom for newcomer readiness.
+ */
 export interface GroomIssueInput {
   /** GitHub issue reference accepted by `IExternalIssueFetcher.fetchGitHubIssue`. */
   ref: string;
 }
 
+/**
+ * Pure grooming recommendation for labels, criteria, and optional welcome copy.
+ */
 export interface GroomIssueResult {
+  /** Recommended contributor lane for the issue. */
   lane: ContributorLane;
+  /** Recommended issue difficulty based on labels and body heuristics. */
   difficulty: ContributionDifficulty;
   /** Markdown checklist (joined with newlines). */
   acceptanceCriteria: string;

--- a/packages/core/src/application/use-cases/contributors/propose-acceptance-criteria.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/propose-acceptance-criteria.use-case.ts
@@ -25,6 +25,9 @@ const SYSTEM_PROMPT = [
 
 const MIN_CRITERIA = 2;
 
+/**
+ * Issue text used by the agent to generate acceptance criteria.
+ */
 export interface ProposeAcceptanceCriteriaInput {
   /** Issue body — natural language; agent grounds criteria on this only. */
   body: string;
@@ -32,6 +35,9 @@ export interface ProposeAcceptanceCriteriaInput {
   title?: string;
 }
 
+/**
+ * Normalized acceptance criteria returned as both a list and markdown block.
+ */
 export interface ProposeAcceptanceCriteriaResult {
   /** Markdown checklist (joined with newlines) ready to paste into an issue. */
   markdown: string;

--- a/packages/core/src/application/use-cases/contributors/publish-monthly-recap.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/publish-monthly-recap.use-case.ts
@@ -23,19 +23,58 @@ import type {
   RecapTarget,
 } from '../../ports/output/services/recap-publisher.interface.js';
 
+/**
+ * Recap artifact and per-channel destinations requested for publication.
+ */
 export interface PublishMonthlyRecapInput {
+  /** Rendered monthly recap to publish. */
   artifact: RecapArtifact;
   /** Per-channel target descriptors. Channels missing here are skipped. */
   targets: readonly RecapTarget[];
 }
 
+/**
+ * Per-channel publication outcome returned after gating and publisher execution.
+ */
 export type ChannelOutcome =
-  | { channel: RecapChannel; status: 'published'; reference: string }
-  | { channel: RecapChannel; status: 'denied'; rationale: string }
-  | { channel: RecapChannel; status: 'failed'; error: string }
-  | { channel: RecapChannel; status: 'skipped'; reason: string };
+  | {
+      /** Channel whose publisher completed successfully. */
+      channel: RecapChannel;
+      /** Terminal status indicating the publisher returned a reference. */
+      status: 'published';
+      /** Channel-specific identifier or URL returned by the publisher. */
+      reference: string;
+    }
+  | {
+      /** Channel blocked by `IContributorActionGate`. */
+      channel: RecapChannel;
+      /** Terminal status indicating supervisor gating denied publication. */
+      status: 'denied';
+      /** Human-readable reason returned by the gate. */
+      rationale: string;
+    }
+  | {
+      /** Channel whose publisher or gate threw unexpectedly. */
+      channel: RecapChannel;
+      /** Terminal status indicating publication failed after being attempted. */
+      status: 'failed';
+      /** Error message normalized from the thrown reason. */
+      error: string;
+    }
+  | {
+      /** Channel with no registered publisher implementation. */
+      channel: RecapChannel;
+      /** Terminal status indicating no publication attempt was made. */
+      status: 'skipped';
+      /** Human-readable reason the target was skipped. */
+      reason: string;
+    };
 
+/**
+ * Aggregate publication result preserving one outcome per requested target.
+ */
 export interface PublishMonthlyRecapResult {
+  /** Outcomes ordered to match the requested targets. */
   outcomes: readonly ChannelOutcome[];
 }
 


### PR DESCRIPTION
Closes #616

## Summary
- add JSDoc blocks to exported contributor use-case interfaces and type aliases
- document previously bare exported fields, including units and invariants where relevant
- document the exported `nextLevel` helper contract

## Verification
- `pnpm typecheck`
- `pnpm exec prettier --check packages/core/src/application/use-cases/contributors/award-recognition.use-case.ts packages/core/src/application/use-cases/contributors/classify-into-lane.use-case.ts packages/core/src/application/use-cases/contributors/detect-stale-good-first-issue.use-case.ts packages/core/src/application/use-cases/contributors/draft-outreach-post.use-case.ts packages/core/src/application/use-cases/contributors/generate-monthly-recap.use-case.ts packages/core/src/application/use-cases/contributors/get-contributor-leaderboard.use-case.ts packages/core/src/application/use-cases/contributors/get-curated-issues-by-lane.use-case.ts packages/core/src/application/use-cases/contributors/groom-issue.use-case.ts packages/core/src/application/use-cases/contributors/propose-acceptance-criteria.use-case.ts packages/core/src/application/use-cases/contributors/publish-monthly-recap.use-case.ts`
- `git diff --check`
- commit hook: `pnpm generate`, `eslint --fix --max-warnings 0 --no-warn-ignored`, `prettier --write`, `pnpm run typecheck`