### PR TITLE
docs(web): add doctor-summary state stories

### DIFF
--- a/src/presentation/web/components/contributors/DoctorSummary.stories.tsx
+++ b/src/presentation/web/components/contributors/DoctorSummary.stories.tsx
@@ -77,18 +77,35 @@ const hasFail: DoctorSummaryReport = {
   ],
 };
 
-export const AllOk: Story = {
-  args: { report: allOk },
-};
-
-export const MixedWarn: Story = {
-  args: { report: mixedWarn },
-};
-
-export const HasFail: Story = {
-  args: { report: hasFail },
+const errorState: DoctorSummaryReport = {
+  overallStatus: DiagnosticStatus.Fail,
+  summary: { ok: 0, warn: 0, fail: 1 },
+  results: [
+    {
+      name: 'doctor-runner',
+      status: DiagnosticStatus.Fail,
+      detail: 'Unable to run diagnostics for this workspace',
+      fixHint: 'Retry after confirming the repository path is accessible',
+    },
+  ],
 };
 
 export const Loading: Story = {
   args: { loading: true },
+};
+
+export const AllOk: Story = {
+  args: { report: allOk },
+};
+
+export const WithWarnings: Story = {
+  args: { report: mixedWarn },
+};
+
+export const WithFailures: Story = {
+  args: { report: hasFail },
+};
+
+export const ErrorState: Story = {
+  args: { report: errorState },
 };


### PR DESCRIPTION
Closes #620

## Summary
- rename the existing warning/failure exports to `WithWarnings` and `WithFailures`
- add `Loading`, `AllOk`, `WithWarnings`, `WithFailures`, and `ErrorState` story coverage for DoctorSummary
- keep this Storybook-only; no component behavior changes

## Verification
- `pnpm exec prettier --write src/presentation/web/components/contributors/DoctorSummary.stories.tsx`
- `pnpm typecheck`
- `git diff --check`
- `pnpm build:storybook`
- commit hook: `pnpm generate`, ESLint, Prettier, typecheck

Note: Storybook build passed with existing Vite warnings about ignored `"use client"` directives, sourcemap locations, eval in Storybook runtime, and large chunks.
