### PR TITLE
feat(cli): add --help example blocks to 10 shep app subcommands

### DIFF
--- a/src/presentation/cli/commands/app/cloud-providers/connect.command.ts
+++ b/src/presentation/cli/commands/app/cloud-providers/connect.command.ts
@@ -31,6 +31,13 @@ export function createCloudProvidersConnectCommand(): Command {
     .description('Connect a cloud deployment provider with an API token')
     .argument('<provider>', 'Provider id (e.g. CloudflarePages)')
     .option('--token <token>', 'API token (if omitted, prompts securely)')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app cloud-providers connect CloudflarePages
+  $ shep app cloud-providers connect CloudflarePages --token <api-token>`
+    )
     .action(async (providerArg: string, options: { token?: string }) => {
       try {
         const provider = parseProvider(providerArg);

--- a/src/presentation/cli/commands/app/cloud-providers/github-login.command.ts
+++ b/src/presentation/cli/commands/app/cloud-providers/github-login.command.ts
@@ -22,6 +22,12 @@ function sleep(ms: number): Promise<void> {
 export function createGithubLoginCommand(): Command {
   return new Command('github-login')
     .description('Run `gh auth login --web` and wait for authentication to complete')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app cloud-providers github-login`
+    )
     .action(async () => {
       try {
         const useCase = container.resolve(EnsureGhAuthenticatedUseCase);

--- a/src/presentation/cli/commands/app/cloud-providers/ls.command.ts
+++ b/src/presentation/cli/commands/app/cloud-providers/ls.command.ts
@@ -13,6 +13,13 @@ export function createCloudProvidersLsCommand(): Command {
   return new Command('ls')
     .description('List cloud deployment providers and their connection state')
     .option('--json', 'Output as JSON')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app cloud-providers ls
+  $ shep app cloud-providers ls --json`
+    )
     .action(async (options: { json?: boolean }) => {
       try {
         const useCase = container.resolve(ListCloudProvidersUseCase);

--- a/src/presentation/cli/commands/app/del.command.ts
+++ b/src/presentation/cli/commands/app/del.command.ts
@@ -28,6 +28,13 @@ export function createDelCommand(): Command {
     .description(t('cli:commands.app.del.description'))
     .argument('<id>', t('cli:commands.app.del.idArgument'))
     .option('-f, --force', t('cli:commands.app.del.forceOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app del a1b2c3d4
+  $ shep app del a1b2c3d4 --force`
+    )
     .action(async (id: string, options: DelOptions) => {
       try {
         const resolved = await resolveApplication(id);

--- a/src/presentation/cli/commands/app/deploy/initiate.command.ts
+++ b/src/presentation/cli/commands/app/deploy/initiate.command.ts
@@ -47,6 +47,13 @@ export function createDeployInitiateCommand(): Command {
     .description('Start a cloud deployment for the application (streams progress)')
     .argument('<id>', 'Application id or slug')
     .option('--provider <provider>', 'Override the selected provider')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app deploy start a1b2c3d4
+  $ shep app deploy start my-app --provider CloudflarePages`
+    )
     .action(async (id: string, options: { provider?: string }) => {
       try {
         const resolved = await resolveApplication(id);

--- a/src/presentation/cli/commands/app/deploy/status.command.ts
+++ b/src/presentation/cli/commands/app/deploy/status.command.ts
@@ -15,6 +15,13 @@ export function createDeployStatusCommand(): Command {
     .description('Show the latest cloud deployment status for an application')
     .argument('<id>', 'Application id or slug')
     .option('--json', 'Output as JSON')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app deploy status a1b2c3d4
+  $ shep app deploy status my-app --json`
+    )
     .action(async (id: string, options: { json?: boolean }) => {
       try {
         const resolved = await resolveApplication(id);

--- a/src/presentation/cli/commands/app/git/create-remote.command.ts
+++ b/src/presentation/cli/commands/app/git/create-remote.command.ts
@@ -18,6 +18,13 @@ export function createGitCreateRemoteCommand(): Command {
   return new Command('create-remote')
     .description('Create a GitHub repository for the application and push')
     .argument('<id>', 'Application id or slug')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app git create-remote a1b2c3d4
+  $ shep app git create-remote my-app`
+    )
     .action(async (id: string) => {
       try {
         const resolved = await resolveApplication(id);

--- a/src/presentation/cli/commands/app/ls.command.ts
+++ b/src/presentation/cli/commands/app/ls.command.ts
@@ -41,7 +41,15 @@ function colorStatus(status: string): string {
 
 export function createLsCommand(): Command {
   const t = getCliI18n().t;
-  return new Command('ls').description(t('cli:commands.app.ls.description')).action(async () => {
+  return new Command('ls')
+    .description(t('cli:commands.app.ls.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app ls`
+    )
+    .action(async () => {
     try {
       const useCase = container.resolve(ListApplicationsUseCase);
       const applications = await useCase.execute();

--- a/src/presentation/cli/commands/app/ls.command.ts
+++ b/src/presentation/cli/commands/app/ls.command.ts
@@ -50,35 +50,35 @@ Examples:
   $ shep app ls`
     )
     .action(async () => {
-    try {
-      const useCase = container.resolve(ListApplicationsUseCase);
-      const applications = await useCase.execute();
+      try {
+        const useCase = container.resolve(ListApplicationsUseCase);
+        const applications = await useCase.execute();
 
-      const now = Date.now();
-      const rows = applications.map((app) => [
-        app.id.substring(0, 8),
-        app.name,
-        colorStatus(app.status),
-        app.repositoryPath,
-        colors.muted(`${formatDuration(now - new Date(app.createdAt).getTime())} ago`),
-      ]);
+        const now = Date.now();
+        const rows = applications.map((app) => [
+          app.id.substring(0, 8),
+          app.name,
+          colorStatus(app.status),
+          app.repositoryPath,
+          colors.muted(`${formatDuration(now - new Date(app.createdAt).getTime())} ago`),
+        ]);
 
-      renderListView({
-        title: t('cli:commands.app.ls.title'),
-        columns: [
-          { label: t('cli:commands.app.ls.idColumn'), width: 10 },
-          { label: t('cli:commands.app.ls.nameColumn'), width: 28 },
-          { label: t('cli:commands.app.ls.statusColumn'), width: 10 },
-          { label: t('cli:commands.app.ls.pathColumn'), width: 36 },
-          { label: t('cli:commands.app.ls.createdColumn'), width: 12 },
-        ],
-        rows,
-        emptyMessage: t('cli:commands.app.ls.noApps'),
-      });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      messages.error(t('cli:commands.app.ls.failedToList'), err);
-      process.exitCode = 1;
-    }
-  });
+        renderListView({
+          title: t('cli:commands.app.ls.title'),
+          columns: [
+            { label: t('cli:commands.app.ls.idColumn'), width: 10 },
+            { label: t('cli:commands.app.ls.nameColumn'), width: 28 },
+            { label: t('cli:commands.app.ls.statusColumn'), width: 10 },
+            { label: t('cli:commands.app.ls.pathColumn'), width: 36 },
+            { label: t('cli:commands.app.ls.createdColumn'), width: 12 },
+          ],
+          rows,
+          emptyMessage: t('cli:commands.app.ls.noApps'),
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        messages.error(t('cli:commands.app.ls.failedToList'), err);
+        process.exitCode = 1;
+      }
+    });
 }

--- a/src/presentation/cli/commands/app/new.command.ts
+++ b/src/presentation/cli/commands/app/new.command.ts
@@ -31,6 +31,14 @@ export function createNewCommand(): Command {
     .argument('<description>', t('cli:commands.app.new.descriptionArgument'))
     .option('--agent <type>', t('cli:commands.app.new.agentOption'))
     .option('--model <model>', t('cli:commands.app.new.modelOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app new "Build a todo list app with React"
+  $ shep app new "REST API for inventory management" --agent claude-code
+  $ shep app new "Portfolio website" --model claude-opus-4-6`
+    )
     .action(async (description: string, options: NewOptions) => {
       try {
         const useCase = container.resolve(CreateApplicationUseCase);

--- a/src/presentation/cli/commands/app/show.command.ts
+++ b/src/presentation/cli/commands/app/show.command.ts
@@ -26,6 +26,12 @@ export function createShowCommand(): Command {
   return new Command('show')
     .description(t('cli:commands.app.show.description'))
     .argument('<id>', t('cli:commands.app.show.idArgument'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep app show a1b2c3d4`
+    )
     .action(async (id: string) => {
       try {
         const resolved = await resolveApplication(id);


### PR DESCRIPTION
## What

Add a runtime Examples: block (.addHelpText('after', ...)) to every leaf subcommand in the shep app command group. Today these commands carry usage examples only in their source-file JSDoc header — those never reach the user running `shep app new --help`. This PR lifts the existing JSDoc examples (and adds one where missing) into a `.addHelpText('after', ...)` call so --help actually shows them. No behavior changes — help text only.

## Why

The coding-agent ecosystem is increasingly CLI-first and deploy-aware. shep's app group is exactly that surface — it creates applications and drives their cloud deploys from the terminal — yet `shep app new --help`, `shep app deploy initiate --help`, and `shep app cloud-providers connect --help` all render with no examples. The sibling groups already got this treatment (feat #650, agent #639, supervisor #648); the flagship application-creation group is the conspicuous gap.

## Changes

Added `.addHelpText('after', ...)` blocks to all 10 leaf app subcommands:

- `shep app new`
- `shep app ls`
- `shep app show`
- `shep app del`
- `shep app deploy start`
- `shep app deploy status`
- `shep app cloud-providers connect`
- `shep app cloud-providers ls`
- `shep app cloud-providers github-login`
- `shep app git create-remote`

## Acceptance Criteria

- ✅ Each of the 10 leaf app subcommands gains a `.addHelpText('after', ...)` block with at least one realistic `$ shep app ...` example
- ✅ Examples use real flags the commands actually define (e.g. `--agent`, `--model` for new) — no invented options
- ✅ `shep app new --help` (and the other nine) visibly print an Examples: section
- ✅ No changes to command behavior, options, or actions — help text only

Fixes #660
