### PR TITLE
feat(web): add Storybook stories for VersionPageClient

### DIFF
--- a/src/presentation/web/components/features/version/version-page-client.stories.tsx
+++ b/src/presentation/web/components/features/version/version-page-client.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import VersionPageClient from './version-page-client';
+import type { VersionInfo, SystemInfo } from '@/lib/version';
+
+const meta: Meta<typeof VersionPageClient> = {
+  title: 'Version/VersionPageClient',
+  component: VersionPageClient,
+  parameters: { layout: 'padded' },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof VersionPageClient>;
+
+function makeVersionInfo(overrides: Partial<VersionInfo> = {}): VersionInfo {
+  return {
+    version: '1.206.2',
+    name: '@shepai/cli',
+    description: 'Autonomous AI Native SDLC Platform',
+    branch: 'main',
+    commitHash: 'a1b2c3d',
+    ...overrides,
+  };
+}
+
+function makeSystemInfo(overrides: Partial<SystemInfo> = {}): SystemInfo {
+  return {
+    nodeVersion: 'v22.22.2',
+    platform: 'darwin',
+    arch: 'arm64',
+    ...overrides,
+  };
+}
+
+export const Default: Story = {
+  args: {
+    versionInfo: makeVersionInfo(),
+    systemInfo: makeSystemInfo(),
+  },
+};
+
+export const SystemTab: Story = {
+  args: {
+    versionInfo: makeVersionInfo(),
+    systemInfo: makeSystemInfo(),
+  },
+  parameters: {
+    activeTab: 'system',
+  },
+};
+
+export const FeaturesTab: Story = {
+  args: {
+    versionInfo: makeVersionInfo(),
+    systemInfo: makeSystemInfo(),
+  },
+  parameters: {
+    activeTab: 'features',
+  },
+};
+
+export const LongVersionString: Story = {
+  args: {
+    versionInfo: makeVersionInfo({
+      version: '1.207.0-alpha.3+build.456',
+    }),
+    systemInfo: makeSystemInfo(),
+  },
+};
+
+export const LinuxAmd64: Story = {
+  args: {
+    versionInfo: makeVersionInfo({
+      version: '1.206.2',
+    }),
+    systemInfo: makeSystemInfo({
+      platform: 'linux',
+      arch: 'x64',
+      nodeVersion: 'v20.18.1',
+    }),
+  },
+};


### PR DESCRIPTION
## Problem

The `/version` page has zero Storybook coverage. Any visual regression on the badge/tab layout (e.g. when the version string grows from `v1.206.2` to a multi-segment prerelease tag) ships unnoticed until a user reports it.

## Fix

Add a colocated `version-page-client.stories.tsx` with:

- **Default** — standard props, Overview tab
- **SystemTab** — same props, System tab active
- **FeaturesTab** — same props, Features tab active
- **LongVersionString** — exercises badge layout with `1.207.0-alpha.3+build.456`
- **LinuxAmd64** — cross-platform variant (Linux x64, Node 20)

No component edits — pure visual-regression coverage.

## Test Plan

- [ ] Stories build cleanly via `pnpm build:storybook`
- [ ] `pnpm validate` passes
- [ ] Stories render correctly in `pnpm storybook`

Closes #688
