### PR TITLE
feat(web): internationalize contributor onboarding

### DIFF
--- a/src/presentation/web/components/contributors/ContributorLeaderboard.tsx
+++ b/src/presentation/web/components/contributors/ContributorLeaderboard.tsx
@@ -12,6 +12,7 @@ import { Trophy, Crown } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ContributorLevel, type ContributorLane } from '@shepai/core/domain/generated/output';
+import { useTranslation } from 'react-i18next';
 
 export interface LeaderboardEntry {
   login: string;
@@ -49,17 +50,23 @@ export function ContributorLeaderboard({
   loading,
   error,
 }: ContributorLeaderboardProps) {
+  const { t } = useTranslation('web');
+
   return (
     <section
       className="flex flex-col gap-3"
       data-testid="contributor-leaderboard"
-      aria-label="Contributor leaderboard"
+      aria-label={t('contributors.leaderboard.ariaLabel', {
+        defaultValue: 'Contributor leaderboard',
+      })}
     >
       <header className="flex items-center gap-2">
         <Trophy className="text-primary size-5" aria-hidden />
-        <h2 className="text-lg font-semibold">Top contributors</h2>
+        <h2 className="text-lg font-semibold">
+          {t('contributors.leaderboard.title', { defaultValue: 'Top contributors' })}
+        </h2>
         <Badge variant="secondary" className="ml-1">
-          {SCOPE_LABEL[scope]}
+          {t(`contributors.leaderboard.scopes.${scope}`, { defaultValue: SCOPE_LABEL[scope] })}
         </Badge>
       </header>
 
@@ -86,6 +93,8 @@ interface RowProps {
 }
 
 function LeaderboardRow({ rank, entry }: RowProps) {
+  const { t } = useTranslation('web');
+
   return (
     <li
       className="flex items-center gap-3 px-3 py-2"
@@ -111,7 +120,11 @@ function LeaderboardRow({ rank, entry }: RowProps) {
         </p>
         <p className="text-muted-foreground text-xs">
           @{entry.login}
-          {entry.lane ? ` · ${entry.lane}` : ''}
+          {entry.lane
+            ? ` · ${t(`contributors.lanes.${entry.lane}.label`, {
+                defaultValue: entry.lane,
+              })}`
+            : ''}
         </p>
       </div>
       <Badge
@@ -119,13 +132,16 @@ function LeaderboardRow({ rank, entry }: RowProps) {
         className="shrink-0 capitalize"
         data-testid={`leaderboard-level-${entry.login}`}
       >
-        {entry.level}
+        {t(`contributors.leaderboard.levels.${entry.level}`, { defaultValue: entry.level })}
       </Badge>
       <span
         className="w-12 shrink-0 text-right text-sm tabular-nums"
         data-testid={`leaderboard-prs-${entry.login}`}
       >
-        {entry.prCount} PR{entry.prCount === 1 ? '' : 's'}
+        {t('contributors.leaderboard.prCount', {
+          count: entry.prCount,
+          defaultValue: `${entry.prCount} PR${entry.prCount === 1 ? '' : 's'}`,
+        })}
       </span>
     </li>
   );
@@ -174,24 +190,33 @@ function LoadingState() {
 }
 
 function EmptyState() {
+  const { t } = useTranslation('web');
+
   return (
     <p
       className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm"
       data-testid="leaderboard-empty"
     >
-      No contributors yet — be the first to merge a PR!
+      {t('contributors.leaderboard.empty', {
+        defaultValue: 'No contributors yet — be the first to merge a PR!',
+      })}
     </p>
   );
 }
 
 function ErrorState({ message }: { message: string }) {
+  const { t } = useTranslation('web');
+
   return (
     <p
       className="text-destructive bg-destructive/5 border-destructive/40 rounded-lg border p-4 text-sm"
       data-testid="leaderboard-error"
       role="alert"
     >
-      Couldn&apos;t load the leaderboard: {message}
+      {t('contributors.leaderboard.error', {
+        message,
+        defaultValue: "Couldn't load the leaderboard: {{message}}",
+      })}
     </p>
   );
 }

--- a/src/presentation/web/components/contributors/ContributorOnboardingView.tsx
+++ b/src/presentation/web/components/contributors/ContributorOnboardingView.tsx
@@ -15,6 +15,7 @@ import { DoctorSummary, type DoctorSummaryReport } from './DoctorSummary';
 import { ContributorLeaderboard } from './ContributorLeaderboard';
 import type { LeaderboardEntry, LeaderboardScope } from './ContributorLeaderboard';
 import { loadCuratedIssues } from '@/app/actions/load-curated-issues';
+import { useTranslation } from 'react-i18next';
 
 export interface ContributorOnboardingViewProps {
   initialLeaderboard: {
@@ -31,6 +32,7 @@ export function ContributorOnboardingView({
   initialDoctorReport,
   doctorError,
 }: ContributorOnboardingViewProps) {
+  const { t } = useTranslation('web');
   const [lane, setLane] = useState<ContributorLane | undefined>(undefined);
   const [issues, setIssues] = useState<readonly CuratedIssueView[]>([]);
   const [issuesError, setIssuesError] = useState<string | undefined>(undefined);
@@ -53,11 +55,14 @@ export function ContributorOnboardingView({
   return (
     <div className="flex flex-col gap-8" data-testid="contributor-onboarding-view">
       <header className="flex flex-col gap-2">
-        <h1 className="text-2xl font-semibold">Contribute to Shep</h1>
+        <h1 className="text-2xl font-semibold">
+          {t('contributors.onboarding.title', { defaultValue: 'Contribute to Shep' })}
+        </h1>
         <p className="text-muted-foreground max-w-2xl text-sm">
-          Pick a lane that matches what you want to work on. Shep will list curated
-          good-first-issues you can ship in under 30 minutes — and run a quick environment check so
-          your fresh clone actually builds.
+          {t('contributors.onboarding.description', {
+            defaultValue:
+              'Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.',
+          })}
         </p>
       </header>
 
@@ -70,7 +75,9 @@ export function ContributorOnboardingView({
             className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm"
             data-testid="contributor-pick-issue-prompt"
           >
-            Choose a lane to see curated issues.
+            {t('contributors.onboarding.pickLanePrompt', {
+              defaultValue: 'Choose a lane to see curated issues.',
+            })}
           </p>
         )}
       </section>
@@ -78,7 +85,10 @@ export function ContributorOnboardingView({
       <DoctorSummary report={initialDoctorReport} />
       {doctorError ? (
         <p className="text-muted-foreground text-xs" data-testid="doctor-summary-fallback">
-          Environment check unavailable: {doctorError}
+          {t('contributors.onboarding.doctorUnavailable', {
+            error: doctorError,
+            defaultValue: 'Environment check unavailable: {{error}}',
+          })}
         </p>
       ) : null}
 

--- a/src/presentation/web/components/contributors/CuratedIssuesList.tsx
+++ b/src/presentation/web/components/contributors/CuratedIssuesList.tsx
@@ -12,6 +12,7 @@ import { ExternalLink } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ContributionDifficulty, type ContributorLane } from '@shepai/core/domain/generated/output';
+import { useTranslation } from 'react-i18next';
 
 export interface CuratedIssueView {
   owner: string;
@@ -50,11 +51,15 @@ const DIFFICULTY_LABEL: Record<ContributionDifficulty, string> = {
 const PREVIEW_MAX_LEN = 160;
 
 export function CuratedIssuesList({ issues, loading, error }: CuratedIssuesListProps) {
+  const { t } = useTranslation('web');
+
   return (
     <section
       className="flex flex-col gap-3"
       data-testid="curated-issues-list"
-      aria-label="Curated good-first-issues"
+      aria-label={t('contributors.curatedIssues.ariaLabel', {
+        defaultValue: 'Curated good-first-issues',
+      })}
     >
       {loading ? (
         <LoadingState />
@@ -74,6 +79,7 @@ export function CuratedIssuesList({ issues, loading, error }: CuratedIssuesListP
 }
 
 function IssueCard({ issue }: { issue: CuratedIssueView }) {
+  const { t } = useTranslation('web');
   const slug = `${issue.owner}/${issue.repo}#${issue.issueNumber}`;
   const preview = previewCriteria(issue.acceptanceCriteria);
   return (
@@ -100,7 +106,9 @@ function IssueCard({ issue }: { issue: CuratedIssueView }) {
           className="shrink-0"
           data-testid={`curated-issue-difficulty-${issue.issueNumber}`}
         >
-          {DIFFICULTY_LABEL[issue.difficulty] ?? issue.difficulty}
+          {t(`contributors.curatedIssues.difficulty.${issue.difficulty}`, {
+            defaultValue: DIFFICULTY_LABEL[issue.difficulty] ?? issue.difficulty,
+          })}
         </Badge>
       </div>
       {preview ? (
@@ -136,24 +144,34 @@ function LoadingState() {
 }
 
 function EmptyState() {
+  const { t } = useTranslation('web');
+
   return (
     <p
       className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm"
       data-testid="curated-issues-empty"
     >
-      No good-first-issues open in this lane right now — check back soon, or pick a different lane.
+      {t('contributors.curatedIssues.empty', {
+        defaultValue:
+          'No good-first-issues open in this lane right now — check back soon, or pick a different lane.',
+      })}
     </p>
   );
 }
 
 function ErrorState({ message }: { message: string }) {
+  const { t } = useTranslation('web');
+
   return (
     <p
       className="text-destructive bg-destructive/5 border-destructive/40 rounded-lg border p-4 text-sm"
       data-testid="curated-issues-error"
       role="alert"
     >
-      Couldn&apos;t load curated issues: {message}
+      {t('contributors.curatedIssues.error', {
+        message,
+        defaultValue: "Couldn't load curated issues: {{message}}",
+      })}
     </p>
   );
 }

--- a/src/presentation/web/components/contributors/DoctorSummary.tsx
+++ b/src/presentation/web/components/contributors/DoctorSummary.tsx
@@ -11,6 +11,7 @@
 import { CheckCircle2, AlertTriangle, XCircle, Stethoscope } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DiagnosticStatus } from '@shepai/core/domain/generated/output';
+import { useTranslation } from 'react-i18next';
 
 export interface DoctorSummaryResult {
   name: string;
@@ -31,15 +32,21 @@ export interface DoctorSummaryProps {
 }
 
 export function DoctorSummary({ report, loading }: DoctorSummaryProps) {
+  const { t } = useTranslation('web');
+
   return (
     <section
       className="flex flex-col gap-3"
       data-testid="doctor-summary"
-      aria-label="Environment diagnostic summary"
+      aria-label={t('contributors.doctorSummary.ariaLabel', {
+        defaultValue: 'Environment diagnostic summary',
+      })}
     >
       <header className="flex items-center gap-2">
         <Stethoscope className="text-primary size-5" aria-hidden />
-        <h2 className="text-lg font-semibold">Environment health</h2>
+        <h2 className="text-lg font-semibold">
+          {t('contributors.doctorSummary.title', { defaultValue: 'Environment health' })}
+        </h2>
       </header>
 
       {loading || !report ? (
@@ -62,28 +69,38 @@ export function DoctorSummary({ report, loading }: DoctorSummaryProps) {
 }
 
 function Counts({ summary }: { summary: DoctorSummaryReport['summary'] }) {
+  const { t } = useTranslation('web');
+
   return (
     <div className="flex flex-wrap gap-4 text-sm" data-testid="doctor-summary-counts">
       <span className="inline-flex items-center gap-1.5" data-testid="doctor-summary-ok">
         <CheckCircle2 className="size-4 text-emerald-600" aria-hidden />
         <span className="font-medium">{summary.ok}</span>
-        <span className="text-muted-foreground">ok</span>
+        <span className="text-muted-foreground">
+          {t('contributors.doctorSummary.counts.ok', { defaultValue: 'ok' })}
+        </span>
       </span>
       <span className="inline-flex items-center gap-1.5" data-testid="doctor-summary-warn">
         <AlertTriangle className="size-4 text-amber-600" aria-hidden />
         <span className="font-medium">{summary.warn}</span>
-        <span className="text-muted-foreground">warn</span>
+        <span className="text-muted-foreground">
+          {t('contributors.doctorSummary.counts.warn', { defaultValue: 'warn' })}
+        </span>
       </span>
       <span className="inline-flex items-center gap-1.5" data-testid="doctor-summary-fail">
         <XCircle className="size-4 text-red-600" aria-hidden />
         <span className="font-medium">{summary.fail}</span>
-        <span className="text-muted-foreground">fail</span>
+        <span className="text-muted-foreground">
+          {t('contributors.doctorSummary.counts.fail', { defaultValue: 'fail' })}
+        </span>
       </span>
     </div>
   );
 }
 
 function DiagnosticRow({ result }: { result: DoctorSummaryResult }) {
+  const { t } = useTranslation('web');
+
   return (
     <li className="flex items-start gap-3 px-3 py-2" data-testid={`doctor-row-${result.name}`}>
       <StatusIcon status={result.status} />
@@ -97,7 +114,10 @@ function DiagnosticRow({ result }: { result: DoctorSummaryResult }) {
             className="text-muted-foreground/80 text-xs italic"
             data-testid={`doctor-row-fix-${result.name}`}
           >
-            Hint: {result.fixHint}
+            {t('contributors.doctorSummary.hint', {
+              fixHint: result.fixHint,
+              defaultValue: 'Hint: {{fixHint}}',
+            })}
           </p>
         ) : null}
       </div>

--- a/src/presentation/web/components/contributors/LaneChooser.tsx
+++ b/src/presentation/web/components/contributors/LaneChooser.tsx
@@ -10,6 +10,7 @@
  */
 
 import { ContributorLane } from '@shepai/core/domain/generated/output';
+import { useTranslation } from 'react-i18next';
 
 const LANE_LABEL: Record<ContributorLane, string> = {
   [ContributorLane.Docs]: 'Docs',
@@ -36,16 +37,15 @@ export interface LaneChooserProps {
   id?: string;
 }
 
-export function LaneChooser({
-  value,
-  onLaneChange,
-  label = 'Pick a lane',
-  id = 'lane-chooser',
-}: LaneChooserProps) {
+export function LaneChooser({ value, onLaneChange, label, id = 'lane-chooser' }: LaneChooserProps) {
+  const { t } = useTranslation('web');
+  const resolvedLabel =
+    label ?? t('contributors.laneChooser.label', { defaultValue: 'Pick a lane' });
+
   return (
     <div className="flex flex-col gap-1.5" data-testid="lane-chooser">
       <label htmlFor={id} className="text-sm font-medium">
-        {label}
+        {resolvedLabel}
       </label>
       <select
         id={id}
@@ -55,11 +55,14 @@ export function LaneChooser({
         data-testid="lane-chooser-select"
       >
         <option value="" disabled>
-          Choose a lane…
+          {t('contributors.laneChooser.placeholder', { defaultValue: 'Choose a lane…' })}
         </option>
         {LANE_OPTIONS.map((lane) => (
           <option key={lane} value={lane} data-testid={`lane-chooser-option-${lane}`}>
-            {LANE_LABEL[lane]} — {LANE_DESCRIPTION[lane]}
+            {t(`contributors.lanes.${lane}.label`, { defaultValue: LANE_LABEL[lane] })} —{' '}
+            {t(`contributors.lanes.${lane}.description`, {
+              defaultValue: LANE_DESCRIPTION[lane],
+            })}
           </option>
         ))}
       </select>

--- a/src/presentation/web/components/onboarding/onboarding-tutorial.tsx
+++ b/src/presentation/web/components/onboarding/onboarding-tutorial.tsx
@@ -25,6 +25,7 @@ import type { Route } from 'next';
 import type { LucideIcon } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
 
 interface TutorialStep {
   title: string;
@@ -178,6 +179,7 @@ const SECTIONS: TutorialSection[] = [
 ];
 
 export function OnboardingTutorial() {
+  const { t } = useTranslation('web');
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
   function toggle(id: string) {
@@ -189,106 +191,134 @@ export function OnboardingTutorial() {
       <header className="flex flex-col gap-2">
         <div className="flex items-center gap-2">
           <GraduationCap className="text-primary size-6" />
-          <h1 className="text-2xl font-semibold">Get started</h1>
+          <h1 className="text-2xl font-semibold">
+            {t('onboarding.tutorial.title', { defaultValue: 'Get started' })}
+          </h1>
         </div>
         <p className="text-muted-foreground max-w-2xl text-sm">
-          A short tour through the new agent collaboration & supervision features. Each section
-          links to the live surface — read for two minutes, then go try it.
+          {t('onboarding.tutorial.description', {
+            defaultValue:
+              'A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.',
+          })}
         </p>
       </header>
 
       <nav
         className="bg-muted/40 flex flex-wrap gap-2 rounded-lg border p-3"
-        aria-label="Tutorial sections"
+        aria-label={t('onboarding.tutorial.sectionsNavLabel', {
+          defaultValue: 'Tutorial sections',
+        })}
       >
-        {SECTIONS.map((section) => (
-          <a
-            key={section.id}
-            href={`#${section.id}`}
-            className="border-border hover:bg-muted inline-flex items-center gap-1.5 rounded-md border bg-white/40 px-3 py-1.5 text-xs font-medium dark:bg-black/20"
-          >
-            <section.icon className="size-3" />
-            {section.title.split('—')[0]?.trim() ?? section.title}
-          </a>
-        ))}
+        {SECTIONS.map((section) => {
+          const title = t(`onboarding.tutorial.sections.${section.id}.title`, {
+            defaultValue: section.title,
+          });
+          return (
+            <a
+              key={section.id}
+              href={`#${section.id}`}
+              className="border-border hover:bg-muted inline-flex items-center gap-1.5 rounded-md border bg-white/40 px-3 py-1.5 text-xs font-medium dark:bg-black/20"
+            >
+              <section.icon className="size-3" />
+              {title.split('—')[0]?.trim() ?? title}
+            </a>
+          );
+        })}
       </nav>
 
-      {SECTIONS.map((section) => (
-        <section
-          key={section.id}
-          id={section.id}
-          data-testid={`tutorial-section-${section.id}`}
-          className="flex scroll-mt-6 flex-col gap-4"
-        >
-          <header className="flex items-start justify-between gap-3">
-            <div className="flex flex-col gap-1">
-              <div className="flex items-center gap-2">
-                <section.icon className="text-primary size-5" />
-                <h2 className="text-lg font-semibold">{section.title}</h2>
-                {section.badge ? (
-                  <Badge variant="secondary" className="shrink-0">
-                    {section.badge}
-                  </Badge>
-                ) : null}
+      {SECTIONS.map((section) => {
+        const sectionKey = `onboarding.tutorial.sections.${section.id}`;
+        return (
+          <section
+            key={section.id}
+            id={section.id}
+            data-testid={`tutorial-section-${section.id}`}
+            className="flex scroll-mt-6 flex-col gap-4"
+          >
+            <header className="flex items-start justify-between gap-3">
+              <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <section.icon className="text-primary size-5" />
+                  <h2 className="text-lg font-semibold">
+                    {t(`${sectionKey}.title`, { defaultValue: section.title })}
+                  </h2>
+                  {section.badge ? (
+                    <Badge variant="secondary" className="shrink-0">
+                      {t(`${sectionKey}.badge`, { defaultValue: section.badge })}
+                    </Badge>
+                  ) : null}
+                </div>
+                <p className="text-muted-foreground max-w-2xl text-sm">
+                  {t(`${sectionKey}.intro`, { defaultValue: section.intro })}
+                </p>
               </div>
-              <p className="text-muted-foreground max-w-2xl text-sm">{section.intro}</p>
-            </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              onClick={() => toggle(section.id)}
-              aria-expanded={!collapsed[section.id]}
-              aria-controls={`steps-${section.id}`}
-              data-testid={`tutorial-toggle-${section.id}`}
-            >
-              {collapsed[section.id] ? (
-                <ChevronDown className="size-4" />
-              ) : (
-                <ChevronUp className="size-4" />
-              )}
-            </Button>
-          </header>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => toggle(section.id)}
+                aria-expanded={!collapsed[section.id]}
+                aria-controls={`steps-${section.id}`}
+                data-testid={`tutorial-toggle-${section.id}`}
+              >
+                {collapsed[section.id] ? (
+                  <ChevronDown className="size-4" />
+                ) : (
+                  <ChevronUp className="size-4" />
+                )}
+              </Button>
+            </header>
 
-          {collapsed[section.id] ? null : (
-            <ol
-              id={`steps-${section.id}`}
-              className="flex flex-col gap-3 border-l-2 pl-5"
-              data-testid={`tutorial-steps-${section.id}`}
-            >
-              {section.steps.map((step, i) => (
-                <li key={step.title} className="flex flex-col gap-2">
-                  <div className="flex items-baseline gap-2">
-                    <span className="text-muted-foreground font-mono text-xs">
-                      {String(i + 1).padStart(2, '0')}
-                    </span>
-                    <h3 className="text-sm font-semibold">{step.title}</h3>
-                  </div>
-                  <p className="text-muted-foreground text-sm">{step.description}</p>
-                  {step.detail ? (
-                    <p className="text-muted-foreground/80 text-xs">{step.detail}</p>
-                  ) : null}
-                  {step.cta ? (
-                    <div>
-                      <Button asChild size="sm" variant="outline">
-                        <Link href={step.cta.href as Route}>
-                          {step.cta.label}
-                          <ArrowRight className="size-3" />
-                        </Link>
-                      </Button>
-                    </div>
-                  ) : null}
-                </li>
-              ))}
-            </ol>
-          )}
-        </section>
-      ))}
+            {collapsed[section.id] ? null : (
+              <ol
+                id={`steps-${section.id}`}
+                className="flex flex-col gap-3 border-l-2 pl-5"
+                data-testid={`tutorial-steps-${section.id}`}
+              >
+                {section.steps.map((step, i) => {
+                  const stepKey = `${sectionKey}.steps.${i}`;
+                  return (
+                    <li key={step.title} className="flex flex-col gap-2">
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-muted-foreground font-mono text-xs">
+                          {String(i + 1).padStart(2, '0')}
+                        </span>
+                        <h3 className="text-sm font-semibold">
+                          {t(`${stepKey}.title`, { defaultValue: step.title })}
+                        </h3>
+                      </div>
+                      <p className="text-muted-foreground text-sm">
+                        {t(`${stepKey}.description`, { defaultValue: step.description })}
+                      </p>
+                      {step.detail ? (
+                        <p className="text-muted-foreground/80 text-xs">
+                          {t(`${stepKey}.detail`, { defaultValue: step.detail })}
+                        </p>
+                      ) : null}
+                      {step.cta ? (
+                        <div>
+                          <Button asChild size="sm" variant="outline">
+                            <Link href={step.cta.href as Route}>
+                              {t(`${stepKey}.cta`, { defaultValue: step.cta.label })}
+                              <ArrowRight className="size-3" />
+                            </Link>
+                          </Button>
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ol>
+            )}
+          </section>
+        );
+      })}
 
       <footer className="text-muted-foreground bg-muted/40 mt-4 rounded-lg border p-4 text-sm">
-        Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy
-        level. Bumping a slot version is reversible: delete the override and the bundled default
-        returns byte-for-byte.
+        {t('onboarding.tutorial.footer', {
+          defaultValue:
+            'Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.',
+        })}
       </footer>
     </div>
   );

--- a/src/presentation/web/components/onboarding/welcome-banner.tsx
+++ b/src/presentation/web/components/onboarding/welcome-banner.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link';
 import type { Route } from 'next';
 import { GraduationCap, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
 
 const STORAGE_PREFIX = 'shep:onboarding:';
 
@@ -40,6 +41,7 @@ export function WelcomeBanner({
   ctaHref,
   forceVisible,
 }: WelcomeBannerProps) {
+  const { t } = useTranslation('web');
   const storageKey = `${STORAGE_PREFIX}${id}`;
   // Mounted gate avoids a server/client hydration mismatch: SSR returns null,
   // the effect resolves visibility from localStorage on the client.
@@ -100,7 +102,9 @@ export function WelcomeBanner({
         size="icon"
         className="size-7 shrink-0"
         onClick={dismiss}
-        aria-label="Dismiss this hint"
+        aria-label={t('onboarding.welcomeBanner.dismiss', {
+          defaultValue: 'Dismiss this hint',
+        })}
         data-testid={`welcome-banner-${id}-dismiss`}
       >
         <X className="size-4" />

--- a/translations/ar/web.json
+++ b/translations/ar/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "ملاحظات الصورة",
     "viewServerLogs": "عرض سجلات الخادم",
     "toggleSidebar": "تبديل الشريط الجانبي"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/de/web.json
+++ b/translations/de/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Bildnotizen",
     "viewServerLogs": "Server-Logs anzeigen",
     "toggleSidebar": "Seitenleiste umschalten"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/en/web.json
+++ b/translations/en/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Image notes",
     "viewServerLogs": "View server logs",
     "toggleSidebar": "Toggle Sidebar"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/es/web.json
+++ b/translations/es/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Notas de imagen",
     "viewServerLogs": "Ver logs del servidor",
     "toggleSidebar": "Alternar barra lateral"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/fr/web.json
+++ b/translations/fr/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Notes de l'image",
     "viewServerLogs": "Voir les logs du serveur",
     "toggleSidebar": "Basculer la barre latérale"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/he/web.json
+++ b/translations/he/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "הערות לתמונה",
     "viewServerLogs": "צפייה ביומני שרת",
     "toggleSidebar": "החלפת סרגל צד"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/pt/web.json
+++ b/translations/pt/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Notas da imagem",
     "viewServerLogs": "Ver logs do servidor",
     "toggleSidebar": "Alternar barra lateral"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/ru/web.json
+++ b/translations/ru/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Заметки к изображению",
     "viewServerLogs": "Просмотр журналов сервера",
     "toggleSidebar": "Переключить боковую панель"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/translations/uk/web.json
+++ b/translations/uk/web.json
@@ -641,5 +641,191 @@
     "imageNotes": "Нотатки до зображення",
     "viewServerLogs": "Переглянути журнали сервера",
     "toggleSidebar": "Перемкнути бічну панель"
+  },
+  "contributors": {
+    "lanes": {
+      "docs": {
+        "label": "Docs",
+        "description": "Guides, references, READMEs"
+      },
+      "agents": {
+        "label": "Agents",
+        "description": "Prompts, graphs, custom agents"
+      },
+      "ui": {
+        "label": "UI",
+        "description": "Web dashboard & components"
+      },
+      "cli": {
+        "label": "CLI",
+        "description": "CLI commands & TUI"
+      },
+      "infra": {
+        "label": "Infra",
+        "description": "Build, CI, deps, releases"
+      }
+    },
+    "laneChooser": {
+      "label": "Pick a lane",
+      "placeholder": "Choose a lane…"
+    },
+    "leaderboard": {
+      "ariaLabel": "Contributor leaderboard",
+      "title": "Top contributors",
+      "scopes": {
+        "month": "This month",
+        "allTime": "All time"
+      },
+      "levels": {
+        "user": "user",
+        "contributor": "contributor",
+        "core": "core",
+        "maintainer": "maintainer"
+      },
+      "prCount": "{{count}} PR",
+      "prCount_other": "{{count}} PRs",
+      "empty": "No contributors yet — be the first to merge a PR!",
+      "error": "Couldn't load the leaderboard: {{message}}"
+    },
+    "doctorSummary": {
+      "ariaLabel": "Environment diagnostic summary",
+      "title": "Environment health",
+      "counts": {
+        "ok": "ok",
+        "warn": "warn",
+        "fail": "fail"
+      },
+      "hint": "Hint: {{fixHint}}"
+    },
+    "curatedIssues": {
+      "ariaLabel": "Curated good-first-issues",
+      "difficulty": {
+        "goodFirst": "good first",
+        "easy": "easy",
+        "medium": "medium",
+        "hard": "hard"
+      },
+      "empty": "No good-first-issues open in this lane right now — check back soon, or pick a different lane.",
+      "error": "Couldn't load curated issues: {{message}}"
+    },
+    "onboarding": {
+      "title": "Contribute to Shep",
+      "description": "Pick a lane that matches what you want to work on. Shep will list curated good-first-issues you can ship in under 30 minutes — and run a quick environment check so your fresh clone actually builds.",
+      "pickLanePrompt": "Choose a lane to see curated issues.",
+      "doctorUnavailable": "Environment check unavailable: {{error}}"
+    }
+  },
+  "onboarding": {
+    "welcomeBanner": {
+      "dismiss": "Dismiss this hint"
+    },
+    "tutorial": {
+      "title": "Get started",
+      "description": "A short tour through the new agent collaboration & supervision features. Each section links to the live surface — read for two minutes, then go try it.",
+      "sectionsNavLabel": "Tutorial sections",
+      "footer": "Stuck on something? The whole stack is editable — every prompt, every graph, every autonomy level. Bumping a slot version is reversible: delete the override and the bundled default returns byte-for-byte.",
+      "sections": {
+        "supervisors": {
+          "badge": "Supervision",
+          "title": "Supervisors keep agents on the rails",
+          "intro": "A supervisor is a small agent that watches another agent and decides whether to approve, advise, escalate, or reject what it tries to do. Policies cascade — feature beats repo beats application beats global.",
+          "steps": {
+            "0": {
+              "title": "Open the supervisor dashboard",
+              "description": "Lists every configured policy grouped by scope and the most recent decisions across all of them.",
+              "detail": "You will land on an empty state the first time. The buttons there jump straight into pick-an-application or edit-agent-prompts so the page is never a dead end.",
+              "cta": "Open /supervisor"
+            },
+            "1": {
+              "title": "Create your first supervisor",
+              "description": "Click \"Create supervisor\" at the top right. Pick the scope you want to watch (global, application, repository, or per-feature override), then choose an autonomy level.",
+              "detail": "Advisory recommends only — safest default. Co-sign requires both supervisor and user to approve a gate. Autonomous lets the supervisor act on your behalf within the policy you configure."
+            },
+            "2": {
+              "title": "Tune per-gate authority",
+              "description": "For each gate (PRD, Plan, Merge) you can override the global autonomy level. A merge gate set to Co-sign while everything else is Advisory is a common starter setup."
+            },
+            "3": {
+              "title": "Inspect decisions",
+              "description": "Once your supervisor evaluates an event, the rationale + verdict shows up in the Recent decisions list. Click \"Why?\" on any row to see the full audit trail."
+            },
+            "4": {
+              "title": "Promoted on the application page",
+              "description": "Every application top-bar now has a Configure supervisor button that takes you straight to the per-app policy editor."
+            }
+          }
+        },
+        "agents": {
+          "badge": "Agents",
+          "title": "Edit prompts, graphs, and try them in the playground",
+          "intro": "The Agents page lists every built-in agent (feature-agent, supervisor-agent) plus any custom agents you create. Each one has three tabs: Prompts, Graph, and Playground.",
+          "steps": {
+            "0": {
+              "title": "Open the agent list",
+              "description": "You will see one row per registered agent with its prompt count and override count. Click any row to open the editor.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Edit a prompt slot",
+              "description": "Each agent has one or more system-prompt slots. Save an override and it replaces the bundled body at runtime; click \"Reset to bundled\" to restore the byte-identical default.",
+              "detail": "Overrides are versioned — every save bumps the version counter so the audit trail tells you exactly which prompt was in effect when an action ran."
+            },
+            "2": {
+              "title": "Edit the graph (write capability)",
+              "description": "Open the Graph tab and click Edit. Drag nodes to rearrange, drag from a node handle to connect, double-click a label to rename, and Backspace to delete. Save or Reset to bundled to roll back.",
+              "detail": "Nodes and edges are stored as a JSON descriptor — a structural override of the LangGraph topology shipped with the runtime."
+            },
+            "3": {
+              "title": "Try it in the playground",
+              "description": "The Playground tab streams a live chat against the configured executor with the current (possibly unsaved) prompt body so you can A/B before saving.",
+              "detail": "Playground runs are isolated — they never touch agent_runs, agent_messages, or supervisor_decisions tables."
+            }
+          }
+        },
+        "custom-agents": {
+          "badge": "Custom agents",
+          "title": "Stand up a brand-new agent type",
+          "intro": "Custom agents share the same prompt + graph + playground surfaces as built-ins. Use them when you want a new agent type the runtime does not ship with — code review, doc rewriting, whatever.",
+          "steps": {
+            "0": {
+              "title": "Click \"New agent\" on /agents",
+              "description": "Pick a stable kebab-case id (e.g. code-review), a display name, a description, and optionally seed the first prompt slot.",
+              "cta": "Open /agents"
+            },
+            "1": {
+              "title": "Author more prompt slots",
+              "description": "Once created, the agent opens in the editor. Add as many prompt slots as you need — custom agents accept any slot id you invent (built-ins are locked to the registry)."
+            },
+            "2": {
+              "title": "Design the graph from scratch",
+              "description": "A custom agent starts with a single \"Start\" node so the editor is immediately useful. Add nodes, connect them, save — your topology is now persisted as an override."
+            },
+            "3": {
+              "title": "Delete cleans up after itself",
+              "description": "Removing a custom agent cascades through prompt + graph overrides so nothing is left orphaned in the database. Built-ins cannot be deleted."
+            }
+          }
+        },
+        "where-to-find-things": {
+          "badge": "Discoverability",
+          "title": "Where everything lives",
+          "intro": "A quick map of the new surfaces and how to reach each.",
+          "steps": {
+            "0": {
+              "title": "Sidebar — Supervisor / Agents / Get started",
+              "description": "All three live under the collaboration feature flag. If they are missing, enable the flag in Settings."
+            },
+            "1": {
+              "title": "Application top-bar — Configure supervisor",
+              "description": "Lands you on /application/[id]/supervisor with the per-app policy form pre-loaded."
+            },
+            "2": {
+              "title": "Per-feature override",
+              "description": "On the supervisor dashboard, the \"Per-feature overrides\" group surfaces every policy that targets a single feature. Use the Create dialog and pick scope = feature to add one."
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #621

## Summary
- wrap contributor onboarding, lane chooser, curated issues, doctor summary, leaderboard, and onboarding tutorial copy with `useTranslation`
- add contributor and onboarding translation keys to all 9 `translations/*/web.json` locale files
- keep non-English locale values as English stubs so key sets stay aligned for translators

## Verification
- `pnpm exec prettier --write src/presentation/web/components/onboarding/onboarding-tutorial.tsx src/presentation/web/components/onboarding/welcome-banner.tsx src/presentation/web/components/contributors/LaneChooser.tsx src/presentation/web/components/contributors/ContributorLeaderboard.tsx src/presentation/web/components/contributors/DoctorSummary.tsx src/presentation/web/components/contributors/CuratedIssuesList.tsx src/presentation/web/components/contributors/ContributorOnboardingView.tsx translations/{ar,de,en,es,fr,he,pt,ru,uk}/web.json`
- `pnpm typecheck`
- `git diff --check`
- issue grep check: every target component returns `t('` count > 0
- locale key parity check: all 9 `web.json` files match with 625 flattened keys
- `pnpm lint`
- `pnpm exec vitest run tests/unit/presentation/web/components/contributors/doctor-summary.test.tsx`
- commit hook: `pnpm generate`, ESLint, Prettier, typecheck
