### PR TITLE
docs(cli): add help examples to issue 722 commands

### DIFF
--- a/src/presentation/cli/commands/ide-open.command.ts
+++ b/src/presentation/cli/commands/ide-open.command.ts
@@ -46,6 +46,15 @@ export function createIdeOpenCommand(): Command {
     cmd.option(`--${id}`, t('cli:commands.ide.openInOption', { name: meta.name }));
   }
 
+  cmd.addHelpText(
+    'after',
+    `
+Examples:
+  $ shep ide feat-abc12345                Open the configured default editor
+  $ shep ide feat-abc12345 --vscode        Force Visual Studio Code
+  $ shep ide feat-abc12345 --cursor        Force Cursor`
+  );
+
   cmd.action(async (featId: string, options: Record<string, boolean | undefined>) => {
     try {
       const editorId = resolveEditorId(options, ideIds);

--- a/src/presentation/cli/commands/notifications/ls.command.ts
+++ b/src/presentation/cli/commands/notifications/ls.command.ts
@@ -9,6 +9,14 @@ export function createLsCommand(): Command {
     .argument('<recipient>', 'Recipient user ID')
     .option('-p, --project <projectId>', 'Filter by project ID')
     .option('--unread', 'Show only unread notifications')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep notifications ls alice                          List all of alice's notifications
+  $ shep notifications ls alice --unread                 Show only unread notifications
+  $ shep notifications ls alice --project proj-abc12345  Filter by project ID`
+    )
     .action(async (recipientId: string, opts: { project?: string; unread?: boolean }) => {
       try {
         const useCase = container.resolve(ListNotificationsUseCase);

--- a/tests/unit/presentation/cli/commands/ide-open.command.test.ts
+++ b/tests/unit/presentation/cli/commands/ide-open.command.test.ts
@@ -131,6 +131,29 @@ describe('IDE Open Command', () => {
         expect(opt, `Expected option ${flag}`).toBeDefined();
       }
     });
+
+    it('should include examples in help output', () => {
+      const cmd = createIdeOpenCommand();
+      let output = '';
+      cmd.configureOutput({
+        writeOut: (text) => {
+          output += text;
+        },
+      });
+      cmd.exitOverride();
+      try {
+        cmd.parse(['node', 'test', 'feat-abc12345', '--help']);
+      } catch {
+        // Commander throws when help is requested with exitOverride enabled.
+      }
+
+      expect(output).toContain('Examples:');
+      expect(output).toContain(
+        '$ shep ide feat-abc12345                Open the configured default editor'
+      );
+      expect(output).toContain('$ shep ide feat-abc12345 --vscode        Force Visual Studio Code');
+      expect(output).toContain('$ shep ide feat-abc12345 --cursor        Force Cursor');
+    });
   });
 
   describe('IDE selection', () => {

--- a/tests/unit/presentation/cli/commands/notifications/ls.command.test.ts
+++ b/tests/unit/presentation/cli/commands/notifications/ls.command.test.ts
@@ -38,6 +38,33 @@ describe('notifications ls command', () => {
     expect(cmd.name()).toBe('ls');
   });
 
+  it('should include examples in help output', () => {
+    const cmd = createLsCommand();
+    let output = '';
+    cmd.configureOutput({
+      writeOut: (text) => {
+        output += text;
+      },
+    });
+    cmd.exitOverride();
+    try {
+      cmd.parse(['node', 'test', 'alice', '--help']);
+    } catch {
+      // Commander throws when help is requested with exitOverride enabled.
+    }
+
+    expect(output).toContain('Examples:');
+    expect(output).toContain(
+      "$ shep notifications ls alice                          List all of alice's notifications"
+    );
+    expect(output).toContain(
+      '$ shep notifications ls alice --unread                 Show only unread notifications'
+    );
+    expect(output).toContain(
+      '$ shep notifications ls alice --project proj-abc12345  Filter by project ID'
+    );
+  });
+
   it('should list notifications', async () => {
     mockExecute.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## What
- Add `.helpText('after', ...)` example blocks to `shep ide` and `shep notifications ls` command help.
- Extend unit tests to assert help output includes the new Examples sections.

## Why
- Requested in issue #722 to improve discoverability of command usage.

## Testing
- `npm run test:unit -- tests/unit/presentation/cli/commands/ide-open.command.test.ts tests/unit/presentation/cli/commands/notifications/ls.command.test.ts`
- `pnpm exec prettier --check src/presentation/cli/commands/ide-open.command.ts src/presentation/cli/commands/notifications/ls.command.ts tests/unit/presentation/cli/commands/ide-open.command.test.ts tests/unit/presentation/cli/commands/notifications/ls.command.test.ts`
- `npm run check` (fails: Missing script `check`)

Closes #722
