### PR TITLE
docs(cli): add bedrock command help examples

### DIFF
--- a/src/presentation/cli/commands/bedrock/doctor.command.ts
+++ b/src/presentation/cli/commands/bedrock/doctor.command.ts
@@ -33,6 +33,7 @@ function tiersOf(health: BedrockHealth): BedrockTierStatus[] {
 export function createBedrockDoctorCommand(): Command {
   return new Command('doctor')
     .description('Verify bedrock prerequisites (Python, pipx, bedrock binary)')
+    .addHelpText('after', `\nExamples:\n  $ shep bedrock doctor    Check prerequisites`)
     .action(async () => {
       try {
         const useCase = container.resolve<CheckBedrockHealthUseCase>(

--- a/src/presentation/cli/commands/bedrock/init.command.ts
+++ b/src/presentation/cli/commands/bedrock/init.command.ts
@@ -16,6 +16,10 @@ export function createBedrockInitCommand(): Command {
   const cmd = new Command('init').description(
     'Enable bedrock memory for an application and run `bedrock init`'
   );
+  cmd.addHelpText(
+    'after',
+    `\nExamples:\n  $ shep bedrock init --app my-app    Enable bedrock memory`
+  );
   appOption(cmd).action(async (options: { app: string }) => {
     try {
       const useCase = container.resolve<EnableBedrockForApplicationUseCase>(

--- a/src/presentation/cli/commands/bedrock/ship.command.ts
+++ b/src/presentation/cli/commands/bedrock/ship.command.ts
@@ -17,6 +17,10 @@ export function createBedrockShipCommand(): Command {
   const cmd = new Command('ship').description(
     'Commit bedrock memory updates inside the application worktree'
   );
+  cmd.addHelpText(
+    'after',
+    `\nExamples:\n  $ shep bedrock ship --app my-app    Commit bedrock updates`
+  );
   appOption(cmd).action(async (options: { app: string }) => {
     try {
       const useCase = container.resolve<RunBedrockLifecycleUseCase>(

--- a/src/presentation/cli/commands/bedrock/sync.command.ts
+++ b/src/presentation/cli/commands/bedrock/sync.command.ts
@@ -17,6 +17,10 @@ export function createBedrockSyncCommand(): Command {
   const cmd = new Command('sync').description(
     'Reconcile bedrock memory with git state inside the application worktree'
   );
+  cmd.addHelpText(
+    'after',
+    `\nExamples:\n  $ shep bedrock sync --app my-app    Reconcile with git state`
+  );
   appOption(cmd).action(async (options: { app: string }) => {
     try {
       const useCase = container.resolve<RunBedrockLifecycleUseCase>(


### PR DESCRIPTION
Fixes #677

## What changed

Added `addHelpText('after', ...)` blocks to the four `shep bedrock` subcommands so `--help` output includes copy-paste examples.

**Files changed:**
- `bedrock/init.command.ts` shows `$ shep bedrock init --app my-app`
- `bedrock/sync.command.ts` shows `$ shep bedrock sync --app my-app`
- `bedrock/doctor.command.ts` shows `$ shep bedrock doctor`
- `bedrock/ship.command.ts` shows `$ shep bedrock ship --app my-app`

Each block follows the existing pattern from `ui.command.ts`. No behavior changes, help text only.

## Checks run

```
pnpm dev:cli bedrock init --help
pnpm dev:cli bedrock sync --help
pnpm dev:cli bedrock doctor --help
pnpm dev:cli bedrock ship --help
npx prettier --check src/presentation/cli/commands/bedrock/*.command.ts
```

All four help outputs show Examples blocks. Prettier passes.

## Skipped checks

`pnpm validate` was not run to completion due to a Node heap out-of-memory error during the ESLint step (VPS memory constraint, not related to this change). The diff is pure string additions with no type implications.

## Notes

Follows the same `addHelpText('after', ...)` convention used by sibling groups (intake #678, app #660, agent #639, supervisor #648).