### PR TITLE
test(web): seed optimistic node clickability fixtures

### DIFF
--- a/src/presentation/web/components/features/control-center/control-center-inner.tsx
+++ b/src/presentation/web/components/features/control-center/control-center-inner.tsx
@@ -206,7 +206,12 @@ export function ControlCenterInner({ initialNodes, initialEdges }: ControlCenter
         // Only navigate when the click lands on the card itself, not on
         // overlay buttons (delete, add) or pointer events leaking from dialogs.
         const target = event.target as HTMLElement;
-        if (!target.closest('[data-testid="feature-node-card"]')) return;
+        if (target.closest('button,a,input,textarea,select,[role="button"]')) return;
+        const currentTarget = event.currentTarget as HTMLElement;
+        const clickedCard =
+          target.closest('[data-testid="feature-node-card"]') ??
+          currentTarget.querySelector('[data-testid="feature-node-card"]');
+        if (!clickedCard) return;
         guardedNavigate(() => {
           clickSound.play();
           router.push(`/feature/${data.featureId}`);

--- a/tests/e2e/web/helpers/optimistic-node-fixtures.ts
+++ b/tests/e2e/web/helpers/optimistic-node-fixtures.ts
@@ -1,0 +1,121 @@
+import 'reflect-metadata';
+
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import type { IRepositoryRepository } from '@/application/ports/output/repositories/repository-repository.interface.js';
+import { BuildMode, SdlcLifecycle } from '@/domain/generated/output.js';
+import type { Feature, Repository } from '@/domain/generated/output.js';
+import { SQLiteFeatureRepository } from '@/infrastructure/repositories/sqlite-feature.repository.js';
+import { SQLiteRepositoryRepository } from '@/infrastructure/repositories/sqlite-repository.repository.js';
+import { openShepDb } from './collaboration-flag';
+
+export const OPTIMISTIC_NODE_REPOSITORY_PATH = '/tmp/shep-e2e-optimistic-node-repo';
+export const OPTIMISTIC_NODE_ACTIVE_FEATURE_NAME = 'E2E Active Click Target';
+const REPOSITORY_ID = 'e2e-optimistic-node-repo';
+
+const FEATURE_FIXTURES = [
+  {
+    id: 'e2e-optimistic-node-existing',
+    name: 'E2E Existing Click Target',
+    slug: 'e2e-existing-click-target',
+    lifecycle: SdlcLifecycle.Maintain,
+  },
+  {
+    id: 'e2e-optimistic-node-active',
+    name: OPTIMISTIC_NODE_ACTIVE_FEATURE_NAME,
+    slug: 'e2e-active-click-target',
+    lifecycle: SdlcLifecycle.Implementation,
+  },
+] as const;
+
+function buildRepository(now: Date): Repository {
+  return {
+    id: REPOSITORY_ID,
+    name: 'E2E Optimistic Node Repo',
+    path: OPTIMISTIC_NODE_REPOSITORY_PATH,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildFeature(fixture: (typeof FEATURE_FIXTURES)[number], now: Date): Feature {
+  return {
+    id: fixture.id,
+    name: fixture.name,
+    userQuery: fixture.name,
+    slug: fixture.slug,
+    description: `${fixture.name} seeded by optimistic-node-clickability e2e fixtures.`,
+    repositoryPath: OPTIMISTIC_NODE_REPOSITORY_PATH,
+    branch: `feature/${fixture.slug}`,
+    lifecycle: fixture.lifecycle,
+    messages: [],
+    relatedArtifacts: [],
+    repositoryId: REPOSITORY_ID,
+    buildMode: BuildMode.Spec,
+    fast: false,
+    push: false,
+    openPr: false,
+    forkAndPr: false,
+    commitSpecs: false,
+    ciWatchEnabled: false,
+    enableEvidence: false,
+    injectSkills: false,
+    commitEvidence: false,
+    approvalGates: {
+      allowPrd: true,
+      allowPlan: true,
+      allowMerge: true,
+    },
+    attachments: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function deleteExistingFixtureFeatures(features: IFeatureRepository): Promise<void> {
+  const existing = await features.list({ includeArchived: true, includeDeleted: true });
+  for (const feature of existing) {
+    if (
+      feature.repositoryPath === OPTIMISTIC_NODE_REPOSITORY_PATH ||
+      feature.id.startsWith('e2e-optimistic-node-')
+    ) {
+      await features.delete(feature.id);
+    }
+  }
+}
+
+/**
+ * Seeds deterministic feature nodes for optimistic clickability e2e tests.
+ *
+ * Writes through the repository ports so the fixtures stay aligned with the
+ * domain mapper instead of duplicating the current SQLite column list.
+ */
+export async function seedOptimisticNodeFixtures(): Promise<() => Promise<void>> {
+  const db = openShepDb();
+  const features: IFeatureRepository = new SQLiteFeatureRepository(db);
+  const repositories: IRepositoryRepository = new SQLiteRepositoryRepository(db);
+  const now = new Date();
+
+  await deleteExistingFixtureFeatures(features);
+
+  const existingRepo = await repositories.findByPathIncludingDeleted(
+    OPTIMISTIC_NODE_REPOSITORY_PATH
+  );
+  if (existingRepo?.deletedAt) {
+    await repositories.restore(existingRepo.id);
+  } else if (!existingRepo) {
+    await repositories.create(buildRepository(now));
+  }
+
+  for (const fixture of FEATURE_FIXTURES) {
+    await features.create(buildFeature(fixture, now));
+  }
+
+  return async () => {
+    await deleteExistingFixtureFeatures(features);
+    const repo = await repositories.findByPathIncludingDeleted(OPTIMISTIC_NODE_REPOSITORY_PATH);
+    if (repo) {
+      await repositories.remove(repo.id);
+    }
+    db.close();
+  };
+}

--- a/tests/e2e/web/optimistic-node-clickability.spec.ts
+++ b/tests/e2e/web/optimistic-node-clickability.spec.ts
@@ -1,9 +1,34 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  OPTIMISTIC_NODE_ACTIVE_FEATURE_NAME,
+  OPTIMISTIC_NODE_REPOSITORY_PATH,
+  seedOptimisticNodeFixtures,
+} from './helpers/optimistic-node-fixtures';
+
+test.describe.configure({ mode: 'serial' });
+
+let cleanupOptimisticNodeFixtures: (() => Promise<void>) | undefined;
+
+async function dismissCollaborationOnboarding(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('shep:collaboration-onboarding-dismissed', '1');
+  });
+}
+
+test.beforeAll(async () => {
+  cleanupOptimisticNodeFixtures = await seedOptimisticNodeFixtures();
+});
+
+test.afterAll(async () => {
+  await cleanupOptimisticNodeFixtures?.();
+});
 
 test.describe('Feature node clickability — drawer opens after feature creation', () => {
   test('clicking existing feature nodes opens the detail drawer after submitting the create form', async ({
     page,
   }) => {
+    await dismissCollaborationOnboarding(page);
+
     // Mock the repositories API to provide at least one repo
     await page.route('**/api/repositories', (route) =>
       route.fulfill({
@@ -12,28 +37,31 @@ test.describe('Feature node clickability — drawer opens after feature creation
         body: JSON.stringify([
           {
             id: 'repo-1',
-            path: '/test/repo',
-            name: 'Test Repo',
+            path: OPTIMISTIC_NODE_REPOSITORY_PATH,
+            name: 'E2E Optimistic Node Repo',
           },
         ]),
       })
     );
 
     // Intercept createFeature server action to delay it (simulate slow creation)
+    let shouldDelayCreateFeature = false;
     await page.route('**/*', async (route) => {
       const request = route.request();
-      if (request.method() === 'POST' && request.headers()['next-action']) {
-        const body = request.postData();
-        if (body?.includes('E2E Optimistic Clickability Test')) {
-          // Delay for 10 seconds — long enough to click other nodes
-          await new Promise((resolve) => setTimeout(resolve, 10000));
-          await route.fulfill({
-            status: 200,
-            contentType: 'text/x-component',
-            body: '1:{"error":"Test intercepted"}\n',
-          });
-          return;
-        }
+      if (
+        shouldDelayCreateFeature &&
+        request.method() === 'POST' &&
+        request.headers()['next-action']
+      ) {
+        shouldDelayCreateFeature = false;
+        // Delay for 10 seconds — long enough to click other nodes
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/x-component',
+          body: '1:{"error":"Test intercepted"}\n',
+        });
+        return;
       }
       await route.continue();
     });
@@ -41,22 +69,22 @@ test.describe('Feature node clickability — drawer opens after feature creation
     // Navigate to control center
     await page.goto('/control-center');
 
-    // Check if any feature nodes exist
+    // Seeded fixtures guarantee at least one existing, non-busy feature node.
     const featureCards = page.locator('[data-testid="feature-node-card"]');
-    const hasFeatures = await featureCards
-      .first()
-      .isVisible({ timeout: 10000 })
-      .catch(() => false);
-    test.skip(!hasFeatures, 'Need at least 1 existing feature node to test clickability');
+    await expect(featureCards.first()).toBeVisible({ timeout: 10000 });
 
-    // Remember the name of the first existing feature node for drawer verification
-    const firstNodeHeading = page
-      .locator('[data-testid="feature-node-card"]:not([aria-busy="true"]) h3')
-      .first();
-    const firstNodeName = await firstNodeHeading.textContent();
+    // Target the deterministic fixture that remains in view when the optimistic node is added.
+    await expect(
+      page.getByRole('heading', { name: OPTIMISTIC_NODE_ACTIVE_FEATURE_NAME })
+    ).toBeVisible();
 
     // Step 1: Open the create-feature drawer by navigating to /create with repo selected
-    await page.goto('/create?repo=/test/repo');
+    await page.goto(`/create?repo=${encodeURIComponent(OPTIMISTIC_NODE_REPOSITORY_PATH)}`);
+
+    const agentPickerHeading = page.getByRole('heading', { name: 'Choose your agent' });
+    if (await agentPickerHeading.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await page.getByRole('button', { name: 'Demo' }).click();
+    }
 
     // Wait for the create drawer heading
     await expect(page.getByRole('heading', { name: 'NEW FEATURE' })).toBeVisible({
@@ -71,6 +99,7 @@ test.describe('Feature node clickability — drawer opens after feature creation
 
     const submitButton = page.getByRole('button', { name: '+ Create Feature' });
     await expect(submitButton).toBeEnabled();
+    shouldDelayCreateFeature = true;
     await submitButton.click();
 
     // Step 3: Drawer should close (router.push('/') fires immediately on submit)
@@ -81,18 +110,17 @@ test.describe('Feature node clickability — drawer opens after feature creation
     // Step 4: While the server action is still in-flight, click on an existing feature node
     const clickableNode = page
       .locator('[data-testid="feature-node-card"]:not([aria-busy="true"])')
+      .filter({ has: page.getByRole('heading', { name: OPTIMISTIC_NODE_ACTIVE_FEATURE_NAME }) })
       .first();
     await expect(clickableNode).toBeVisible();
-    await clickableNode.click();
+    await clickableNode.locator('h3').click();
 
     // Step 5: Verify the feature detail drawer opens for the clicked node
     const drawerHeader = page.locator('[data-testid="feature-drawer-header"]');
     await expect(drawerHeader).toBeVisible({ timeout: 5000 });
 
     // The drawer should show the name of the clicked feature
-    if (firstNodeName) {
-      await expect(drawerHeader).toContainText(firstNodeName);
-    }
+    await expect(drawerHeader).toContainText(OPTIMISTIC_NODE_ACTIVE_FEATURE_NAME);
 
     // Step 6: Close the drawer by pressing Escape
     await page.keyboard.press('Escape');
@@ -118,23 +146,21 @@ test.describe('Feature node clickability — drawer opens after feature creation
 
 test.describe('All feature nodes open a drawer on click', () => {
   test('clicking each non-creating feature node opens some drawer', async ({ page }) => {
+    await dismissCollaborationOnboarding(page);
+
     // Navigate to control center
     await page.goto('/control-center');
 
-    // Check if any feature nodes exist (use isVisible with short timeout to avoid blocking)
+    // Seeded fixtures guarantee at least one feature node in deterministic DB state.
     const featureCards = page.locator('[data-testid="feature-node-card"]');
-    const hasFeatures = await featureCards
-      .first()
-      .isVisible({ timeout: 10000 })
-      .catch(() => false);
-    test.skip(!hasFeatures, 'Need at least 1 feature node to test drawer opening');
+    await expect(featureCards.first()).toBeVisible({ timeout: 10000 });
 
     // Get all non-creating feature nodes
     const clickableNodes = page.locator(
       '[data-testid="feature-node-card"]:not([aria-busy="true"])'
     );
     const clickableCount = await clickableNodes.count();
-    test.skip(clickableCount < 1, 'Need at least 1 non-creating feature node');
+    expect(clickableCount).toBeGreaterThanOrEqual(1);
 
     const drawerHeader = page.locator('[data-testid="feature-drawer-header"]');
 
@@ -144,7 +170,7 @@ test.describe('All feature nodes open a drawer on click', () => {
       const nodeName = await node.locator('h3').textContent();
 
       // Click the feature node
-      await node.click();
+      await node.locator('h3').click();
 
       // Verify some drawer opens (either basic FeatureDrawer or specialized ReviewDrawerShell)
       await expect(drawerHeader).toBeVisible({


### PR DESCRIPTION
Closes #624

## Summary
- seed deterministic optimistic-node clickability fixtures through repository ports
- remove skip guards from the e2e spec and dismiss the first-run collaboration overlay
- preserve feature-node navigation when React Flow reports the wrapper as the click target

## Verification
- `pnpm exec prettier --write src/presentation/web/components/features/control-center/control-center-inner.tsx tests/e2e/web/helpers/optimistic-node-fixtures.ts tests/e2e/web/optimistic-node-clickability.spec.ts`
- `pnpm typecheck`
- `git diff --check`
- `CI=1 pnpm exec playwright test tests/e2e/web/optimistic-node-clickability.spec.ts`
- commit hook: `pnpm generate`, ESLint, Prettier, typecheck

Note: the targeted Playwright run prints the existing local `NO_COLOR`/`FORCE_COLOR` warning and the expected missing local `claude` binary error from the intentionally failing create-action path, but the regression spec passed: `2 passed (29.9s)`.
