### PR TITLE
chore: relax commit message case requirements

### DIFF
--- a/.claude/rules/commit-conventions.md
+++ b/.claude/rules/commit-conventions.md
@@ -36,18 +36,18 @@ specs | shep-kit | cli | tui | web | api | domain | agents | deployment | tsp | 
 
 ## <subject> rules
 
-- MUST be lowercase only (a–z, 0–9, spaces, and hyphens only)
+- Case is flexible — sentence-case, lowercase, or mixed are all accepted (e.g. "Add new command" or "add new command")
 - MUST NOT be empty
 - MUST NOT end with a period `.`
 - MUST be <= 72 characters (subject only, not including `<type>(<scope>): `)
-- SHOULD be an imperative phrase (e.g., "add", "fix", "remove", "refactor")
+- SHOULD be an imperative phrase (e.g., "Add", "Fix", "Remove", "Refactor")
 
 ## Header rules (entire first line)
 
 - MUST be <= 100 characters total
-- MUST match this regex exactly:
+- MUST match this regex:
 
-^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((specs|shep-kit|cli|tui|web|api|domain|agents|deployment|tsp|deps|config|dx|release|ci)\): [a-z0-9][a-z0-9\- ]{0,71}$
+^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)\((specs|shep-kit|cli|tui|web|api|domain|agents|deployment|tsp|deps|config|dx|release|ci)\): .{1,72}$
 
 ## Body / Footer (optional)
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -83,7 +83,7 @@ jobs:
             release
             ci
           requireScope: false
-          subjectPattern: ^[a-z].+$
+          subjectPattern: ^.+$
           subjectPatternError: |
-            PR title subject must start with lowercase letter.
-            Example: "feat(cli): add new command"
+            PR title subject must not be empty.
+            Example: "feat(cli): Add new command"

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -80,8 +80,8 @@ export default {
       ],
     ],
 
-    // Subject rules - ALL lowercase including acronyms (pr not PR, api not API)
-    'subject-case': [2, 'always', 'lower-case'],
+    // Subject case is not enforced — sentence-case, lowercase, or mixed are all accepted
+    'subject-case': [0],
     'subject-empty': [2, 'never'],
     'subject-full-stop': [2, 'never', '.'],
     'subject-max-length': [2, 'always', 72],


### PR DESCRIPTION
## What

Relaxed commit message case enforcement across all three validation layers (commitlint, PR check workflow, and commit conventions documentation). Subject lines now accept sentence-case, lowercase, or mixed case — previously only lowercase was allowed.

## Why

The strict lowercase-only requirement was unnecessarily rigid and created friction for contributors. Sentence-case (e.g., "Add new command") is more natural and readable while still maintaining consistency through the imperative verb requirement. This change aligns with common Conventional Commits practices used across the industry.

## Changes

- **commitlint.config.mjs**: Disabled `subject-case` rule (changed from `'lower-case'` to `[0]`)
- **.github/workflows/pr-check.yml**: Updated `subjectPattern` regex from `^[a-z].+$` to `^.+$` and updated error message to reflect new flexibility
- **.claude/rules/commit-conventions.md**: Updated documentation to reflect that case is flexible and updated regex pattern to accept any characters in subject line

## Testing

N/A — non-functional change. Existing commit validation tests will continue to pass with the relaxed pattern. Manual verification: commits with sentence-case subjects (e.g., "feat(cli): Add new command") will now pass validation where they previously would have failed.

## Checklist

- [x] `pnpm lint` passes
- [x] Documentation updated to reflect new behavior
- [x] No code logic changes — configuration only

https://claude.ai/code/session_01HvPbfopWdzxVzxrwFKPJ6w