### PR TITLE
feat(dx): regenerate good-first-issues doc

### DIFF
--- a/GOOD_FIRST_ISSUES.md
+++ b/GOOD_FIRST_ISSUES.md
@@ -20,6 +20,8 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full flow.
 
 ---
 
+<!-- good-first-issues:start -->
+
 ## docs lane
 
 *Documentation, READMEs, JSDoc, contributor docs, lessons.*
@@ -109,6 +111,8 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full flow.
 ### medium
 
 - [#625 — auto-regenerate GOOD_FIRST_ISSUES.md from live GitHub labels](https://github.com/shep-ai/shep/issues/625)
+
+<!-- good-first-issues:end -->
 
 ---
 

--- a/packages/core/src/application/ports/output/services/contributor-action-gate.interface.ts
+++ b/packages/core/src/application/ports/output/services/contributor-action-gate.interface.ts
@@ -29,7 +29,8 @@ export type ContributorActionKind =
   | 'discord-post'
   | 'recap-publish-file'
   | 'recap-publish-discord'
-  | 'recap-publish-github-discussion';
+  | 'recap-publish-github-discussion'
+  | 'good-first-issues-doc-write';
 
 export interface ContributorGateInput {
   /** Kind of action being gated. */

--- a/packages/core/src/application/ports/output/services/external-issue-fetcher.interface.ts
+++ b/packages/core/src/application/ports/output/services/external-issue-fetcher.interface.ts
@@ -93,6 +93,16 @@ export interface IExternalIssueFetcher {
     repo: string,
     labels: readonly string[]
   ): Promise<ExternalIssueSummary[]>;
+
+  /**
+   * Alias for listing open GitHub issues carrying ALL labels. Named for
+   * cadence-driven document regeneration callers.
+   */
+  listOpenByLabels(
+    owner: string,
+    repo: string,
+    labels: readonly string[]
+  ): Promise<ExternalIssueSummary[]>;
 }
 
 /**

--- a/packages/core/src/application/ports/output/services/file-system-service.interface.ts
+++ b/packages/core/src/application/ports/output/services/file-system-service.interface.ts
@@ -7,6 +7,21 @@
 
 export interface IFileSystemService {
   /**
+   * Read a UTF-8 text file.
+   *
+   * @param filePath - Absolute path to the file to read
+   */
+  readTextFile(filePath: string): Promise<string>;
+
+  /**
+   * Write a UTF-8 text file, replacing its previous contents.
+   *
+   * @param filePath - Absolute path to the file to write
+   * @param contents - UTF-8 text contents
+   */
+  writeTextFile(filePath: string, contents: string): Promise<void>;
+
+  /**
    * Recursively remove a directory and all its contents.
    *
    * Idempotent: succeeds silently if the path does not exist.

--- a/packages/core/src/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.ts
+++ b/packages/core/src/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.ts
@@ -1,0 +1,193 @@
+/**
+ * RegenerateGoodFirstIssuesDocUseCase — spec 097.
+ *
+ * Rebuilds only the generated lane/difficulty buckets in
+ * GOOD_FIRST_ISSUES.md from live GitHub labels. The surrounding preamble,
+ * claim instructions, empty-list guidance, and related links are preserved
+ * byte-for-byte. Actual file writes are supervisor-gated.
+ */
+
+import { inject, injectable } from 'tsyringe';
+
+import { ContributionDifficulty, ContributorLane } from '../../../domain/generated/output.js';
+import type {
+  ExternalIssueSummary,
+  IExternalIssueFetcher,
+} from '../../ports/output/services/external-issue-fetcher.interface.js';
+import type { IFileSystemService } from '../../ports/output/services/file-system-service.interface.js';
+import type { IContributorActionGate } from '../../ports/output/services/contributor-action-gate.interface.js';
+
+export const GOOD_FIRST_ISSUE_DOC_START = '<!-- good-first-issues:start -->';
+export const GOOD_FIRST_ISSUE_DOC_END = '<!-- good-first-issues:end -->';
+export const GOOD_FIRST_ISSUE_LABEL = 'good first issue';
+
+const LANES: readonly ContributorLane[] = [
+  ContributorLane.Docs,
+  ContributorLane.Agents,
+  ContributorLane.Ui,
+  ContributorLane.Cli,
+  ContributorLane.Infra,
+];
+
+const DIFFICULTIES: readonly ContributionDifficulty[] = [
+  ContributionDifficulty.GoodFirst,
+  ContributionDifficulty.Easy,
+  ContributionDifficulty.Medium,
+  ContributionDifficulty.Hard,
+];
+
+const LANE_DESCRIPTIONS: Readonly<Record<ContributorLane, string>> = {
+  [ContributorLane.Docs]: 'Documentation, READMEs, JSDoc, contributor docs, lessons.',
+  [ContributorLane.Agents]:
+    'Agent prompts, supervisor flow, agent-agnostic plumbing under `tsp/agents/`, `application/use-cases/agents/`, `infrastructure/agents/`.',
+  [ContributorLane.Ui]:
+    'Web dashboard under `src/presentation/web/`, Storybook stories, Playwright e2e.',
+  [ContributorLane.Cli]:
+    'Commander commands, terminal UX, structured output under `src/presentation/cli/`.',
+  [ContributorLane.Infra]:
+    'SQLite, ports/adapters, queues, schedulers, GitHub plumbing under `infrastructure/`.',
+};
+
+export interface RegenerateGoodFirstIssuesDocInput {
+  owner: string;
+  repo: string;
+  docPath: string;
+}
+
+export type RegenerateGoodFirstIssuesDocResult =
+  | { status: 'unchanged'; issueCount: number }
+  | { status: 'updated'; issueCount: number }
+  | { status: 'denied'; issueCount: number; rationale: string };
+
+interface Bucket {
+  lane: ContributorLane;
+  difficulty: ContributionDifficulty;
+  issues: readonly ExternalIssueSummary[];
+}
+
+@injectable()
+export class RegenerateGoodFirstIssuesDocUseCase {
+  constructor(
+    @inject('IExternalIssueFetcher')
+    private readonly issues: IExternalIssueFetcher,
+    @inject('IFileSystemService')
+    private readonly files: IFileSystemService,
+    @inject('IContributorActionGate')
+    private readonly gate: IContributorActionGate
+  ) {}
+
+  async execute(
+    input: RegenerateGoodFirstIssuesDocInput
+  ): Promise<RegenerateGoodFirstIssuesDocResult> {
+    const current = await this.files.readTextFile(input.docPath);
+    const buckets = await this.fetchBuckets(input.owner, input.repo);
+    const generated = renderGeneratedBuckets(buckets);
+    const next = replaceGeneratedRegion(current, generated);
+    const issueCount = buckets.reduce((sum, bucket) => sum + bucket.issues.length, 0);
+
+    if (next === current) {
+      return { status: 'unchanged', issueCount };
+    }
+
+    const decision = await this.gate.gate({
+      kind: 'good-first-issues-doc-write',
+      summary: `Regenerate GOOD_FIRST_ISSUES.md for ${input.owner}/${input.repo}`,
+      context: {
+        owner: input.owner,
+        repo: input.repo,
+        docPath: input.docPath,
+        issueCount,
+      },
+    });
+
+    if (!decision.approved) {
+      return { status: 'denied', issueCount, rationale: decision.rationale };
+    }
+
+    await this.files.writeTextFile(input.docPath, next);
+    return { status: 'updated', issueCount };
+  }
+
+  private async fetchBuckets(owner: string, repo: string): Promise<Bucket[]> {
+    const buckets: Bucket[] = [];
+    for (const lane of LANES) {
+      for (const difficulty of DIFFICULTIES) {
+        const issues = await this.issues.listOpenByLabels(owner, repo, [
+          GOOD_FIRST_ISSUE_LABEL,
+          `lane:${lane}`,
+          `difficulty:${difficulty}`,
+        ]);
+        buckets.push({
+          lane,
+          difficulty,
+          issues: [...issues].sort(compareIssues),
+        });
+      }
+    }
+    return buckets;
+  }
+}
+
+export function replaceGeneratedRegion(current: string, generated: string): string {
+  const markerStart = current.indexOf(GOOD_FIRST_ISSUE_DOC_START);
+  const markerEnd = current.indexOf(GOOD_FIRST_ISSUE_DOC_END);
+  if ((markerStart === -1) !== (markerEnd === -1)) {
+    throw new Error('GOOD_FIRST_ISSUES.md generated bucket markers are incomplete.');
+  }
+
+  if (markerStart !== -1 && markerEnd !== -1) {
+    if (markerEnd <= markerStart) {
+      throw new Error('GOOD_FIRST_ISSUES.md generated bucket markers are out of order.');
+    }
+
+    const before = current.slice(0, markerStart);
+    const after = current.slice(markerEnd + GOOD_FIRST_ISSUE_DOC_END.length);
+    return `${before}${GOOD_FIRST_ISSUE_DOC_START}\n\n${generated}\n\n${GOOD_FIRST_ISSUE_DOC_END}${after}`;
+  }
+
+  const fallbackStart = current.indexOf('\n## docs lane\n');
+  const fallbackEnd = current.indexOf('\n---\n\n## When this list is empty');
+  if (fallbackStart === -1 || fallbackEnd === -1 || fallbackEnd <= fallbackStart) {
+    throw new Error('GOOD_FIRST_ISSUES.md generated bucket region was not found.');
+  }
+
+  return `${current.slice(0, fallbackStart + 1)}${GOOD_FIRST_ISSUE_DOC_START}\n\n${generated}\n\n${GOOD_FIRST_ISSUE_DOC_END}${current.slice(fallbackEnd)}`;
+}
+
+export function renderGeneratedBuckets(buckets: readonly Bucket[]): string {
+  const byLaneAndDifficulty = new Map<string, readonly ExternalIssueSummary[]>();
+  for (const bucket of buckets) {
+    byLaneAndDifficulty.set(bucketKey(bucket.lane, bucket.difficulty), bucket.issues);
+  }
+
+  return LANES.map((lane) => renderLane(lane, byLaneAndDifficulty)).join('\n\n---\n\n');
+}
+
+function renderLane(
+  lane: ContributorLane,
+  byLaneAndDifficulty: ReadonlyMap<string, readonly ExternalIssueSummary[]>
+): string {
+  const chunks = [`## ${lane} lane`, '', `*${LANE_DESCRIPTIONS[lane]}*`];
+  for (const difficulty of DIFFICULTIES) {
+    chunks.push('', `### ${difficulty}`, '');
+    const issues = byLaneAndDifficulty.get(bucketKey(lane, difficulty)) ?? [];
+    if (issues.length === 0) {
+      chunks.push('- _No curated issues right now._');
+    } else {
+      chunks.push(...issues.map(renderIssue));
+    }
+  }
+  return chunks.join('\n');
+}
+
+function renderIssue(issue: ExternalIssueSummary): string {
+  return `- [#${issue.issueNumber} — ${issue.title}](${issue.url})`;
+}
+
+function bucketKey(lane: ContributorLane, difficulty: ContributionDifficulty): string {
+  return `${lane}:${difficulty}`;
+}
+
+function compareIssues(a: ExternalIssueSummary, b: ExternalIssueSummary): number {
+  return a.issueNumber - b.issueNumber || a.title.localeCompare(b.title);
+}

--- a/packages/core/src/infrastructure/di/modules/register-use-cases.ts
+++ b/packages/core/src/infrastructure/di/modules/register-use-cases.ts
@@ -78,6 +78,7 @@ import { RunDoctorUseCase } from '../../../application/use-cases/doctor/run-doct
 // Contributor onboarding (feature 097) read use cases — wired for the web view
 import { GetContributorLeaderboardUseCase } from '../../../application/use-cases/contributors/get-contributor-leaderboard.use-case.js';
 import { GetCuratedIssuesByLaneUseCase } from '../../../application/use-cases/contributors/get-curated-issues-by-lane.use-case.js';
+import { RegenerateGoodFirstIssuesDocUseCase } from '../../../application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
 
 // Code review (feature 090) use cases
 import { RunCodeReviewUseCase } from '../../../application/use-cases/code-review/run-code-review.use-case.js';
@@ -202,6 +203,7 @@ export function registerUseCases(container: DependencyContainer): void {
   // ─── Contributor onboarding (feature 097) read use cases ───────────────
   container.registerSingleton(GetContributorLeaderboardUseCase);
   container.registerSingleton(GetCuratedIssuesByLaneUseCase);
+  container.registerSingleton(RegenerateGoodFirstIssuesDocUseCase);
 
   // ─── Code review (feature 090) use cases ────────────────────────────────
   container.registerSingleton(RunCodeReviewUseCase);
@@ -499,5 +501,8 @@ export function registerUseCases(container: DependencyContainer): void {
   });
   container.register('GetCuratedIssuesByLaneUseCase', {
     useFactory: (c) => c.resolve(GetCuratedIssuesByLaneUseCase),
+  });
+  container.register('RegenerateGoodFirstIssuesDocUseCase', {
+    useFactory: (c) => c.resolve(RegenerateGoodFirstIssuesDocUseCase),
   });
 }

--- a/packages/core/src/infrastructure/services/contributors/good-first-issues-doc-watcher.service.ts
+++ b/packages/core/src/infrastructure/services/contributors/good-first-issues-doc-watcher.service.ts
@@ -1,0 +1,118 @@
+/**
+ * Good First Issues Doc Watcher Service
+ *
+ * Daily cadence companion for the contributor pipeline. It regenerates the
+ * checked-in GOOD_FIRST_ISSUES.md bucket region from live GitHub labels via
+ * RegenerateGoodFirstIssuesDocUseCase. The use case gates writes, so this
+ * watcher only discovers repositories and supplies the doc path.
+ */
+
+import path from 'node:path';
+
+import type { IRepositoryRepository } from '../../../application/ports/output/repositories/repository-repository.interface.js';
+import type { IGitHubRepositoryService } from '../../../application/ports/output/services/github-repository-service.interface.js';
+import type { RegenerateGoodFirstIssuesDocUseCase } from '../../../application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
+
+export const DEFAULT_GOOD_FIRST_ISSUES_DOC_POLL_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export class GoodFirstIssuesDocWatcherService {
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly useCase: RegenerateGoodFirstIssuesDocUseCase,
+    private readonly repositoryRepo: IRepositoryRepository,
+    private readonly githubService: IGitHubRepositoryService,
+    private readonly workspaceRoot: string,
+    private readonly pollIntervalMs: number = DEFAULT_GOOD_FIRST_ISSUES_DOC_POLL_INTERVAL_MS
+  ) {}
+
+  isRunning(): boolean {
+    return this.intervalId !== null;
+  }
+
+  start(): void {
+    if (this.intervalId !== null) return;
+    void this.poll();
+    this.intervalId = setInterval(() => {
+      void this.poll();
+    }, this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /** Exposed for tests and manual trigger callers. */
+  async poll(): Promise<void> {
+    let repositories;
+    try {
+      repositories = await this.repositoryRepo.list();
+    } catch {
+      return;
+    }
+
+    for (const repo of repositories) {
+      if (!repo.remoteUrl) continue;
+      const docPath = path.join(repo.path || this.workspaceRoot, 'GOOD_FIRST_ISSUES.md');
+      let parsed;
+      try {
+        parsed = this.githubService.parseGitHubUrl(repo.remoteUrl);
+      } catch {
+        continue;
+      }
+      try {
+        await this.useCase.execute({
+          owner: parsed.owner,
+          repo: parsed.repo,
+          docPath,
+        });
+      } catch {
+        // Per-repo failures are isolated; continue with other repos.
+      }
+    }
+  }
+}
+
+let watcherInstance: GoodFirstIssuesDocWatcherService | null = null;
+
+export function initializeGoodFirstIssuesDocWatcher(
+  useCase: RegenerateGoodFirstIssuesDocUseCase,
+  repositoryRepo: IRepositoryRepository,
+  githubService: IGitHubRepositoryService,
+  workspaceRoot: string,
+  pollIntervalMs?: number
+): void {
+  if (watcherInstance !== null) {
+    throw new Error('Good-first-issues doc watcher already initialized. Cannot re-initialize.');
+  }
+  watcherInstance = new GoodFirstIssuesDocWatcherService(
+    useCase,
+    repositoryRepo,
+    githubService,
+    workspaceRoot,
+    pollIntervalMs
+  );
+}
+
+export function getGoodFirstIssuesDocWatcher(): GoodFirstIssuesDocWatcherService {
+  if (watcherInstance === null) {
+    throw new Error(
+      'Good-first-issues doc watcher not initialized. Call initializeGoodFirstIssuesDocWatcher() during web server startup.'
+    );
+  }
+  return watcherInstance;
+}
+
+export function hasGoodFirstIssuesDocWatcher(): boolean {
+  return watcherInstance !== null;
+}
+
+export function resetGoodFirstIssuesDocWatcher(): void {
+  if (watcherInstance !== null) {
+    watcherInstance.stop();
+  }
+  watcherInstance = null;
+}

--- a/packages/core/src/infrastructure/services/external/github-issue.service.ts
+++ b/packages/core/src/infrastructure/services/external/github-issue.service.ts
@@ -147,6 +147,14 @@ export class GitHubIssueFetcher implements IExternalIssueFetcher {
     }
   }
 
+  async listOpenByLabels(
+    owner: string,
+    repo: string,
+    labels: readonly string[]
+  ): Promise<ExternalIssueSummary[]> {
+    return this.listIssuesByLabels(owner, repo, labels);
+  }
+
   private parseRef(ref: string): { issueNumber: string; repo?: string } {
     const fullMatch = ref.match(/^([^#]+)#(\d+)$/);
     if (fullMatch) {

--- a/packages/core/src/infrastructure/services/file-system.service.ts
+++ b/packages/core/src/infrastructure/services/file-system.service.ts
@@ -5,13 +5,21 @@
  */
 
 import { existsSync } from 'node:fs';
-import { rm } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import { injectable } from 'tsyringe';
 
 import type { IFileSystemService } from '../../application/ports/output/services/file-system-service.interface.js';
 
 @injectable()
 export class FileSystemService implements IFileSystemService {
+  async readTextFile(filePath: string): Promise<string> {
+    return readFile(filePath, 'utf8');
+  }
+
+  async writeTextFile(filePath: string, contents: string): Promise<void> {
+    await writeFile(filePath, contents, 'utf8');
+  }
+
   async removeDirectory(dirPath: string): Promise<void> {
     await rm(dirPath, { recursive: true, force: true });
   }

--- a/src/presentation/cli/commands/_serve.command.ts
+++ b/src/presentation/cli/commands/_serve.command.ts
@@ -45,7 +45,12 @@ import {
   initializeMonthlyRecapWatcher,
   getMonthlyRecapWatcher,
 } from '@/infrastructure/services/contributors/monthly-recap-watcher.service.js';
+import {
+  initializeGoodFirstIssuesDocWatcher,
+  getGoodFirstIssuesDocWatcher,
+} from '@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js';
 import { DetectStaleGoodFirstIssueUseCase } from '@/application/use-cases/contributors/detect-stale-good-first-issue.use-case.js';
+import { RegenerateGoodFirstIssuesDocUseCase } from '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
 import { GenerateMonthlyRecapUseCase } from '@/application/use-cases/contributors/generate-monthly-recap.use-case.js';
 import { PublishMonthlyRecapUseCase } from '@/application/use-cases/contributors/publish-monthly-recap.use-case.js';
 import type { IVersionService } from '@/application/ports/output/services/version-service.interface.js';
@@ -109,6 +114,10 @@ export function createServeCommand(): Command {
           'IGitHubRepositoryService'
         );
         const desktopNotifier = container.resolve<IDesktopNotifier>('IDesktopNotifier');
+        const workspaceRoot =
+          process.env.SHEP_INSTANCE_PATH ??
+          process.env.NEXT_PUBLIC_SHEP_INSTANCE_PATH ??
+          process.cwd();
         initializeStaleGoodFirstIssueWatcher(
           container.resolve(DetectStaleGoodFirstIssueUseCase),
           repositoryRepo,
@@ -121,6 +130,13 @@ export function createServeCommand(): Command {
           publish: container.resolve(PublishMonthlyRecapUseCase),
         });
         getMonthlyRecapWatcher().start();
+        initializeGoodFirstIssuesDocWatcher(
+          container.resolve(RegenerateGoodFirstIssuesDocUseCase),
+          repositoryRepo,
+          githubRepoService,
+          workspaceRoot
+        );
+        getGoodFirstIssuesDocWatcher().start();
 
         // Graceful shutdown handler — identical pattern to ui.command.ts
         let isShuttingDown = false;
@@ -136,6 +152,7 @@ export function createServeCommand(): Command {
           getAutoArchiveWatcher().stop();
           getStaleGoodFirstIssueWatcher().stop();
           getMonthlyRecapWatcher().stop();
+          getGoodFirstIssuesDocWatcher().stop();
           const deploymentService = container.resolve<IDeploymentService>('IDeploymentService');
           deploymentService.stopAll();
           await service.stop();

--- a/src/presentation/cli/commands/ui.command.ts
+++ b/src/presentation/cli/commands/ui.command.ts
@@ -48,7 +48,12 @@ import {
   initializeMonthlyRecapWatcher,
   getMonthlyRecapWatcher,
 } from '@/infrastructure/services/contributors/monthly-recap-watcher.service.js';
+import {
+  initializeGoodFirstIssuesDocWatcher,
+  getGoodFirstIssuesDocWatcher,
+} from '@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js';
 import { DetectStaleGoodFirstIssueUseCase } from '@/application/use-cases/contributors/detect-stale-good-first-issue.use-case.js';
+import { RegenerateGoodFirstIssuesDocUseCase } from '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
 import { GenerateMonthlyRecapUseCase } from '@/application/use-cases/contributors/generate-monthly-recap.use-case.js';
 import { PublishMonthlyRecapUseCase } from '@/application/use-cases/contributors/publish-monthly-recap.use-case.js';
 import { getExistingConnection } from '@/infrastructure/persistence/sqlite/connection.js';
@@ -137,6 +142,10 @@ Examples:
           'IGitHubRepositoryService'
         );
         const desktopNotifier = container.resolve<IDesktopNotifier>('IDesktopNotifier');
+        const workspaceRoot =
+          process.env.SHEP_INSTANCE_PATH ??
+          process.env.NEXT_PUBLIC_SHEP_INSTANCE_PATH ??
+          process.cwd();
         initializeStaleGoodFirstIssueWatcher(
           container.resolve(DetectStaleGoodFirstIssueUseCase),
           repositoryRepo,
@@ -149,6 +158,13 @@ Examples:
           publish: container.resolve(PublishMonthlyRecapUseCase),
         });
         getMonthlyRecapWatcher().start();
+        initializeGoodFirstIssuesDocWatcher(
+          container.resolve(RegenerateGoodFirstIssuesDocUseCase),
+          repositoryRepo,
+          githubRepoService,
+          workspaceRoot
+        );
+        getGoodFirstIssuesDocWatcher().start();
 
         const baseUrl = `http://localhost:${port}`;
         messages.success(t('cli:commands.ui.serverReady', { url: fmt.code(baseUrl) }));
@@ -179,6 +195,7 @@ Examples:
           getAutoArchiveWatcher().stop();
           getStaleGoodFirstIssueWatcher().stop();
           getMonthlyRecapWatcher().stop();
+          getGoodFirstIssuesDocWatcher().stop();
           await service.stop();
           process.exit(0);
         };

--- a/src/presentation/web/dev-server.ts
+++ b/src/presentation/web/dev-server.ts
@@ -49,7 +49,12 @@ import {
   initializeMonthlyRecapWatcher,
   getMonthlyRecapWatcher,
 } from '@/infrastructure/services/contributors/monthly-recap-watcher.service.js';
+import {
+  initializeGoodFirstIssuesDocWatcher,
+  getGoodFirstIssuesDocWatcher,
+} from '@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js';
 import { DetectStaleGoodFirstIssueUseCase } from '@/application/use-cases/contributors/detect-stale-good-first-issue.use-case.js';
+import { RegenerateGoodFirstIssuesDocUseCase } from '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
 import { GenerateMonthlyRecapUseCase } from '@/application/use-cases/contributors/generate-monthly-recap.use-case.js';
 import { PublishMonthlyRecapUseCase } from '@/application/use-cases/contributors/publish-monthly-recap.use-case.js';
 import type { IRepositoryRepository } from '@/application/ports/output/repositories/repository-repository.interface.js';
@@ -175,6 +180,8 @@ async function main() {
       'IGitHubRepositoryService'
     );
     const desktopNotifier = container.resolve<IDesktopNotifier>('IDesktopNotifier');
+    const workspaceRoot =
+      process.env.SHEP_INSTANCE_PATH ?? process.env.NEXT_PUBLIC_SHEP_INSTANCE_PATH ?? process.cwd();
     initializeStaleGoodFirstIssueWatcher(
       container.resolve(DetectStaleGoodFirstIssueUseCase),
       repositoryRepo,
@@ -187,6 +194,13 @@ async function main() {
       publish: container.resolve(PublishMonthlyRecapUseCase),
     });
     getMonthlyRecapWatcher().start();
+    initializeGoodFirstIssuesDocWatcher(
+      container.resolve(RegenerateGoodFirstIssuesDocUseCase),
+      repositoryRepo,
+      githubRepoService,
+      workspaceRoot
+    );
+    getGoodFirstIssuesDocWatcher().start();
   } catch (error) {
     console.warn('[dev-server] DI initialization failed — features will be empty:', error);
   }
@@ -264,6 +278,11 @@ async function main() {
       }
       try {
         getMonthlyRecapWatcher().stop();
+      } catch {
+        /* not initialized */
+      }
+      try {
+        getGoodFirstIssuesDocWatcher().stop();
       } catch {
         /* not initialized */
       }

--- a/tests/unit/application/ports/external-issue-fetcher.interface.test.ts
+++ b/tests/unit/application/ports/external-issue-fetcher.interface.test.ts
@@ -40,6 +40,7 @@ describe('IExternalIssueFetcher type contracts', () => {
       getMergedPrCount: async () => 0,
       listIssuesByLabel: async () => [],
       listIssuesByLabels: async () => [],
+      listOpenByLabels: async () => [],
     };
     expect(mockFetcher.fetchGitHubIssue).toBeDefined();
     expect(mockFetcher.fetchJiraTicket).toBeDefined();

--- a/tests/unit/application/use-cases/cloud-deploy/cloud-deploy-use-cases.test.ts
+++ b/tests/unit/application/use-cases/cloud-deploy/cloud-deploy-use-cases.test.ts
@@ -104,6 +104,12 @@ class FakeRegistry implements ICloudDeploymentProviderRegistry {
 
 class FakeFs implements IFileSystemService {
   constructor(public existingPaths = new Set<string>()) {}
+  async readTextFile(): Promise<string> {
+    return '';
+  }
+  async writeTextFile(): Promise<void> {
+    /* no-op for tests */
+  }
   async removeDirectory(): Promise<void> {
     /* no-op for tests */
   }

--- a/tests/unit/application/use-cases/contributors/detect-stale-good-first-issue.use-case.test.ts
+++ b/tests/unit/application/use-cases/contributors/detect-stale-good-first-issue.use-case.test.ts
@@ -31,6 +31,7 @@ function fakeFetcher(items: ExternalIssueSummary[]): IExternalIssueFetcher {
     getMergedPrCount: vi.fn(),
     listIssuesByLabel: vi.fn().mockResolvedValue(items),
     listIssuesByLabels: vi.fn(),
+    listOpenByLabels: vi.fn(),
   };
 }
 

--- a/tests/unit/application/use-cases/contributors/get-curated-issues-by-lane.use-case.test.ts
+++ b/tests/unit/application/use-cases/contributors/get-curated-issues-by-lane.use-case.test.ts
@@ -33,6 +33,7 @@ function fakeFetcher(items: ExternalIssueSummary[]): IExternalIssueFetcher {
     getMergedPrCount: vi.fn(),
     listIssuesByLabel: vi.fn(),
     listIssuesByLabels: vi.fn().mockResolvedValue(items),
+    listOpenByLabels: vi.fn(),
   };
 }
 

--- a/tests/unit/application/use-cases/contributors/groom-issue.use-case.test.ts
+++ b/tests/unit/application/use-cases/contributors/groom-issue.use-case.test.ts
@@ -17,6 +17,7 @@ function fetcherReturning(issue: ExternalIssue): IExternalIssueFetcher {
     getMergedPrCount: vi.fn(),
     listIssuesByLabel: vi.fn(),
     listIssuesByLabels: vi.fn(),
+    listOpenByLabels: vi.fn(),
   };
 }
 

--- a/tests/unit/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.test.ts
+++ b/tests/unit/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.test.ts
@@ -1,0 +1,223 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  GOOD_FIRST_ISSUE_DOC_END,
+  GOOD_FIRST_ISSUE_DOC_START,
+  GOOD_FIRST_ISSUE_LABEL,
+  RegenerateGoodFirstIssuesDocUseCase,
+  replaceGeneratedRegion,
+} from '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
+import type {
+  ExternalIssueSummary,
+  IExternalIssueFetcher,
+} from '@/application/ports/output/services/external-issue-fetcher.interface.js';
+import type { IFileSystemService } from '@/application/ports/output/services/file-system-service.interface.js';
+import type { IContributorActionGate } from '@/application/ports/output/services/contributor-action-gate.interface.js';
+
+const DOC_PATH = '/repo/GOOD_FIRST_ISSUES.md';
+
+function docWithBuckets(bucketRegion: string): string {
+  return [
+    '# Good First Issues',
+    '',
+    'Preamble stays exactly as written.',
+    '',
+    '---',
+    '',
+    '## How to claim',
+    '',
+    '1. Comment `/claim`.',
+    '',
+    GOOD_FIRST_ISSUE_DOC_START,
+    '',
+    bucketRegion,
+    '',
+    GOOD_FIRST_ISSUE_DOC_END,
+    '',
+    '---',
+    '',
+    '## When this list is empty',
+    '',
+    'Search the live tracker.',
+    '',
+    '---',
+    '',
+    '## Related',
+    '',
+    '- [CONTRIBUTING.md](./CONTRIBUTING.md)',
+    '',
+  ].join('\n');
+}
+
+function summary(
+  issueNumber: number,
+  title: string,
+  labels: readonly string[]
+): ExternalIssueSummary {
+  return {
+    owner: 'shep-ai',
+    repo: 'shep',
+    issueNumber,
+    title,
+    labels,
+    lastActivityAt: '2026-05-20T00:00:00Z',
+    url: `https://github.com/shep-ai/shep/issues/${issueNumber}`,
+  };
+}
+
+function makeFetcher(itemsByLabels: Record<string, ExternalIssueSummary[]>): IExternalIssueFetcher {
+  return {
+    fetchGitHubIssue: vi.fn(),
+    fetchJiraTicket: vi.fn(),
+    getMergedPrCount: vi.fn(),
+    listIssuesByLabel: vi.fn(),
+    listIssuesByLabels: vi.fn(),
+    listOpenByLabels: vi.fn((_owner: string, _repo: string, labels: readonly string[]) => {
+      return Promise.resolve(itemsByLabels[labels.join('|')] ?? []);
+    }),
+  };
+}
+
+function makeFiles(initial: string): IFileSystemService {
+  return {
+    readTextFile: vi.fn().mockResolvedValue(initial),
+    writeTextFile: vi.fn().mockResolvedValue(undefined),
+    removeDirectory: vi.fn(),
+    pathExists: vi.fn().mockReturnValue(true),
+  };
+}
+
+function makeGate(approved: boolean): IContributorActionGate {
+  return {
+    gate: vi.fn().mockResolvedValue({
+      approved,
+      rationale: approved ? 'autonomous' : 'needs maintainer review',
+    }),
+  };
+}
+
+describe('RegenerateGoodFirstIssuesDocUseCase', () => {
+  it('queries live issues for every lane and difficulty label bucket', async () => {
+    const fetcher = makeFetcher({});
+    const files = makeFiles(docWithBuckets('old buckets'));
+    const gate = makeGate(true);
+    const useCase = new RegenerateGoodFirstIssuesDocUseCase(fetcher, files, gate);
+
+    await useCase.execute({ owner: 'shep-ai', repo: 'shep', docPath: DOC_PATH });
+
+    expect(fetcher.listOpenByLabels).toHaveBeenCalledWith('shep-ai', 'shep', [
+      GOOD_FIRST_ISSUE_LABEL,
+      'lane:docs',
+      'difficulty:goodFirst',
+    ]);
+    expect(fetcher.listOpenByLabels).toHaveBeenCalledWith('shep-ai', 'shep', [
+      GOOD_FIRST_ISSUE_LABEL,
+      'lane:infra',
+      'difficulty:hard',
+    ]);
+    expect(fetcher.listOpenByLabels).toHaveBeenCalledTimes(20);
+  });
+
+  it('rewrites only the generated bucket region and preserves surrounding markdown', async () => {
+    const current = docWithBuckets('old buckets');
+    const fetcher = makeFetcher({
+      [`${GOOD_FIRST_ISSUE_LABEL}|lane:docs|difficulty:goodFirst`]: [
+        summary(616, 'add JSDoc to contributor use cases', [
+          GOOD_FIRST_ISSUE_LABEL,
+          'lane:docs',
+          'difficulty:goodFirst',
+        ]),
+      ],
+    });
+    const files = makeFiles(current);
+    const gate = makeGate(true);
+    const useCase = new RegenerateGoodFirstIssuesDocUseCase(fetcher, files, gate);
+
+    const result = await useCase.execute({ owner: 'shep-ai', repo: 'shep', docPath: DOC_PATH });
+
+    expect(result).toEqual({ status: 'updated', issueCount: 1 });
+    expect(files.writeTextFile).toHaveBeenCalledTimes(1);
+    const next = vi.mocked(files.writeTextFile).mock.calls[0][1];
+    expect(next).toContain('Preamble stays exactly as written.');
+    expect(next).toContain('1. Comment `/claim`.');
+    expect(next).toContain('- [CONTRIBUTING.md](./CONTRIBUTING.md)');
+    expect(next).toContain(
+      '- [#616 — add JSDoc to contributor use cases](https://github.com/shep-ai/shep/issues/616)'
+    );
+    expect(next).not.toContain('old buckets');
+  });
+
+  it('does not gate or write when regenerated content is unchanged', async () => {
+    const fetcher = makeFetcher({});
+    const files = makeFiles(docWithBucketsWithNoIssues());
+    const gate = makeGate(true);
+    const useCase = new RegenerateGoodFirstIssuesDocUseCase(fetcher, files, gate);
+
+    const result = await useCase.execute({ owner: 'shep-ai', repo: 'shep', docPath: DOC_PATH });
+
+    expect(result).toEqual({ status: 'unchanged', issueCount: 0 });
+    expect(gate.gate).not.toHaveBeenCalled();
+    expect(files.writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits the write when the supervisor gate denies it', async () => {
+    const fetcher = makeFetcher({});
+    const files = makeFiles(docWithBuckets('old buckets'));
+    const gate = makeGate(false);
+    const useCase = new RegenerateGoodFirstIssuesDocUseCase(fetcher, files, gate);
+
+    const result = await useCase.execute({ owner: 'shep-ai', repo: 'shep', docPath: DOC_PATH });
+
+    expect(result).toEqual({
+      status: 'denied',
+      issueCount: 0,
+      rationale: 'needs maintainer review',
+    });
+    expect(gate.gate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'good-first-issues-doc-write',
+        summary: 'Regenerate GOOD_FIRST_ISSUES.md for shep-ai/shep',
+      })
+    );
+    expect(files.writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects generated bucket markers that are out of order', () => {
+    expect(() =>
+      replaceGeneratedRegion(
+        `${GOOD_FIRST_ISSUE_DOC_END}\n\n## docs lane\n\n${GOOD_FIRST_ISSUE_DOC_START}`,
+        'generated'
+      )
+    ).toThrow(/out of order/);
+  });
+
+  it('rejects generated bucket markers when only one marker exists', () => {
+    expect(() =>
+      replaceGeneratedRegion(`${GOOD_FIRST_ISSUE_DOC_START}\n\n## docs lane`, 'generated')
+    ).toThrow(/incomplete/);
+  });
+});
+
+function docWithBucketsWithNoIssues(): string {
+  const lanes = ['docs', 'agents', 'ui', 'cli', 'infra'];
+  const difficulties = ['goodFirst', 'easy', 'medium', 'hard'];
+  const descriptions: Record<string, string> = {
+    docs: 'Documentation, READMEs, JSDoc, contributor docs, lessons.',
+    agents:
+      'Agent prompts, supervisor flow, agent-agnostic plumbing under `tsp/agents/`, `application/use-cases/agents/`, `infrastructure/agents/`.',
+    ui: 'Web dashboard under `src/presentation/web/`, Storybook stories, Playwright e2e.',
+    cli: 'Commander commands, terminal UX, structured output under `src/presentation/cli/`.',
+    infra: 'SQLite, ports/adapters, queues, schedulers, GitHub plumbing under `infrastructure/`.',
+  };
+  const region = lanes
+    .map((lane) => {
+      const chunks = [`## ${lane} lane`, '', `*${descriptions[lane]}*`];
+      for (const difficulty of difficulties) {
+        chunks.push('', `### ${difficulty}`, '', '- _No curated issues right now._');
+      }
+      return chunks.join('\n');
+    })
+    .join('\n\n---\n\n');
+  return docWithBuckets(region);
+}

--- a/tests/unit/application/use-cases/contributors/welcome-first-time-contributor.use-case.test.ts
+++ b/tests/unit/application/use-cases/contributors/welcome-first-time-contributor.use-case.test.ts
@@ -19,6 +19,7 @@ function makeFetcher(mergedCount: number): IExternalIssueFetcher {
     getMergedPrCount: vi.fn().mockResolvedValue(mergedCount),
     listIssuesByLabel: vi.fn(),
     listIssuesByLabels: vi.fn(),
+    listOpenByLabels: vi.fn(),
   };
 }
 

--- a/tests/unit/application/use-cases/deployments/start-application-deployment.use-case.test.ts
+++ b/tests/unit/application/use-cases/deployments/start-application-deployment.use-case.test.ts
@@ -33,6 +33,8 @@ function createDeps() {
   } as unknown as IApplicationRepository;
 
   const fileSystem: IFileSystemService = {
+    readTextFile: vi.fn().mockResolvedValue(''),
+    writeTextFile: vi.fn().mockResolvedValue(undefined),
     removeDirectory: vi.fn().mockResolvedValue(undefined),
     pathExists: vi.fn().mockReturnValue(true),
   };

--- a/tests/unit/application/use-cases/deployments/start-feature-deployment.use-case.test.ts
+++ b/tests/unit/application/use-cases/deployments/start-feature-deployment.use-case.test.ts
@@ -71,6 +71,8 @@ function createDeps() {
   };
 
   const fileSystem: IFileSystemService = {
+    readTextFile: vi.fn().mockResolvedValue(''),
+    writeTextFile: vi.fn().mockResolvedValue(undefined),
     removeDirectory: vi.fn().mockResolvedValue(undefined),
     pathExists: vi.fn().mockReturnValue(true),
   };

--- a/tests/unit/application/use-cases/deployments/start-repository-deployment.use-case.test.ts
+++ b/tests/unit/application/use-cases/deployments/start-repository-deployment.use-case.test.ts
@@ -21,6 +21,8 @@ function createDeps() {
   };
 
   const fileSystem: IFileSystemService = {
+    readTextFile: vi.fn().mockResolvedValue(''),
+    writeTextFile: vi.fn().mockResolvedValue(undefined),
     removeDirectory: vi.fn().mockResolvedValue(undefined),
     pathExists: vi.fn().mockReturnValue(true),
   };

--- a/tests/unit/application/use-cases/doctor/diagnostics/dotenv-presence.diagnostic.test.ts
+++ b/tests/unit/application/use-cases/doctor/diagnostics/dotenv-presence.diagnostic.test.ts
@@ -8,6 +8,8 @@ import { DiagnosticStatus } from '@/domain/generated/output.js';
 
 function makeFs(exists: boolean): IFileSystemService {
   return {
+    readTextFile: vi.fn().mockResolvedValue(''),
+    writeTextFile: vi.fn().mockResolvedValue(undefined),
     pathExists: vi.fn().mockReturnValue(exists),
     removeDirectory: vi.fn(),
   };

--- a/tests/unit/application/use-cases/doctor/diagnostics/typespec-freshness.diagnostic.test.ts
+++ b/tests/unit/application/use-cases/doctor/diagnostics/typespec-freshness.diagnostic.test.ts
@@ -11,6 +11,10 @@ import { existsSync } from 'node:fs';
 
 function makeFs(): IFileSystemService {
   return {
+    readTextFile: async () => '',
+    writeTextFile: async () => {
+      /* unused */
+    },
     pathExists: (p: string) => existsSync(p),
     removeDirectory: async () => {
       /* unused */

--- a/tests/unit/application/use-cases/repositories/delete-repository.use-case.test.ts
+++ b/tests/unit/application/use-cases/repositories/delete-repository.use-case.test.ts
@@ -76,6 +76,8 @@ describe('DeleteRepositoryUseCase', () => {
       execute: vi.fn().mockResolvedValue({}),
     } as unknown as DeleteFeatureUseCase;
     mockFileSystem = {
+      readTextFile: vi.fn().mockResolvedValue(''),
+      writeTextFile: vi.fn().mockResolvedValue(undefined),
       removeDirectory: vi.fn().mockResolvedValue(undefined),
       pathExists: vi.fn().mockReturnValue(true),
     };

--- a/tests/unit/commands/_serve.command.test.ts
+++ b/tests/unit/commands/_serve.command.test.ts
@@ -92,11 +92,24 @@ vi.mock('@/infrastructure/services/contributors/monthly-recap-watcher.service.js
     stop: vi.fn(),
   }),
 }));
+vi.mock('@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js', () => ({
+  initializeGoodFirstIssuesDocWatcher: vi.fn(),
+  getGoodFirstIssuesDocWatcher: vi.fn().mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
 
 // Mock contributor pipeline use cases (resolved via class tokens)
 vi.mock('@/application/use-cases/contributors/detect-stale-good-first-issue.use-case.js', () => ({
   DetectStaleGoodFirstIssueUseCase: vi.fn(),
 }));
+vi.mock(
+  '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js',
+  () => ({
+    RegenerateGoodFirstIssuesDocUseCase: vi.fn(),
+  })
+);
 vi.mock('@/application/use-cases/contributors/generate-monthly-recap.use-case.js', () => ({
   GenerateMonthlyRecapUseCase: vi.fn(),
 }));

--- a/tests/unit/commands/index.integration.test.ts
+++ b/tests/unit/commands/index.integration.test.ts
@@ -82,9 +82,19 @@ vi.mock('@/infrastructure/services/contributors/monthly-recap-watcher.service.js
   initializeMonthlyRecapWatcher: vi.fn(),
   getMonthlyRecapWatcher: vi.fn().mockReturnValue({ start: vi.fn(), stop: vi.fn() }),
 }));
+vi.mock('@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js', () => ({
+  initializeGoodFirstIssuesDocWatcher: vi.fn(),
+  getGoodFirstIssuesDocWatcher: vi.fn().mockReturnValue({ start: vi.fn(), stop: vi.fn() }),
+}));
 vi.mock('@/application/use-cases/contributors/detect-stale-good-first-issue.use-case.js', () => ({
   DetectStaleGoodFirstIssueUseCase: vi.fn(),
 }));
+vi.mock(
+  '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js',
+  () => ({
+    RegenerateGoodFirstIssuesDocUseCase: vi.fn(),
+  })
+);
 vi.mock('@/application/use-cases/contributors/generate-monthly-recap.use-case.js', () => ({
   GenerateMonthlyRecapUseCase: vi.fn(),
 }));

--- a/tests/unit/infrastructure/services/contributors/good-first-issues-doc-watcher.service.test.ts
+++ b/tests/unit/infrastructure/services/contributors/good-first-issues-doc-watcher.service.test.ts
@@ -1,0 +1,194 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+import {
+  GoodFirstIssuesDocWatcherService,
+  initializeGoodFirstIssuesDocWatcher,
+  getGoodFirstIssuesDocWatcher,
+  hasGoodFirstIssuesDocWatcher,
+  resetGoodFirstIssuesDocWatcher,
+} from '@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js';
+import type { IRepositoryRepository } from '@/application/ports/output/repositories/repository-repository.interface.js';
+import type { IGitHubRepositoryService } from '@/application/ports/output/services/github-repository-service.interface.js';
+import type { Repository } from '@/domain/generated/output.js';
+import type { RegenerateGoodFirstIssuesDocUseCase } from '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js';
+
+const WORKSPACE_ROOT = '/workspace/shep';
+
+function makeRepoRow(overrides: Partial<Repository>): Repository {
+  return {
+    id: overrides.id ?? 'repo-1',
+    name: overrides.name ?? 'shep',
+    path: overrides.path ?? WORKSPACE_ROOT,
+    remoteUrl: overrides.remoteUrl,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Repository;
+}
+
+function makeMockRepositoryRepo(rows: Repository[]): IRepositoryRepository {
+  return {
+    create: vi.fn(),
+    findById: vi.fn(),
+    findByPath: vi.fn(),
+    findByPathIncludingDeleted: vi.fn(),
+    findByRemoteUrl: vi.fn(),
+    findByUpstreamUrl: vi.fn(),
+    list: vi.fn().mockResolvedValue(rows),
+    remove: vi.fn(),
+    softDelete: vi.fn(),
+    restore: vi.fn(),
+    update: vi.fn(),
+  };
+}
+
+function makeMockGitHubService(): IGitHubRepositoryService {
+  return {
+    parseGitHubUrl: vi.fn().mockImplementation((url: string) => {
+      const match = /github\.com\/([^/]+)\/([^/.]+)/.exec(url);
+      if (!match) throw new Error(`unparseable: ${url}`);
+      return { owner: match[1], repo: match[2], nameWithOwner: `${match[1]}/${match[2]}` };
+    }),
+  } as unknown as IGitHubRepositoryService;
+}
+
+function makeMockUseCase(): RegenerateGoodFirstIssuesDocUseCase {
+  return {
+    execute: vi.fn().mockResolvedValue({ status: 'unchanged', issueCount: 0 }),
+  } as unknown as RegenerateGoodFirstIssuesDocUseCase;
+}
+
+describe('GoodFirstIssuesDocWatcherService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetGoodFirstIssuesDocWatcher();
+  });
+
+  it('dispatches the regeneration use case for each connected repo with a remoteUrl', async () => {
+    const repoRepo = makeMockRepositoryRepo([
+      makeRepoRow({
+        id: 'r1',
+        path: '/workspace/shep',
+        remoteUrl: 'https://github.com/shep-ai/shep',
+      }),
+      makeRepoRow({
+        id: 'r2',
+        path: '/workspace/other',
+        remoteUrl: 'https://github.com/shep-ai/other',
+      }),
+      makeRepoRow({ id: 'r3', remoteUrl: undefined }),
+    ]);
+    const ghService = makeMockGitHubService();
+    const useCase = makeMockUseCase();
+
+    const watcher = new GoodFirstIssuesDocWatcherService(
+      useCase,
+      repoRepo,
+      ghService,
+      WORKSPACE_ROOT,
+      1000
+    );
+    watcher.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(useCase.execute).toHaveBeenCalledTimes(2);
+    expect(useCase.execute).toHaveBeenCalledWith({
+      owner: 'shep-ai',
+      repo: 'shep',
+      docPath: path.join('/workspace/shep', 'GOOD_FIRST_ISSUES.md'),
+    });
+    expect(useCase.execute).toHaveBeenCalledWith({
+      owner: 'shep-ai',
+      repo: 'other',
+      docPath: path.join('/workspace/other', 'GOOD_FIRST_ISSUES.md'),
+    });
+    watcher.stop();
+  });
+
+  it('continues after a per-repo regeneration failure', async () => {
+    const repoRepo = makeMockRepositoryRepo([
+      makeRepoRow({ id: 'r1', remoteUrl: 'https://github.com/a/x' }),
+      makeRepoRow({ id: 'r2', remoteUrl: 'https://github.com/b/y' }),
+    ]);
+    const ghService = makeMockGitHubService();
+    const useCase = makeMockUseCase();
+    vi.mocked(useCase.execute)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ status: 'unchanged', issueCount: 0 });
+
+    const watcher = new GoodFirstIssuesDocWatcherService(
+      useCase,
+      repoRepo,
+      ghService,
+      WORKSPACE_ROOT,
+      1000
+    );
+    watcher.start();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(useCase.execute).toHaveBeenCalledTimes(2);
+    watcher.stop();
+  });
+
+  it('polls again on the configured interval', async () => {
+    const repoRepo = makeMockRepositoryRepo([makeRepoRow({ remoteUrl: 'https://github.com/a/x' })]);
+    const watcher = new GoodFirstIssuesDocWatcherService(
+      makeMockUseCase(),
+      repoRepo,
+      makeMockGitHubService(),
+      WORKSPACE_ROOT,
+      1000
+    );
+    watcher.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(repoRepo.list).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(repoRepo.list).toHaveBeenCalledTimes(2);
+    watcher.stop();
+  });
+});
+
+describe('Good-first-issues doc watcher singleton', () => {
+  afterEach(() => {
+    resetGoodFirstIssuesDocWatcher();
+  });
+
+  it('is uninitialized initially', () => {
+    expect(hasGoodFirstIssuesDocWatcher()).toBe(false);
+  });
+
+  it('initializes once', () => {
+    initializeGoodFirstIssuesDocWatcher(
+      makeMockUseCase(),
+      makeMockRepositoryRepo([]),
+      makeMockGitHubService(),
+      WORKSPACE_ROOT
+    );
+    expect(hasGoodFirstIssuesDocWatcher()).toBe(true);
+    expect(getGoodFirstIssuesDocWatcher()).toBeInstanceOf(GoodFirstIssuesDocWatcherService);
+  });
+
+  it('throws on double init', () => {
+    initializeGoodFirstIssuesDocWatcher(
+      makeMockUseCase(),
+      makeMockRepositoryRepo([]),
+      makeMockGitHubService(),
+      WORKSPACE_ROOT
+    );
+    expect(() =>
+      initializeGoodFirstIssuesDocWatcher(
+        makeMockUseCase(),
+        makeMockRepositoryRepo([]),
+        makeMockGitHubService(),
+        WORKSPACE_ROOT
+      )
+    ).toThrow(/already initialized/);
+  });
+});

--- a/tests/unit/presentation/cli/commands/ui.command.test.ts
+++ b/tests/unit/presentation/cli/commands/ui.command.test.ts
@@ -118,9 +118,22 @@ vi.mock('@/infrastructure/services/contributors/monthly-recap-watcher.service.js
     stop: vi.fn(),
   }),
 }));
+vi.mock('@/infrastructure/services/contributors/good-first-issues-doc-watcher.service.js', () => ({
+  initializeGoodFirstIssuesDocWatcher: vi.fn(),
+  getGoodFirstIssuesDocWatcher: vi.fn().mockReturnValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
 vi.mock('@/application/use-cases/contributors/detect-stale-good-first-issue.use-case.js', () => ({
   DetectStaleGoodFirstIssueUseCase: vi.fn(),
 }));
+vi.mock(
+  '@/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.js',
+  () => ({
+    RegenerateGoodFirstIssuesDocUseCase: vi.fn(),
+  })
+);
 vi.mock('@/application/use-cases/contributors/generate-monthly-recap.use-case.js', () => ({
   GenerateMonthlyRecapUseCase: vi.fn(),
 }));


### PR DESCRIPTION
Closes #625

## Summary
- add a supervisor-gated RegenerateGoodFirstIssuesDocUseCase that queries open GitHub issues by good first issue + lane + difficulty labels and rewrites only the generated GOOD_FIRST_ISSUES.md bucket region
- add a daily GoodFirstIssuesDocWatcher wired into ui, _serve, and dev-server startup/shutdown; each repository regenerates its own checked-out GOOD_FIRST_ISSUES.md path
- extend filesystem and issue-fetcher ports for text-file reads/writes and multi-label open issue listing, with tests for the use case, watcher, and startup mocks

## Verification
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run tests/unit/application/use-cases/contributors/regenerate-good-first-issues-doc.use-case.test.ts tests/unit/infrastructure/services/contributors/good-first-issues-doc-watcher.service.test.ts
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm typecheck
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm lint
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm test:unit
- PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm test:int
- git diff --check