### PR TITLE
docs(web): add shadcn primitive stories

### DIFF
--- a/src/presentation/web/components/ui/scroll-area.stories.tsx
+++ b/src/presentation/web/components/ui/scroll-area.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ScrollArea, ScrollBar } from './scroll-area';
+
+const meta = {
+  title: 'Primitives/ScrollArea',
+  component: ScrollArea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const items = Array.from({ length: 24 }, (_, index) => `Activity event ${index + 1}`);
+
+export const Default: Story = {
+  render: () => (
+    <ScrollArea className="h-72 w-64 rounded-md border">
+      <div className="p-4">
+        <h4 className="mb-4 text-sm leading-none font-medium">Recent activity</h4>
+        {items.map((item) => (
+          <div key={item} className="border-t py-2 text-sm">
+            {item}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};
+
+export const Horizontal: Story = {
+  render: () => (
+    <ScrollArea className="w-80 rounded-md border whitespace-nowrap">
+      <div className="flex w-max gap-4 p-4">
+        {items.slice(0, 10).map((item) => (
+          <div key={item} className="bg-muted h-24 w-36 rounded-md p-3 text-sm">
+            {item}
+          </div>
+        ))}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+};
+
+export const BothAxes: Story = {
+  render: () => (
+    <ScrollArea className="h-64 w-80 rounded-md border">
+      <div className="grid w-[560px] grid-cols-4 gap-3 p-4">
+        {items.map((item) => (
+          <div key={item} className="bg-muted rounded-md p-3 text-sm">
+            {item}
+          </div>
+        ))}
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+};

--- a/src/presentation/web/components/ui/sheet.stories.tsx
+++ b/src/presentation/web/components/ui/sheet.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from './sheet';
+import { Button } from './button';
+import { Input } from './input';
+import { Label } from './label';
+
+const meta = {
+  title: 'Primitives/Sheet',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Edit profile</SheetTitle>
+          <SheetDescription>Update your public profile details.</SheetDescription>
+        </SheetHeader>
+        <div className="grid gap-4 px-4">
+          <div className="grid gap-2">
+            <Label htmlFor="sheet-name">Name</Label>
+            <Input id="sheet-name" defaultValue="Pedro Duarte" />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="sheet-username">Username</Label>
+            <Input id="sheet-username" defaultValue="@peduarte" />
+          </div>
+        </div>
+        <SheetFooter>
+          <Button>Save changes</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const LeftSide: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Left Sheet</Button>
+      </SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>Navigation</SheetTitle>
+          <SheetDescription>Left-side panel for navigation or filters.</SheetDescription>
+        </SheetHeader>
+        <div className="space-y-2 px-4 text-sm">
+          <p className="font-medium">Project</p>
+          <p className="text-muted-foreground">Issues, pull requests, and releases.</p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const TopSide: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Top Sheet</Button>
+      </SheetTrigger>
+      <SheetContent side="top">
+        <SheetHeader>
+          <SheetTitle>Deployment queued</SheetTitle>
+          <SheetDescription>Top sheets work well for compact status updates.</SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const BottomSide: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Bottom Sheet</Button>
+      </SheetTrigger>
+      <SheetContent side="bottom">
+        <SheetHeader>
+          <SheetTitle>Command palette</SheetTitle>
+          <SheetDescription>Bottom sheets can hold mobile-first actions.</SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <Button variant="outline">Dismiss</Button>
+          <Button>Run command</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const WithoutCloseButton: Story = {
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Persistent Sheet</Button>
+      </SheetTrigger>
+      <SheetContent showCloseButton={false}>
+        <SheetHeader>
+          <SheetTitle>Persistent panel</SheetTitle>
+          <SheetDescription>
+            This variant hides the default close button for custom action layouts.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <Button>Primary action</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};

--- a/src/presentation/web/components/ui/skeleton.stories.tsx
+++ b/src/presentation/web/components/ui/skeleton.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Skeleton } from './skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Primitives/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <Skeleton className="h-4 w-40" />,
+};
+
+export const TextBlock: Story = {
+  render: () => (
+    <div className="w-80 space-y-3">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  ),
+};
+
+export const CardLoading: Story = {
+  render: () => (
+    <div className="w-80 space-y-4 rounded-md border p-4">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-10 rounded-full" />
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+      </div>
+      <Skeleton className="h-24 w-full" />
+    </div>
+  ),
+};

--- a/src/presentation/web/components/ui/switch.stories.tsx
+++ b/src/presentation/web/components/ui/switch.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Label } from './label';
+import { Switch } from './switch';
+
+const meta = {
+  title: 'Primitives/Switch',
+  component: Switch,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    checked: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm'],
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    size: 'default',
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    defaultChecked: true,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    defaultChecked: true,
+  },
+};
+
+export const DisabledWithLabel: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Switch id="switch-airplane-mode" disabled />
+      <Label htmlFor="switch-airplane-mode">Airplane mode</Label>
+    </div>
+  ),
+};

--- a/src/presentation/web/components/ui/tooltip.stories.tsx
+++ b/src/presentation/web/components/ui/tooltip.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
+
+const meta = {
+  title: 'Primitives/Tooltip',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <TooltipProvider>
+      <Tooltip defaultOpen>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover me</Button>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={6}>Tooltip content</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};
+
+export const TopSide: Story = {
+  render: () => (
+    <TooltipProvider>
+      <Tooltip defaultOpen>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Top tooltip</Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={8}>
+          Appears above the trigger
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};
+
+export const WithDelay: Story = {
+  render: () => (
+    <TooltipProvider delayDuration={800}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Delayed tooltip</Button>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={6}>Shows after an 800ms hover delay</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};


### PR DESCRIPTION
Closes #619

## Summary
- add Storybook stories for Sheet, ScrollArea, Tooltip, Switch, and Skeleton primitives
- cover default states plus obvious side, size, loading, and delayed variants
- leave primitive component implementations unchanged

## Verification
- `pnpm typecheck`
- `git diff --check`
- `pnpm build:storybook`
- commit hook: `pnpm generate`, `eslint --fix --max-warnings 0 --no-warn-ignored`, `prettier --write`, `pnpm run typecheck`

Note: Storybook build passed with existing Vite warnings about ignored `use client` directives and chunk sizes.