### PR TITLE
feat(agents): add claude-opus-4-8 model support across all agents

### DIFF
--- a/.storybook/mocks/app/actions/get-all-agent-models.ts
+++ b/.storybook/mocks/app/actions/get-all-agent-models.ts
@@ -4,7 +4,13 @@ const CATALOG: { agentType: string; label: string; models: string[] }[] = [
   {
     agentType: 'claude-code',
     label: 'Claude Code',
-    models: ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+    models: [
+      'claude-opus-4-8',
+      'claude-opus-4-7',
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5',
+    ],
   },
   {
     agentType: 'codex-cli',
@@ -32,6 +38,7 @@ const CATALOG: { agentType: string; label: string; models: string[] }[] = [
       'claude-opus-4.5',
       'claude-opus-4.6',
       'claude-opus-4.7',
+      'claude-opus-4.8',
       'claude-sonnet-4',
       'claude-sonnet-4.5',
       'claude-sonnet-4.6',
@@ -48,6 +55,7 @@ const CATALOG: { agentType: string; label: string; models: string[] }[] = [
     agentType: 'cursor',
     label: 'Cursor CLI',
     models: [
+      'claude-opus-4-8',
       'claude-opus-4-7',
       'claude-opus-4-6',
       'claude-sonnet-4-6',

--- a/.storybook/mocks/app/actions/get-supported-models.ts
+++ b/.storybook/mocks/app/actions/get-supported-models.ts
@@ -1,3 +1,9 @@
 export async function getSupportedModels(): Promise<string[]> {
-  return ['claude-opus-4-7', 'claude-opus-4-6', 'claude-sonnet-4-6', 'claude-haiku-4-5'];
+  return [
+    'claude-opus-4-8',
+    'claude-opus-4-7',
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5',
+  ];
 }

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -699,3 +699,16 @@ E2E specs in `tests/e2e/web/` run against `pnpm dev:web` (Next.js dev mode, Turb
 Symptom: `toHaveURL` fails with `N × unexpected value "<old url>"`, then passes on retry. Reported as `1 flaky` in the Playwright summary.
 
 **Rule:** in any spec under `tests/e2e/web/`, when waiting for navigation after a click, use `await page.waitForURL(...)`, never `await expect(page).toHaveURL(...)`. Reserve `toHaveURL` for asserting the URL **after** you already know navigation completed (e.g., after a `waitForURL` or after the destination's content is visible).
+
+## Adding a New Claude Model — Exact Touchpoints
+
+Model lists are centralized, but several adapters keep their own provider-format copies. Claude Code passes `options.model` straight to the `claude` CLI via `--model`, so no mapping is needed there — but Cursor and Copilot rewrite the canonical hyphenated ID into their own format. To add a model (e.g. `claude-opus-4-8`), touch ALL of:
+
+1. `packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts` — add to `CLAUDE_CODE_MODELS`, `CURSOR_MODELS`, and `COPILOT_CLI_MODELS` (note Copilot uses dotted form `claude-opus-4.8`, the others hyphenated). This is the source of truth for `AgentExecutorFactory.getSupportedModels()`.
+2. `src/presentation/web/lib/model-metadata.ts` — add a `displayName`/`description` entry (hyphenated key). Missing entries fall back to a prettified raw ID.
+3. `packages/core/src/infrastructure/services/agents/common/executors/cursor-executor.service.ts` — `CURSOR_MODEL_MAP` maps `claude-opus-4-8` → `opus-4.8`. Unmapped IDs pass through unchanged (a silent bug — the catalog can list a model the map doesn't translate).
+4. `packages/core/src/infrastructure/services/agents/common/executors/copilot-cli-executor.service.ts` — `LEGACY_MODEL_ALIASES` maps hyphenated → dotted for old settings payloads.
+5. `.storybook/mocks/app/actions/get-all-agent-models.ts` and `get-supported-models.ts` — Storybook bundles the client only, so these mocks must mirror the catalog or the picker stories drift.
+6. `tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts` — `getSupportedModels` tests assert exact lists AND lengths per agent (Claude Code, Cursor, Copilot). Update the arrays and the `toHaveLength` count.
+
+The default model (`settings-defaults.factory.ts` `DEFAULT_MODEL`) is a SEPARATE decision — adding a model does NOT change the default. Don't touch it unless explicitly asked.

--- a/packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts
@@ -8,6 +8,7 @@
  */
 
 export const CLAUDE_CODE_MODELS: string[] = [
+  'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
@@ -23,6 +24,7 @@ export const GEMINI_CLI_MODELS: string[] = [
 ];
 
 export const CURSOR_MODELS: string[] = [
+  'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
@@ -54,6 +56,7 @@ export const COPILOT_CLI_MODELS: string[] = [
   'claude-opus-4.5',
   'claude-opus-4.6',
   'claude-opus-4.7',
+  'claude-opus-4.8',
   'claude-sonnet-4',
   'claude-sonnet-4.5',
   'claude-sonnet-4.6',

--- a/packages/core/src/infrastructure/services/agents/common/executors/copilot-cli-executor.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/executors/copilot-cli-executor.service.ts
@@ -71,6 +71,8 @@ const LEGACY_MODEL_ALIASES: Record<string, string> = {
   'claude-sonnet-4-6': 'claude-sonnet-4.6',
   'claude-opus-4-5': 'claude-opus-4.5',
   'claude-opus-4-6': 'claude-opus-4.6',
+  'claude-opus-4-7': 'claude-opus-4.7',
+  'claude-opus-4-8': 'claude-opus-4.8',
   'claude-haiku-4-5': 'claude-haiku-4.5',
   'gpt-4-1': 'gpt-4.1',
   'gpt-5-2': 'gpt-5.2',

--- a/packages/core/src/infrastructure/services/agents/common/executors/cursor-executor.service.ts
+++ b/packages/core/src/infrastructure/services/agents/common/executors/cursor-executor.service.ts
@@ -30,6 +30,8 @@ import { IS_WINDOWS } from '../../../../platform.js';
  * Models that already match Cursor's naming pass through unchanged.
  */
 const CURSOR_MODEL_MAP: Record<string, string> = {
+  'claude-opus-4-8': 'opus-4.8',
+  'claude-opus-4-7': 'opus-4.7',
   'claude-opus-4-6': 'opus-4.6',
   'claude-sonnet-4-6': 'sonnet-4.6',
   'claude-haiku-4-5': 'haiku-4.5',

--- a/src/presentation/web/lib/model-metadata.ts
+++ b/src/presentation/web/lib/model-metadata.ts
@@ -9,8 +9,9 @@ export interface ModelMeta {
  */
 const MODEL_METADATA: Record<string, ModelMeta> = {
   // Claude models
-  'claude-opus-4-7': { displayName: 'Opus 4.7', description: 'Most capable, complex tasks' },
-  'claude-opus-4-6': { displayName: 'Opus 4.6', description: 'Previous flagship' },
+  'claude-opus-4-8': { displayName: 'Opus 4.8', description: 'Most capable, complex tasks' },
+  'claude-opus-4-7': { displayName: 'Opus 4.7', description: 'Previous flagship' },
+  'claude-opus-4-6': { displayName: 'Opus 4.6', description: 'Legacy flagship' },
   'claude-sonnet-4-6': { displayName: 'Sonnet 4.6', description: 'Fast & balanced' },
   'claude-haiku-4-5': { displayName: 'Haiku 4.5', description: 'Lightweight & quick' },
 

--- a/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
@@ -349,6 +349,7 @@ describe('AgentExecutorFactory', () => {
       const models = factory.getSupportedModels(AgentType.ClaudeCode);
 
       expect(models).toEqual([
+        'claude-opus-4-8',
         'claude-opus-4-7',
         'claude-opus-4-6',
         'claude-sonnet-4-6',
@@ -372,6 +373,7 @@ describe('AgentExecutorFactory', () => {
       const models = factory.getSupportedModels(AgentType.Cursor);
 
       expect(models).toEqual([
+        'claude-opus-4-8',
         'claude-opus-4-7',
         'claude-opus-4-6',
         'claude-sonnet-4-6',
@@ -404,15 +406,16 @@ describe('AgentExecutorFactory', () => {
       ]);
     });
 
-    it('should return copilot-cli model list with 7 models', () => {
+    it('should return copilot-cli model list with 15 models', () => {
       const models = factory.getSupportedModels(AgentType.CopilotCli);
 
-      expect(models).toHaveLength(14);
+      expect(models).toHaveLength(15);
       expect(models).toEqual([
         'claude-haiku-4.5',
         'claude-opus-4.5',
         'claude-opus-4.6',
         'claude-opus-4.7',
+        'claude-opus-4.8',
         'claude-sonnet-4',
         'claude-sonnet-4.5',
         'claude-sonnet-4.6',


### PR DESCRIPTION
## What

Add `claude-opus-4-8` as the new flagship Claude model across Claude Code, Cursor, and Copilot CLI agents. Update model metadata, test assertions, and Storybook mocks to reflect the new model in all agent catalogs.

## Why

Claude Opus 4.8 is now available and should be offered as the most capable option. This change makes it available in all three agent executors and updates the UI to reflect it as the current flagship model.

## Screenshots / Recording

N/A — non-UI change (model list update).

## Testing

- `pnpm test:unit` — Updated `agent-executor-factory.test.ts` to assert the new model appears in supported lists for Claude Code, Cursor, and Copilot CLI, and updated length assertions (Copilot now 15 models instead of 14).
- Storybook mocks updated to include the new model in both `get-all-agent-models.ts` and `get-supported-models.ts`.
- Model metadata added to `model-metadata.ts` with display name and description; descriptions for 4.7 and 4.6 updated to reflect the new hierarchy.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (agent executor factory tests updated)
- [x] `pnpm build` succeeds
- [x] Updated [LESSONS.md](./LESSONS.md) with exact touchpoints for adding a new Claude model (section: "Adding a New Claude Model — Exact Touchpoints")
- [x] Commit message follows Conventional Commits (`feat(agents)`)

## Notes

All six required touchpoints for adding a new model have been updated:
1. `agent-model-catalog.ts` — added to `CLAUDE_CODE_MODELS`, `CURSOR_MODELS`, `COPILOT_CLI_MODELS`
2. `model-metadata.ts` — added display name and description
3. `cursor-executor.service.ts` — added mapping `claude-opus-4-8` → `opus-4.8`
4. `copilot-cli-executor.service.ts` — added legacy alias mapping
5. Storybook mocks — updated both `get-all-agent-models.ts` and `get-supported-models.ts`
6. Unit tests — updated assertions and length counts

The default model (`settings-defaults.factory.ts`) was intentionally left unchanged per the documented pattern.

https://claude.ai/code/session_018UHedEKUjfdWKvRWsqCKrA