### PR TITLE
fix(cli): add help examples to root commands

### DIFF
--- a/src/presentation/cli/commands/install.command.ts
+++ b/src/presentation/cli/commands/install.command.ts
@@ -45,6 +45,14 @@ export function createInstallCommand(): Command {
       })
     )
     .option('--how', t('cli:commands.install.howOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep install                  List available tools
+  $ shep install claude-code      Install Claude Code
+  $ shep install claude-code --how Show installation instructions only`
+    )
     .action(async (tool: string | undefined, options: InstallOptions) => {
       try {
         // No tool specified — show available tools

--- a/src/presentation/cli/commands/review.command.ts
+++ b/src/presentation/cli/commands/review.command.ts
@@ -149,6 +149,16 @@ export function createReviewCommand(): Command {
     .option('--owner <owner>', t('cli:commands.codeReview.ownerOption'))
     .option('--repo <repo>', t('cli:commands.codeReview.repoOption'))
     .option('--post', t('cli:commands.codeReview.postOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep review 42
+  $ shep review https://github.com/org/repo/pull/42
+  $ shep review show abc12345
+  $ shep review list
+  $ shep review post abc12345`
+    )
     .action(async (target: string | undefined, options: ReviewOptions) => {
       if (!target) {
         reviewCmd.help();

--- a/src/presentation/cli/commands/run.command.ts
+++ b/src/presentation/cli/commands/run.command.ts
@@ -63,6 +63,15 @@ export function createRunCommand(): Command {
     )
     .option('-r, --repo <path>', t('cli:commands.run.repoOption'))
     .option('-s, --stream', t('cli:commands.run.streamOption'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep run analyze-repository
+  $ shep run analyze-repository --prompt "Focus on security"
+  $ shep run analyze-repository --repo /path/to/repo
+  $ shep run analyze-repository --stream`
+    )
     .action(async (agentName: string, options: RunOptions) => {
       try {
         const useCase = container.resolve(RunAgentUseCase);

--- a/src/presentation/cli/commands/upgrade.command.ts
+++ b/src/presentation/cli/commands/upgrade.command.ts
@@ -169,6 +169,14 @@ export function createUpgradeCommand(spawnFn: SpawnFn = defaultSpawn): Command {
   const t = getCliI18n().t;
   return new Command('upgrade')
     .description(t('cli:commands.upgrade.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep upgrade                  Upgrade Shep to the latest version
+  $ shep stop && shep upgrade     Upgrade and restart the daemon automatically
+  $ shep upgrade                  No-op when Shep is already up to date`
+    )
     .action(async () => {
       try {
         const versionService = container.resolve<IVersionService>('IVersionService');

--- a/src/presentation/cli/commands/version.command.ts
+++ b/src/presentation/cli/commands/version.command.ts
@@ -26,18 +26,28 @@ import { getCliI18n } from '../i18n.js';
  */
 export function createVersionCommand(): Command {
   const t = getCliI18n().t;
-  return new Command('version').description(t('cli:commands.version.description')).action(() => {
-    const versionService = container.resolve<IVersionService>('IVersionService');
-    const info = versionService.getVersion();
+  return new Command('version')
+    .description(t('cli:commands.version.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep version                  Show detailed version information
+  $ shep --version                Show version number only
+  $ shep version                  Includes Node.js and platform details`
+    )
+    .action(() => {
+      const versionService = container.resolve<IVersionService>('IVersionService');
+      const info = versionService.getVersion();
 
-    messages.newline();
-    console.log(`${fmt.heading(info.name)} ${fmt.version(info.version)}`);
-    console.log(colors.muted(info.description));
-    messages.newline();
-    console.log(`${fmt.label(t('cli:commands.version.nodeLabel'))}     ${process.version}`);
-    console.log(
-      `${fmt.label(t('cli:commands.version.platformLabel'))} ${process.platform} ${process.arch}`
-    );
-    messages.newline();
-  });
+      messages.newline();
+      console.log(`${fmt.heading(info.name)} ${fmt.version(info.version)}`);
+      console.log(colors.muted(info.description));
+      messages.newline();
+      console.log(`${fmt.label(t('cli:commands.version.nodeLabel'))}     ${process.version}`);
+      console.log(
+        `${fmt.label(t('cli:commands.version.platformLabel'))} ${process.platform} ${process.arch}`
+      );
+      messages.newline();
+    });
 }


### PR DESCRIPTION
## What

Adds `Examples:` help blocks to five root-level Shep CLI commands:

* `shep install`
* `shep upgrade`
* `shep version`
* `shep review`
* `shep run`

Each command now shows copy-pasteable usage examples in its `--help` output.

## Why

Improves discoverability for new CLI users by showing practical examples directly in the command help output.

Closes #685.

## Screenshots / Recording

N/A — non-UI change.

## Testing

Manually verified the new `Examples:` blocks appear in help output for:

* `pnpm dev:cli install --help`
* `pnpm dev:cli upgrade --help`
* `pnpm dev:cli version --help`
* `pnpm dev:cli review --help`
* `pnpm dev:cli run --help`

Also ran:

* `git status`
* `git diff`
* `git diff --check`
* `pnpm dev:cli doctor`

Note: `pnpm dev:cli doctor` failed locally because the doctor check did not detect pnpm on PATH, although `where.exe pnpm` and `Get-Command pnpm` both showed pnpm installed and available.

## Checklist

* [x] `pnpm lint` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm test:unit` and `pnpm test:int` pass
* [x] `pnpm build` succeeds
* [x] No `application/` or `presentation/` file imports anything from `infrastructure/`
* [x] Commit messages follow Conventional Commits — releasing types (`feat`, `fix`) used for user-visible changes
