### PR TITLE
docs(cli): add agent subcommand help examples

### DIFF
--- a/src/presentation/cli/commands/agent/approve.command.ts
+++ b/src/presentation/cli/commands/agent/approve.command.ts
@@ -19,6 +19,13 @@ export function createApproveCommand(): Command {
   return new Command('approve')
     .description(t('cli:commands.agent.approve.description'))
     .argument('<id>', t('cli:commands.agent.approve.idArgument'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent approve <id>       Approve a paused agent run
+  $ shep agent approve a1b2c3d4   Resume a run waiting for approval`
+    )
     .action(async (id: string) => {
       try {
         const resolved = await resolveAgentRun(id);

--- a/src/presentation/cli/commands/agent/delete.command.ts
+++ b/src/presentation/cli/commands/agent/delete.command.ts
@@ -20,6 +20,13 @@ export function createDeleteCommand(): Command {
     .description(t('cli:commands.agent.delete.description'))
     .argument('<id>', t('cli:commands.agent.delete.idArgument'))
     .option('--force', t('cli:commands.agent.delete.forceOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent delete <id>         Delete a completed agent run
+  $ shep agent delete --force <id> Stop and delete a running agent run`
+    )
     .action(async (id: string, opts: { force?: boolean }) => {
       try {
         const resolved = await resolveAgentRun(id);

--- a/src/presentation/cli/commands/agent/logs.command.ts
+++ b/src/presentation/cli/commands/agent/logs.command.ts
@@ -24,6 +24,14 @@ export function createLogsCommand(): Command {
     .argument('<id>', t('cli:commands.agent.logs.idArgument'))
     .option('-f, --follow', t('cli:commands.agent.logs.followOption'))
     .option('-n, --lines <count>', t('cli:commands.agent.logs.linesOption'), '0')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent logs <id>       Print the full log for a run
+  $ shep agent logs -f <id>    Follow log output as it is written
+  $ shep agent logs -n 50 <id> Show the last 50 log lines`
+    )
     .action(async (id: string, opts: { follow?: boolean; lines: string }) => {
       try {
         const resolved = await resolveAgentRun(id);

--- a/src/presentation/cli/commands/agent/ls.command.ts
+++ b/src/presentation/cli/commands/agent/ls.command.ts
@@ -26,42 +26,51 @@ function isProcessAlive(pid: number): boolean {
 
 export function createLsCommand(): Command {
   const t = getCliI18n().t;
-  return new Command('ls').description(t('cli:commands.agent.ls.description')).action(async () => {
-    try {
-      const useCase = container.resolve(ListAgentRunsUseCase);
-      const agentRuns = await useCase.execute();
+  return new Command('ls')
+    .description(t('cli:commands.agent.ls.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent ls              List all agent runs
+  $ shep agent show a1b2c3d4   Use a listed run ID to inspect details`
+    )
+    .action(async () => {
+      try {
+        const useCase = container.resolve(ListAgentRunsUseCase);
+        const agentRuns = await useCase.execute();
 
-      const rows = agentRuns.map((run) => {
-        const liveness = getLiveness(run);
-        return [
-          run.id.substring(0, 8),
-          run.agentName,
-          liveness.displayStatus,
-          getDuration(run),
-          run.pid ? String(run.pid) : colors.muted('-'),
-          liveness.warning || '',
-        ];
-      });
+        const rows = agentRuns.map((run) => {
+          const liveness = getLiveness(run);
+          return [
+            run.id.substring(0, 8),
+            run.agentName,
+            liveness.displayStatus,
+            getDuration(run),
+            run.pid ? String(run.pid) : colors.muted('-'),
+            liveness.warning || '',
+          ];
+        });
 
-      renderListView({
-        title: t('cli:commands.agent.ls.title'),
-        columns: [
-          { label: t('cli:commands.agent.ls.idColumn'), width: 10 },
-          { label: t('cli:commands.agent.ls.agentColumn'), width: 18 },
-          { label: t('cli:commands.agent.ls.statusColumn'), width: 16 },
-          { label: t('cli:commands.agent.ls.durationColumn'), width: 10 },
-          { label: t('cli:commands.agent.ls.pidColumn'), width: 8 },
-          { label: t('cli:commands.agent.ls.warningColumn'), width: 20 },
-        ],
-        rows,
-        emptyMessage: t('cli:commands.agent.ls.noRuns'),
-      });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      messages.error(t('cli:commands.agent.ls.failedToList'), err);
-      process.exitCode = 1;
-    }
-  });
+        renderListView({
+          title: t('cli:commands.agent.ls.title'),
+          columns: [
+            { label: t('cli:commands.agent.ls.idColumn'), width: 10 },
+            { label: t('cli:commands.agent.ls.agentColumn'), width: 18 },
+            { label: t('cli:commands.agent.ls.statusColumn'), width: 16 },
+            { label: t('cli:commands.agent.ls.durationColumn'), width: 10 },
+            { label: t('cli:commands.agent.ls.pidColumn'), width: 8 },
+            { label: t('cli:commands.agent.ls.warningColumn'), width: 20 },
+          ],
+          rows,
+          emptyMessage: t('cli:commands.agent.ls.noRuns'),
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        messages.error(t('cli:commands.agent.ls.failedToList'), err);
+        process.exitCode = 1;
+      }
+    });
 }
 
 function getLiveness(run: AgentRun): { displayStatus: string; warning: string } {

--- a/src/presentation/cli/commands/agent/reject.command.ts
+++ b/src/presentation/cli/commands/agent/reject.command.ts
@@ -20,6 +20,13 @@ export function createRejectCommand(): Command {
     .description(t('cli:commands.agent.reject.description'))
     .argument('<id>', t('cli:commands.agent.reject.idArgument'))
     .option('-r, --reason <text>', t('cli:commands.agent.reject.reasonOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent reject <id>                 Reject a paused agent run
+  $ shep agent reject <id> -r "Needs fix"  Reject with a short reason`
+    )
     .action(async (id: string, opts: { reason?: string }) => {
       try {
         const resolved = await resolveAgentRun(id);

--- a/src/presentation/cli/commands/agent/show.command.ts
+++ b/src/presentation/cli/commands/agent/show.command.ts
@@ -31,6 +31,13 @@ export function createShowCommand(): Command {
   return new Command('show')
     .description(t('cli:commands.agent.show.description'))
     .argument('<id>', t('cli:commands.agent.show.idArgument'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent show <id>       Show details for an agent run
+  $ shep agent show a1b2c3d4   Inspect a run by short ID`
+    )
     .action(async (id: string) => {
       try {
         const resolved = await resolveAgentRun(id);

--- a/src/presentation/cli/commands/agent/stop.command.ts
+++ b/src/presentation/cli/commands/agent/stop.command.ts
@@ -19,6 +19,13 @@ export function createStopCommand(): Command {
   return new Command('stop')
     .description(t('cli:commands.agent.stop.description'))
     .argument('<id>', t('cli:commands.agent.stop.idArgument'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent stop <id>       Stop a running agent
+  $ shep agent stop a1b2c3d4   Interrupt a run by short ID`
+    )
     .action(async (id: string) => {
       try {
         const resolved = await resolveAgentRun(id);


### PR DESCRIPTION
## Problem

Fixes #639. The `shep agent` subcommands exposed descriptions and flags, but did not include copy-pasteable examples like the existing `shep ui` command.

## Solution

Added inline `Examples:` blocks via Commander `.addHelpText('after', ...)` for all seven requested subcommands:

- `shep agent ls`
- `shep agent show`
- `shep agent stop`
- `shep agent logs`
- `shep agent delete`
- `shep agent approve`
- `shep agent reject`

The examples use placeholders or short fake IDs only, and no translation keys were added, matching the `ui.command.ts` precedent called out in the issue.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --write src/presentation/cli/commands/agent/{ls,show,stop,logs,delete,approve,reject}.command.ts`
- `git diff --check`
- `pnpm exec eslint src/presentation/cli/commands/agent/{ls,show,stop,logs,delete,approve,reject}.command.ts --max-warnings 0`
- `pnpm dev:cli agent {ls,show,stop,logs,delete,approve,reject} --help` (confirmed each command prints the new `Examples:` block)
- Commit hook/lint-staged ran `eslint --fix`, `prettier --write`, and `pnpm run typecheck` successfully for the staged TypeScript files

## Confidence

Score: 86/100 (docs/CLI help text). The change is issue-backed, follows the referenced existing pattern, is limited to command help output, and was validated with targeted help invocations plus lint/typecheck hooks.
