### PR TITLE
ci(agents): add daily good-first-issue generator workflow

### DIFF
--- a/.github/workflows/generate-good-first-issues.yml
+++ b/.github/workflows/generate-good-first-issues.yml
@@ -1,0 +1,158 @@
+name: Generate good-first-issues (daily)
+
+# Runs an agent that scans the codebase + current AI trends and opens
+# up to 10 NEW good-first-issues per day in shep-ai/shep.
+#
+# What it does:
+#   1. Checks out the repo (shallow — agent only needs to read)
+#   2. Ensures the `ai-generated` label exists (idempotent)
+#   3. Runs Claude Code with a thin delegation prompt that reads
+#      prompts/generate-good-first-issues.md and follows it
+#      (web-fetch ai-tldr trends, grep the codebase, gh issue create
+#      with dedup against existing labeled issues)
+#   4. Writes a markdown summary of opened issues to the run's
+#      Step Summary
+#
+# The agent does NOT commit or push — its only side effect is opening
+# GitHub issues via `gh issue create`.
+#
+# Required secrets:
+#   CLAUDE_CODE_OAUTH_TOKEN — generate locally with `claude setup-token`
+#                              then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`
+#   GITHUB_TOKEN            — auto-provided by Actions; `issues: write`
+#                              permission below grants issue-create rights
+
+on:
+  schedule:
+    # Daily at 13:05 UTC (09:05 ET / 14:05 CET / 15:05 IST).
+    # Picked to run AFTER ai-tldr's 12:00 UTC sweep so the trends
+    # file we curl is fresh (ai-tldr runs every 2h at minute 0).
+    - cron: '5 13 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  # Required to open issues via `gh issue create`.
+  issues: write
+  # Required by anthropics/claude-code-action@v1 — it fetches an
+  # OIDC token from GitHub during setup. Without it the action fails
+  # before Claude even starts: "Could not fetch an OIDC token."
+  id-token: write
+
+concurrency:
+  group: generate-good-first-issues
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    # Sized for one ~25m agent run + a few minutes of setup. No
+    # retry pattern here — if the agent fails, the daily cron just
+    # tries again tomorrow. (Unlike ai-tldr's release sweep, missing
+    # a day of issue generation is not a data-loss event.)
+    timeout-minutes: 35
+
+    env:
+      # gh CLI picks up GH_TOKEN automatically. The job-level
+      # permissions block above grants issues:write to this token.
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Shallow is fine — the agent only needs to Read / Grep
+          # source files at HEAD. No git history required.
+          fetch-depth: 1
+
+      - name: Capture current date
+        id: now
+        run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure ai-generated label exists
+        # Idempotent: `gh label create` errors if the label already
+        # exists, so we swallow the error. The `good first issue`
+        # label is repo-default; the other labels (`lane:*`,
+        # `difficulty:*`, `area:*`) already exist in this repo.
+        run: |
+          gh label create "ai-generated" \
+            --description "Opened by an automated agent — review before assigning" \
+            --color "ededed" \
+            --repo "${GITHUB_REPOSITORY}" 2>/dev/null || true
+          gh label list --repo "${GITHUB_REPOSITORY}" --limit 200 \
+            | grep -E "^(ai-generated|good first issue|lane:|difficulty:)" || true
+
+      - name: Run good-first-issue generator with Claude Code
+        id: generate
+        uses: anthropics/claude-code-action@v1
+        # Step-level timeout: if the action hangs silently we want
+        # to fail THIS step cleanly. 30m gives healthy runs plenty
+        # of headroom (target p100 ~20m for a 10-issue batch).
+        timeout-minutes: 30
+        env:
+          # Pass the token explicitly to the action's shell so the
+          # `gh` calls the agent makes can authenticate. The
+          # permissions block grants issues:write to this token.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Stream Claude's progress into the GH Actions log instead
+          # of buffering until the run ends. display_report posts a
+          # Step Summary at the end.
+          show_full_output: 'true'
+          display_report: 'true'
+          # The real prompt is `prompts/generate-good-first-issues.md`
+          # — Claude reads it via its Read tool. Keep this shim
+          # minimal: anything added here drifts from the canonical
+          # prompt and creates a second source of truth.
+          prompt: |
+            You are the shep good-first-issue generator running in
+            GitHub Actions. Working dir is the repo root. The repo
+            is `shep-ai/shep`.
+
+            TODAY'S DATE IS ${{ steps.now.outputs.date }} (real UTC,
+            not a fixture). Trust the system clock and what
+            WebFetch / curl return even if releases look unfamiliar
+            — your training data predates today.
+
+            Read `prompts/generate-good-first-issues.md` and follow
+            it exactly. Open issues via `gh issue create`. Do NOT
+            commit or push — this workflow does not commit anything.
+
+            Before opening each issue, you MUST have:
+              1. Read the cited file paths (no hallucinated paths).
+              2. Compared the candidate against both dedup lists
+                 (/tmp/existing-gfi.json and /tmp/existing-ai-generated.json).
+              3. Verified the trend hook is real (sourced from
+                 /tmp/ai-trends.json or an external page you fetched
+                 in this run).
+
+            ZERO ISSUES IS A SUCCESSFUL RUN. If no candidates clear
+            the inclusion bar, write a one-line "no candidates today"
+            note to $GITHUB_STEP_SUMMARY and exit cleanly. Padding
+            to hit 10 is the bug.
+
+            On success, append a markdown table to
+            $GITHUB_STEP_SUMMARY with one row per opened issue:
+            number, title, lane, difficulty, trend hook.
+          claude_args: |
+            --model claude-opus-4-7
+            --verbose
+            --max-turns 6000
+            --permission-mode acceptEdits
+            --allowedTools "WebSearch,WebFetch,Read,Glob,Grep,Bash(gh issue:*),Bash(gh label list:*),Bash(gh search:*),Bash(curl:*),Bash(jq:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(rm:*)"
+
+      - name: Final summary
+        # Always runs (success or fail) so the run page surfaces
+        # what happened even if the agent step errored.
+        if: always()
+        run: |
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "_Run date: ${{ steps.now.outputs.date }}_"
+            echo "_Workflow: \`.github/workflows/generate-good-first-issues.yml\`_"
+            echo "_Canonical prompt: \`prompts/generate-good-first-issues.md\`_"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/prompts/generate-good-first-issues.md
+++ b/prompts/generate-good-first-issues.md
@@ -1,0 +1,296 @@
+---
+prompt-id: shep.generate-good-first-issues
+prompt-version: 1.0.0
+output-target: github issues in shep-ai/shep (labels: good first issue + ai-generated + lane:* + difficulty:*)
+invoke-as: subagent
+---
+
+# Shep — Good-First-Issue Generator
+
+Single source of truth for the daily good-first-issue agent. Invoked
+on cron (once a day) and manually. The agent's output is N new GitHub
+issues opened in `shep-ai/shep` via `gh issue create`.
+
+## Mission
+
+Surface up to **10 NEW good-first-issues per run** that:
+
+1. Are genuinely implementable in the shep codebase (reference real
+   files / features / surfaces that exist today).
+2. Are inspired by what's happening in AI right now — new model
+   releases, what other coding agents (Cursor, Claude Code, Aider,
+   Cline, OpenCode, Codex, Windsurf, Continue, Codium) just shipped,
+   patterns trending on HN / r/LocalLLaMA / HuggingFace.
+3. Are small enough for a newcomer to land in a few hours.
+
+**Empty run is a successful run.** If nothing today clears the
+inclusion bar, ship zero. Padding to hit 10 is the bug — three
+iterations of that pattern killed ai-tldr's data quality. Do not
+repeat it here.
+
+## The pipeline (one canonical path)
+
+You do NOT edit files in the repo. You read the codebase + external
+trends, then open issues via `gh`. That's it.
+
+1. **Briefing — load context.** Read in this order:
+   - `CLAUDE.md` (project rules + mandatory practices)
+   - `LESSONS.md` (hard-won lessons — never repeat these)
+   - `docs/architecture/overview.md` (layer model)
+   - `docs/cli/architecture.md`, `docs/ui/architecture.md`,
+     `docs/tui/architecture.md` (presentation surfaces)
+   - `docs/architecture/agent-system.md` (agent plumbing)
+
+2. **Dedup briefing — load the no-create list.** Run:
+   ```bash
+   gh issue list --repo shep-ai/shep --state all \
+     --label "good first issue" --limit 200 \
+     --json number,title,state,labels,body > /tmp/existing-gfi.json
+   gh issue list --repo shep-ai/shep --state all \
+     --label "ai-generated" --limit 200 \
+     --json number,title,state,labels > /tmp/existing-ai-generated.json
+   ```
+   These two lists are your dedup corpus. Read both before drafting
+   anything. **Every candidate you consider MUST be compared
+   semantically against both lists.**
+
+3. **Trend briefing — load what shipped this week in AI.** Fetch:
+   ```bash
+   curl -fsSL \
+     https://raw.githubusercontent.com/blackpc/ai-tldr/master/src/data/releases.json \
+     > /tmp/ai-trends.json
+   ```
+   Read the top 30 items (most recent first). Note categories,
+   tags, and orgs. These are not issues to file — they are
+   **inspiration vectors**. For each notable item, ask: "Does this
+   suggest a missing affordance, doc, story, or test in shep?"
+
+4. **Codebase scan — find real gaps.** Use Grep / Glob to find
+   concrete, addressable surface area. Examples of *grounded* signals:
+   - `TODO` / `FIXME` / `XXX` comments older than 30 days
+   - Web components in `src/presentation/web/components/` without a
+     colocated `.stories.tsx` (mandatory rule — see CLAUDE.md)
+   - Public exported functions/classes in `application/use-cases/`
+     missing JSDoc
+   - CLI commands in `src/presentation/cli/commands/` whose `--help`
+     output has no example block
+   - Broken relative links in `docs/**/*.md`
+   - Tests skipped via `it.skip` / `xit` / `test.skip` with no
+     tracking issue linked
+   - Adapters in `infrastructure/` referencing AI providers that
+     trail current model availability (e.g., hardcoded model IDs
+     that are now superseded — cross-reference against the trends
+     file)
+
+5. **Synthesize candidates.** For each candidate, draft a
+   `[Good First Issue]: <imperative phrase>` title and a body
+   following the schema below. Cite REAL file paths with line
+   numbers. If you cannot cite a real file, the candidate is
+   ungrounded — drop it.
+
+6. **Apply the inclusion bar** (next section) to each candidate.
+   Reject anything that does not pass.
+
+7. **Apply semantic dedup** against `/tmp/existing-gfi.json` and
+   `/tmp/existing-ai-generated.json`. Reject anything that overlaps
+   with an existing issue's intent — even if the wording is
+   different. Closed + reopened both count.
+
+8. **Cap at 10.** If more than 10 pass, keep the 10 strongest. If
+   fewer than 10 pass, ship what you have. **Zero is fine.**
+
+9. **Open issues.** For each surviving candidate, run:
+   ```bash
+   gh issue create --repo shep-ai/shep \
+     --title "[Good First Issue]: <phrase>" \
+     --body-file /tmp/issue-N.md \
+     --label "good first issue" \
+     --label "ai-generated" \
+     --label "lane:<lane>" \
+     --label "difficulty:<difficulty>" \
+     --label "area: <area>"   # optional, only if it cleanly maps
+   ```
+   Where:
+   - `<lane>` ∈ { `docs`, `agents`, `ui`, `cli`, `infra` }
+   - `<difficulty>` ∈ { `goodFirst`, `easy` } — **never** `medium`
+     or `hard` on this workflow
+   - `<area>` ∈ { `cli`, `dashboard`, `agents`, `plugins`, `docs` }
+
+10. **Write a step summary.** Append a markdown table to
+    `$GITHUB_STEP_SUMMARY` listing the issues opened (number, title,
+    trend hook). On a zero-issue run, write a one-line "no
+    candidates cleared the bar today" note.
+
+11. Stop. You do not commit, push, or modify files in the repo.
+
+## Hard rules (non-negotiable)
+
+### 1. Zero hallucination
+
+Every file path, line number, function name, and API surface you
+cite MUST exist in the repo at HEAD. Working from memory is
+forbidden — Read or Grep first. If you cannot cite a real file, the
+candidate is ungrounded. Drop it.
+
+### 2. Semantic dedup is YOUR job
+
+`gh issue create` will happily open an issue that duplicates one
+opened yesterday with different wording. The CLI cannot catch that.
+
+For every candidate, scan both dedup lists and ask: "Does any
+existing issue (open OR closed) cover the SAME work — same files,
+same affordance, same fix?" If yes, drop the candidate. Reopening
+a closed issue's intent is dedup-violating.
+
+### 3. No padding
+
+If only 4 candidates clear the bar, ship 4. If only 0 clear the
+bar, ship 0. Do not add an "okay-ish" issue to round out the
+batch. Do not generate a generic "add more tests" or "improve
+docs" filler.
+
+### 4. Difficulty cap
+
+Every issue MUST be reachable for a newcomer in a few hours of
+work. If a candidate would require design judgement, multi-file
+refactor, architectural changes, or domain understanding beyond
+reading a few docs — drop it. Use `difficulty:goodFirst` for the
+smallest tier (single file, mechanical), `difficulty:easy` for
+self-contained work spanning a couple files.
+
+### 5. Forbidden topics
+
+Never generate issues for:
+
+- Anything in `packages/core/src/domain/generated/` (auto-generated
+  from TypeSpec — edits go in `tsp/` and require codegen, which is
+  NOT a good first issue).
+- Anything requiring schema migrations or DB changes.
+- Anything touching billing, auth, or security boundaries.
+- Anything requiring an API key for an external service.
+- Style-only changes to `LESSONS.md`, `CLAUDE.md`, or
+  `.claude/rules/*.md`.
+- Renaming public APIs, CLI commands, or use-case names.
+
+## Inclusion bar
+
+Ship a candidate only if ALL are true:
+
+1. Cites at least one real file path (verified via Read or Grep).
+2. Does not collide semantically with anything in the dedup lists.
+3. Has a clear acceptance checklist a newcomer can self-verify.
+4. Is reachable in `difficulty:goodFirst` or `difficulty:easy`.
+5. Has a plausible trend hook — you can name an AI-ecosystem trend
+   (from `/tmp/ai-trends.json` or external context) that motivates
+   the change. The hook can be subtle (e.g., "MCP adoption is
+   trending → shep's MCP-adjacent docs need an example") but it
+   must be real, not invented.
+6. You would assign this to a first-time contributor and feel
+   confident they could land it.
+
+## Sources to scan for trends (in addition to ai-tldr/releases.json)
+
+Use these sparingly — the ai-tldr feed is already pre-curated.
+Reach for these only when looking for a specific signal:
+
+- `https://github.com/trending?since=daily&language=` (filter to
+  AI / dev-tool repos)
+- `https://github.com/anthropics/claude-code/releases`
+- `https://github.com/cline/cline/releases`
+- `https://github.com/sourcegraph/amp/releases` (or similar agent CLIs)
+- `https://huggingface.co/papers` (top trending)
+- HN front page (Show HN: AI / coding agent posts in last 48h)
+
+## Issue body schema
+
+Every opened issue MUST follow this body template:
+
+```markdown
+## What
+
+<one-paragraph description of the change. Imperative voice.>
+
+## Why
+
+<one-paragraph motivation. Reference the trend hook here — what's
+happening in AI that makes this worth doing now. Keep it grounded:
+don't invent hype.>
+
+## Where
+
+<bulleted list of REAL files this issue touches, with line numbers
+where applicable. Each entry uses a clickable markdown link.>
+
+- `src/path/to/file.ts:42` — <what's there today>
+- `src/path/to/other.ts` — <what to add>
+
+## Acceptance criteria
+
+- [ ] <concrete check 1>
+- [ ] <concrete check 2>
+- [ ] <concrete check 3>
+- [ ] `pnpm validate` passes
+- [ ] (if UI) colocated `.stories.tsx` updated/added
+- [ ] (if logic) RED→GREEN tests in place per `docs/development/tdd-guide.md`
+
+## Hints for a first-time contributor
+
+<1-3 short tips: which doc to read first, which existing file is a
+template, which `pnpm` command to run locally>
+
+## Trend hook
+
+> <one sentence quoting the AI-ecosystem trend that motivated this
+> issue, with a link to the source if you have one>
+
+---
+
+_Auto-generated by `.github/workflows/generate-good-first-issues.yml`
+on <UTC date>. Reply with `@claude` if anything is unclear — a
+maintainer will review._
+```
+
+## Title rules
+
+- Prefix EXACTLY `[Good First Issue]: ` (matches existing
+  convention — see issues #615–#625).
+- After the prefix: imperative phrase, lowercase except for proper
+  nouns and acronyms. No trailing period.
+- Total length ≤ 100 characters.
+- Examples that match style:
+  - `[Good First Issue]: add Storybook stories for 5 shadcn UI primitives`
+  - `[Good First Issue]: fix 5 broken docs links from docs/README.md and ARCHITECTURE.md`
+  - `[Good First Issue]: add --help example blocks to 6 user-facing CLI commands`
+
+## Label rules
+
+Always apply:
+
+- `good first issue`
+- `ai-generated`
+- one of `lane:agents` / `lane:docs` / `lane:ui` / `lane:cli` / `lane:infra`
+- one of `difficulty:goodFirst` / `difficulty:easy`
+
+Apply when applicable:
+
+- `area: cli` / `area: dashboard` / `area: agents` / `area: plugins` / `area: docs`
+- `type: docs` / `type: feature` / `type: bug`
+
+Never apply on this workflow:
+
+- `priority: *` — let triage decide
+- `breaking-change`, `needs-design` — these disqualify "good first"
+- `difficulty:medium`, `difficulty:medium`, anything heavier than `easy`
+
+## Self-check before opening each issue
+
+Ask yourself, for each candidate, before running `gh issue create`:
+
+1. Did I Read or Grep every file I cite? (If no → drop.)
+2. Did I check both dedup lists for semantic overlap? (If no → check now.)
+3. Could a first-time contributor land this in an afternoon? (If no → drop.)
+4. Is the trend hook real, not invented? (If invented → drop.)
+5. Does the title match `[Good First Issue]: <lowercase imperative>`?
+6. Are the labels correct and within the allowed set?
+
+If any answer is no, fix or drop before running the `gh` command.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/generate-good-first-issues.yml` — a daily cron (13:05 UTC) that runs `claude-code-action@v1` and opens up to 10 new `good first issue`s in this repo.
- Adds `prompts/generate-good-first-issues.md` — the canonical agent spec. The workflow is a thin shim; the prompt is the source of truth (mirrors the `ai-tldr/prompts/update-releases.md` + `ai-tldr/.github/workflows/update-releases.yml` split).
- Agent is grounded in the shep codebase (must Read/Grep real file paths before citing them) and inspired by current AI trends pulled from `blackpc/ai-tldr/src/data/releases.json`.

## How dedup works

The agent loads two lists at start of every run via `gh issue list`:
1. All `good first issue`s, state: all (open + closed)
2. All `ai-generated`d issues, state: all

It then semantically compares every candidate against both before any `gh issue create` fires. Reopening a closed issue's intent counts as a duplicate violation.

## Quality bars encoded in the prompt

- **Zero hallucination** — every cited file path must be Read first.
- **Zero is a valid outcome** — if no candidates clear the inclusion bar, the run ships nothing. Padding to hit 10 is explicitly the bug (the rule that broke ai-tldr's sweep three times — referenced in the prompt).
- **Difficulty capped** at `goodFirst` / `easy`; never `medium` / `hard`.
- **Forbidden topics** — generated code, migrations, auth/billing, public API renames are all explicitly disqualified.

## Permissions & secrets

- `contents: read`, `issues: write`, `id-token: write` — minimal viable surface for the agent.
- Tool allowlist restricts the agent to `WebSearch,WebFetch,Read,Glob,Grep,Bash(gh issue:*),Bash(gh label list:*),Bash(gh search:*),Bash(curl:*),Bash(jq:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(rm:*)`. It cannot push code, edit files, or run unbounded shell.
- Required secret `CLAUDE_CODE_OAUTH_TOKEN` is already configured for `claude.yml` and `agent-request.yml`.
- Pre-step creates the `ai-generated` label idempotently (other labels already exist in this repo).

## Test plan

- [ ] Merge PR
- [ ] Trigger manually: `gh workflow run generate-good-first-issues.yml`
- [ ] Confirm the run completes within ~25m and either opens issues labeled `good first issue` + `ai-generated` OR writes a "no candidates today" summary
- [ ] Spot-check 2-3 opened issues: file paths cited actually exist, no semantic overlap with existing `#615`–`#625`, trend hook is real
- [ ] Let the daily cron run once; verify dedup works (second run does not re-open yesterday's candidates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)