### PR TITLE
docs(cli): add intake command help examples

### DIFF
--- a/src/presentation/cli/commands/intake/accept.command.ts
+++ b/src/presentation/cli/commands/intake/accept.command.ts
@@ -7,6 +7,12 @@ export function createAcceptCommand(): Command {
   return new Command('accept')
     .description('Accept an intake item and convert it to a work item')
     .argument('<id>', 'Intake item ID')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep intake accept abc123    Accept an intake item by ID`
+    )
     .action(async (intakeItemId: string) => {
       try {
         const useCase = container.resolve(AcceptIntakeItemUseCase);

--- a/src/presentation/cli/commands/intake/decline.command.ts
+++ b/src/presentation/cli/commands/intake/decline.command.ts
@@ -9,6 +9,13 @@ export function createDeclineCommand(): Command {
     .description('Decline an intake item with a reason')
     .argument('<id>', 'Intake item ID')
     .option('-r, --reason <reason>', 'Reason for declining')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep intake decline abc123                   Interactive prompt for reason
+  $ shep intake decline abc123 -r "Duplicate"      Non-interactive with reason`
+    )
     .action(async (intakeItemId: string, opts: { reason?: string }) => {
       try {
         const reason =

--- a/src/presentation/cli/commands/intake/ls.command.ts
+++ b/src/presentation/cli/commands/intake/ls.command.ts
@@ -9,6 +9,13 @@ export function createLsCommand(): Command {
     .description('List intake items for a project')
     .argument('<project>', 'Project slug or identifier prefix')
     .option('-s, --status <status>', 'Filter by status (Pending, Accepted, Declined, Duplicate)')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep intake ls my-project                     List all intake items
+  $ shep intake ls my-project --status Pending     Filter by status`
+    )
     .action(async (projectSlug: string, opts: { status?: string }) => {
       try {
         const getProject = container.resolve(GetPmProjectUseCase);


### PR DESCRIPTION
Fixes #678

## What changed

Added `addHelpText('after', ...)` blocks to the three `shep intake` subcommands so `--help` output includes copy-paste examples.

**Files changed:**
- `src/presentation/cli/commands/intake/accept.command.ts` — shows `$ shep intake accept <id>`
- `src/presentation/cli/commands/intake/decline.command.ts` — shows interactive form (no `-r`) and non-interactive form with `-r "Reason"`
- `src/presentation/cli/commands/intake/ls.command.ts` — shows `<project>` argument and `--status Pending` filter

Each block follows the existing pattern from `ui.command.ts` (template literal with leading `\n`, `Examples:` heading, then `$ shep ...` lines). No behavior changes — help text only.

## Checks run

```
npx prettier --check src/presentation/cli/commands/intake/*.command.ts
# All matched files use Prettier code style!

grep -P '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]' src/presentation/cli/commands/intake/*.command.ts
# No hidden characters found
```

## Skipped checks

`pnpm validate` was not run to completion in this environment due to a Node heap out-of-memory error during the ESLint step (VPS memory constraint, not related to this change). The diff is pure string additions with no type implications. Prettier formatting passes. I expect CI to pass cleanly.

## Notes

- Follows the same `addHelpText('after', ...)` convention used by sibling groups (app #660, agent #639, supervisor #648)