### PR TITLE
docs(cli): add --help example blocks to 3 agent questions subcommands

### DIFF
--- a/src/presentation/cli/commands/agent/questions/answer.command.ts
+++ b/src/presentation/cli/commands/agent/questions/answer.command.ts
@@ -24,6 +24,13 @@ export function createAnswerCommand(): Command {
     .requiredOption('--app <id>', 'Application id (required for scope isolation)')
     .requiredOption('--answer <text>', 'The answer to record')
     .option('--answered-by <actor>', 'Actor id (e.g. user:alice)', 'user:cli')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent questions answer q-abc123 --app app-123 --answer "yes"
+  $ shep agent questions answer q-abc123 --app app-123 --answer "approve" --answered-by user:cli`
+    )
     .action(async (questionId: string, options: AnswerOptions) => {
       try {
         const useCase = container.resolve(AnswerAgentQuestionUseCase);

--- a/src/presentation/cli/commands/agent/questions/cancel.command.ts
+++ b/src/presentation/cli/commands/agent/questions/cancel.command.ts
@@ -24,6 +24,14 @@ export function createCancelCommand(): Command {
     .requiredOption('--app <id>', 'Application id (required for scope isolation)')
     .option('--reason <text>', 'Optional reason recorded as the answer field')
     .option('--cancelled-by <actor>', 'Actor id (e.g. user:alice)', 'user:cli')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent questions cancel q-abc123 --app app-123
+  $ shep agent questions cancel q-abc123 --app app-123 --reason "No longer needed"
+  $ shep agent questions cancel q-abc123 --app app-123 --cancelled-by user:alice`
+    )
     .action(async (questionId: string, options: CancelOptions) => {
       try {
         const useCase = container.resolve(CancelAgentQuestionUseCase);

--- a/src/presentation/cli/commands/agent/questions/ls.command.ts
+++ b/src/presentation/cli/commands/agent/questions/ls.command.ts
@@ -28,6 +28,14 @@ export function createListCommand(): Command {
     .option('--feature <id>', 'Feature id to narrow the list')
     .addOption(new Option('--status <status>', 'Filter by status').choices(STATUS_VALUES))
     .option('--limit <n>', 'Maximum rows to return')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep agent questions ls --app app-123                List all questions for an app
+  $ shep agent questions ls --app app-123 --status pending   Show only pending questions
+  $ shep agent questions ls --app app-123 --limit 10      Limit to 10 results`
+    )
     .action(async (options: LsOptions) => {
       try {
         const useCase = container.resolve(ListAgentQuestionsUseCase);


### PR DESCRIPTION
## Summary

Add `.addHelpText('after', ...)` example blocks to the three leaf subcommands under `shep agent questions` so `--help` shows copy-paste invocations instead of just a flag list.

## Changes

| File | Examples added |
|------|-------------|
| `ls.command.ts` | 3 examples: basic list, filter by status, limit results |
| `answer.command.ts` | 2 examples: basic answer, with explicit actor |
| `cancel.command.ts` | 3 examples: basic cancel, with reason, with custom actor |

All examples use placeholder IDs (`app-123`, `q-abc123`, `user:cli`, `user:alice`) and match the pattern established in `ui.command.ts` and the sibling `agent/ls.command.ts`.

## Verification

- `grep -L addHelpText` no longer matches the three files under `src/presentation/cli/commands/agent/questions/`
- Each block is placed **before** `.action(...)` as per the convention
- No translation keys added — examples are inline strings

## Fixes

Fixes #707
