### PR TITLE
docs: add JSDoc to 4 integrations use-case files

### DIFF
--- a/packages/core/src/application/use-cases/integrations/connect-github.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/connect-github.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Connect GitHub Use Case
+ *
+ * Mints and stores a GitHub integration token via IGithubIntegrationRepository.
+ * Throws InvalidGithubTokenError if the token is invalid or expired.
+ */
 import { inject, injectable } from 'tsyringe';
 
 import type { IGithubIntegrationRepository } from '../../ports/output/repositories/github-integration.repository.interface.js';

--- a/packages/core/src/application/use-cases/integrations/disconnect-github.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/disconnect-github.use-case.ts
@@ -1,3 +1,8 @@
+/**
+ * Disconnect GitHub Use Case
+ *
+ * Removes the GitHub integration token via IGithubIntegrationRepository.
+ */
 import { inject, injectable } from 'tsyringe';
 
 import type { IGithubIntegrationRepository } from '../../ports/output/repositories/github-integration.repository.interface.js';

--- a/packages/core/src/application/use-cases/integrations/get-github-integration-status.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/get-github-integration-status.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Get GitHub Integration Status Use Case
+ *
+ * Returns the current GitHub integration status (connected/disconnected)
+ * via IGithubIntegrationRepository.
+ */
 import { inject, injectable } from 'tsyringe';
 
 import type {

--- a/packages/core/src/application/use-cases/integrations/send-webhook.use-case.ts
+++ b/packages/core/src/application/use-cases/integrations/send-webhook.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * Send Webhook Use Case
+ *
+ * Sends a webhook event to GitHub via IGithubIntegrationService.
+ * Returns { ok: false, error } on failure rather than throwing.
+ */
 import { injectable, inject } from 'tsyringe';
 import type {
   IWebhookService,


### PR DESCRIPTION
## What

Added leading `/** … */` JSDoc blocks to all 4 integrations use-case files.

## Changes

Added JSDoc to:
- `ConnectGithubUseCase` — mints and stores GitHub token, throws `InvalidGithubTokenError`
- `DisconnectGithubUseCase` — removes GitHub integration token
- `GetGithubIntegrationStatusUseCase` — returns connection status
- `SendWebhookUseCase` — sends webhook events, returns `{ ok: false, error }` on failure

## Acceptance criteria

- [x] Each file begins with a `/** … */` doc-comment of 3–8 lines
- [x] `connect-github.use-case.ts` notes `InvalidGithubTokenError`
- [x] `send-webhook.use-case.ts` calls out the failure contract
- [x] No code changes — only new JSDoc at the top of each file

Closes #692