### PR TITLE
fix(ci): install npm 11 in release job for oidc trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,15 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
+
+      # @semantic-release/npm v13 uses npm's OIDC trusted publishing when
+      # `id-token: write` is granted. Node 22 ships npm 10.9.x, which predates
+      # trusted publishing — the plugin's verifyConditions OIDC exchange
+      # succeeds, but `npm publish` then fails with ENEEDAUTH because npm 10
+      # can't use the OIDC token. Trusted publishing requires npm >= 11.5.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5
+
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build:release
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,5 +1,18 @@
 # Lessons Learned
 
+## npm trusted publishing requires npm >= 11.5 on the runner
+
+`@semantic-release/npm` v13 added OIDC trusted publishing. In `lib/verify-auth.js`, when the OIDC token exchange with npmjs.com succeeds, the plugin **early-returns and does NOT write `NPM_TOKEN` to the userconfig `.npmrc`**. It then runs plain `npm publish` and relies on the **npm CLI itself** to do trusted publishing — which needs **npm >= 11.5.0**.
+
+Node 22 ships npm 10.9.x, so the Release job logged "OIDC token exchange with the npm registry succeeded" in verifyConditions and then died at publish with `npm error code ENEEDAUTH`. Two versions (`v1.205.1`, `v1.206.0`) got tagged + the release commit got pushed to main but never made it to npm, because semantic-release succeeded with the tag/push plugins before failing on `@semantic-release/npm`.
+
+Rules:
+
+1. When using `@semantic-release/npm` v13+ with `permissions: id-token: write`, the Release job MUST install npm >= 11.5 before invoking semantic-release. Add `npm install -g npm@^11.5` between setup-node and `npx semantic-release`.
+2. Keep `NPM_TOKEN` in the env as a fallback — the plugin uses it only when OIDC isn't available, but you want belt-and-suspenders in case npmjs trusted-publisher config gets removed.
+3. After a Release job failure, ALWAYS verify with `npm view <pkg> dist-tags` that the version actually landed. A "successful" re-run of a failed release is usually a no-op ("local branch main is behind the remote") and silently leaves the version missing from npm — the tag exists, the chore(release) commit exists, but the package is gone.
+4. A passing OIDC token exchange in verifyConditions only proves the package is configured as a trusted publisher on npmjs.com — it does NOT prove the runner can actually publish. Treat the runner's npm version as a separate, mandatory check.
+
 ## Tool install commands must bootstrap their own package manager
 
 The `project-bedrock.json` tool definition shipped with `pipx install project-bedrock` on every platform, assuming pipx was already present. It often isn't (fresh macOS, fresh Linux dev box), and the install failed silently from the user's perspective — they saw `command not found: pipx` and reported "the tools install is broken." Two follow-on traps appeared while fixing it:


### PR DESCRIPTION
## Summary

- Release job has been silently failing on `npm publish` with `ENEEDAUTH` for the last two releases — `v1.205.1` and `v1.206.0` are tagged on `main` but never made it to npm (`npm view @shepai/cli dist-tags` → `latest: 1.205.0`).
- Root cause: `@semantic-release/npm@13.1.3`'s [`lib/verify-auth.js`](https://github.com/semantic-release/npm/blob/v13.1.3/lib/verify-auth.js#L73-L82) does an OIDC short-circuit — when the OIDC token exchange with the npm registry succeeds, the plugin **does NOT write `NPM_TOKEN` to the userconfig `.npmrc`**. It then runs plain `npm publish --userconfig <empty-ish .npmrc>` and relies on **the npm CLI itself** to do trusted publishing. That requires **npm >= 11.5.0**.
- Node 22 ships **npm 10.9.x**, which predates trusted publishing. So verifyConditions logs `OIDC token exchange with the npm registry succeeded`, and 20 seconds later publish dies with `npm error code ENEEDAUTH`.

This PR installs `npm@^11.5` in the Release job between `setup-node` and `npx semantic-release`. Trusted publishing then works at publish time (and we get provenance attestations for free).

`NPM_TOKEN` stays in `env:` as a fallback in case OIDC ever stops working on the npmjs.com side.

## Out of scope (worth a follow-up)

`v1.205.1` and `v1.206.0` are missing from npm. After this PR merges, the next push to `main` will publish `v1.206.1` (or whatever the next bump is) from a working pipeline. If you want `1.206.0` published from the existing tag, that has to be done manually (semantic-release won't re-attempt past tags).

## Test plan

- [ ] CI green on this PR (release/dev-release skipped by `if` conditions — won't fire here).
- [ ] After merging to `main`, the Release job runs, logs `OIDC token exchange ... succeeded`, runs `npm publish`, and `npm view @shepai/cli dist-tags` shows the new `latest`.
- [ ] If it still fails: the npmjs.com trusted-publisher config for `@shepai/cli` may need re-verification (must point to `shep-ai/shep` repo, `ci.yml` workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)