### PR TITLE
docs: add JSDoc to 6 work-items use-case files

### DIFF
--- a/packages/core/src/application/use-cases/work-items/bulk-update-work-items.use-case.ts
+++ b/packages/core/src/application/use-cases/work-items/bulk-update-work-items.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Bulk Update Work Items Use Case
+ *
+ * Updates multiple work items in a single operation via IWorkItemRepository.
+ * Returns a Result with failures[] for items that could not be updated.
+ */
 import { injectable, inject } from 'tsyringe';
 import { randomUUID } from 'node:crypto';
 import type { IWorkItemRepository } from '../../ports/output/repositories/work-item-repository.interface.js';

--- a/packages/core/src/application/use-cases/work-items/create-work-item.use-case.ts
+++ b/packages/core/src/application/use-cases/work-items/create-work-item.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Create Work Item Use Case
+ *
+ * Creates a new work item in a project. Validates the project and state exist,
+ * generates a UUID, and persists the work item via IWorkItemRepository.
+ */
 import { injectable, inject } from 'tsyringe';
 import { randomUUID } from 'node:crypto';
 import type { WorkItem } from '../../../domain/generated/output.js';

--- a/packages/core/src/application/use-cases/work-items/delete-work-item.use-case.ts
+++ b/packages/core/src/application/use-cases/work-items/delete-work-item.use-case.ts
@@ -1,3 +1,8 @@
+/**
+ * Delete Work Item Use Case
+ *
+ * Deletes a work item by its ID via IWorkItemRepository.
+ */
 import { injectable, inject } from 'tsyringe';
 import type { IWorkItemRepository } from '../../ports/output/repositories/work-item-repository.interface.js';
 

--- a/packages/core/src/application/use-cases/work-items/get-work-item.use-case.ts
+++ b/packages/core/src/application/use-cases/work-items/get-work-item.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Get Work Item Use Case
+ *
+ * Retrieves a single work item by its ID via IWorkItemRepository.
+ * Returns ok: false if the work item is not found.
+ */
 import { injectable, inject } from 'tsyringe';
 import type { WorkItem } from '../../../domain/generated/output.js';
 import type { IWorkItemRepository } from '../../ports/output/repositories/work-item-repository.interface.js';

--- a/packages/core/src/application/use-cases/work-items/list-work-items.use-case.ts
+++ b/packages/core/src/application/use-cases/work-items/list-work-items.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * List Work Items Use Case
+ *
+ * Lists work items matching optional filters via IWorkItemRepository.
+ * Supports filtering by project, state, assignee, and other criteria.
+ */
 import { injectable, inject } from 'tsyringe';
 import type { WorkItem } from '../../../domain/generated/output.js';
 import type {

--- a/packages/core/src/application/use-cases/work-items/update-work-item.use-case.ts
+++ b/packages/core/src/application/use-cases/work-items/update-work-item.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Update Work Item Use Case
+ *
+ * Updates an existing work item's fields via IWorkItemRepository.
+ * Validates the work item exists before applying changes.
+ */
 import { injectable, inject } from 'tsyringe';
 import { randomUUID } from 'node:crypto';
 import type { WorkItem } from '../../../domain/generated/output.js';


### PR DESCRIPTION
## What

Added leading `/** … */` JSDoc blocks to all 6 work-item use-case files.

## Changes

Added JSDoc to:
- `CreateWorkItemUseCase` — creates a new work item, validates project and state
- `GetWorkItemUseCase` — retrieves a single work item by ID
- `ListWorkItemsUseCase` — lists work items with optional filters
- `UpdateWorkItemUseCase` — updates an existing work item's fields
- `DeleteWorkItemUseCase` — deletes a work item by ID
- `BulkUpdateWorkItemsUseCase` — bulk updates with partial-failure Result

## Acceptance criteria

- [x] Each file begins with a `/** … */` doc-comment of 3–8 lines
- [x] BulkUpdateWorkItemsUseCase calls out the partial-failure shape
- [x] No code changes — only new JSDoc at the top of each file

Closes #691