### PR TITLE
fix(deployment): scrub cli-only env from user dev servers to fix preview asset 404s

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -806,3 +806,13 @@ grep -rhoP "register(Singleton|Instance)?(<[^>]+>)?\('(\w+UseCase)'" packages/co
 `comm -23` the two lists. Beware: registrations use generic syntax `register<IFoo>('Foo', ...)` and const tokens (`IBedrockIntegrationServiceToken = 'IBedrockIntegrationService'`) — naive greps miss both and produce false "missing" hits. Always confirm against the real container by RESOLVING, not just grepping.
 
 **Prevention:** every new feature's DI wiring needs a registration test that bootstraps the real container and resolves each string token — see `tests/unit/infrastructure/di/pm-use-case-registrations.test.ts`. A feature with web pages but no DI-registration test is not done. When a file like `register-use-cases.ts` exceeds ~300 lines, add a dedicated `register-<feature>.ts` module instead of growing it.
+
+## User Dev Servers Must Not Inherit cli-only Env (NEXT_ASSET_PREFIX, PORT)
+
+In the cloud org-runner pod, the cli process runs with `NEXT_ASSET_PREFIX=/cli` and `PORT=3000` set pod-wide (so the cli's own Next.js UI is served correctly behind the shep-cloud `/cli` proxy). `DeploymentService.start()` spawned user dev servers with `env: { ...process.env }`, so a user's Next.js dev server **inherited `NEXT_ASSET_PREFIX=/cli`** and emitted `/cli/_next/...` asset URLs. Those 404 on the preview origin (`<port>-<orgHex>.preview.shep.bot`) because a Next server serves static at `/_next/...`, not `/cli/_next/...` — every previewed app loaded unstyled with a console full of `/cli/_next/static/*` 404s.
+
+**Rule:** scrub cli-only vars (`NEXT_ASSET_PREFIX`, `PORT`, Anthropic creds) from the env at the spawn point via `buildDevServerEnv()` — do NOT rely on the org-runner `env-scrub` PATH wrappers, which only intercept `npm/pnpm/yarn/bun/npx` by name and are bypassed when the binary (e.g. `bun`, or a globally-installed pnpm in `/data/.npm-global/bin`) resolves ahead of `/usr/local/sbin`. Keep `HOST`/`HOSTNAME` (intentionally `0.0.0.0` so the preview proxy can reach the dev server on the pod IP).
+
+## Debugging Prod 404s: Read the Request's Referer/Origin BEFORE Theorizing
+
+I first "fixed" these `/cli/_next/*` 404s as a per-org-pod build-skew problem (shep-cloud PR #22) — plausible, but WRONG: the failing requests' **`Referer` was the preview host** (`<port>-<org>.preview.shep.bot`), i.e. they came from a *user dev server*, not the cli UI. The ingress access log line carries Referer, status, and `upstream_addr` — read those FIRST. A 404 from a path that a healthy pod serves at 200 means the request isn't going where you assume; the Referer/Host tells you which proxy path (`/cli/*` vs `/preview-proxy`) actually handled it. Confirm the exact failing request path end-to-end before writing a fix.

--- a/packages/core/src/infrastructure/services/deployment/deployment.service.ts
+++ b/packages/core/src/infrastructure/services/deployment/deployment.service.ts
@@ -27,6 +27,7 @@ import type {
   LogEntry,
 } from '@/application/ports/output/services/deployment-service.interface.js';
 import { detectDevScript } from './detect-dev-script.js';
+import { buildDevServerEnv } from './dev-server-env.js';
 import { createDeploymentLogger } from './deployment-logger.js';
 import { parsePort } from './parse-port.js';
 import { LogRingBuffer } from './log-ring-buffer.js';
@@ -261,6 +262,8 @@ export class DeploymentService implements IDeploymentService {
           cwd: spawnDir,
           shell: true,
           stdio: 'ignore',
+          // Scrub cli-only vars (esp. Anthropic creds) from install scripts too.
+          env: buildDevServerEnv(process.env),
           ...(IS_WINDOWS ? { windowsHide: true } : {}),
         });
         log.info('Dependencies installed successfully');
@@ -285,7 +288,11 @@ export class DeploymentService implements IDeploymentService {
       stdio: ['ignore', 'pipe', 'pipe'] as const,
       // Prevent child shep instances (e.g. worktree dev servers) from running
       // recoverAll() on the shared ~/.shep/data DB and killing our processes.
-      env: { ...process.env, SHEP_SKIP_RECOVERY: '1' },
+      // buildDevServerEnv strips cli-only vars (NEXT_ASSET_PREFIX, PORT,
+      // Anthropic creds) so user dev servers don't inherit them — chiefly
+      // NEXT_ASSET_PREFIX=/cli, which otherwise makes a user's Next.js app emit
+      // /cli/_next/... asset URLs that 404 on the preview origin.
+      env: buildDevServerEnv(process.env, { SHEP_SKIP_RECOVERY: '1' }),
     });
 
     if (!child.pid) {

--- a/packages/core/src/infrastructure/services/deployment/dev-server-env.ts
+++ b/packages/core/src/infrastructure/services/deployment/dev-server-env.ts
@@ -1,0 +1,51 @@
+/**
+ * Environment scrubbing for spawned user dev servers.
+ *
+ * The cloud org-runner pod sets a handful of env vars for the cli process
+ * ITSELF that must NOT propagate to user dev servers that DeploymentService
+ * spawns:
+ *
+ *  - `NEXT_ASSET_PREFIX=/cli` — the cli's own Next.js UI is served behind the
+ *    shep-cloud proxy under `/cli`. If a user's Next.js dev server inherits
+ *    this, it emits `/cli/_next/...` asset URLs, which 404 on the preview
+ *    origin (`<port>-<orgHex>.preview.shep.bot`) because the dev server serves
+ *    its static assets at `/_next/...`. This breaks every previewed app.
+ *  - `PORT` — the cli web port; a user app that honors PORT would fight the
+ *    cli for it instead of using its own framework default.
+ *  - Anthropic credentials — the cli's own agent creds; user dev servers (and
+ *    their postinstall scripts) must never see them.
+ *
+ * The org-runner image also ships `env-scrub` PATH wrappers for the package
+ * managers, but those depend on PATH resolution and are bypassed when the
+ * spawned binary (e.g. `bun`, or a globally-installed pnpm) resolves ahead of
+ * `/usr/local/sbin`. Scrubbing here, at the spawn point, is deterministic and
+ * independent of PATH.
+ *
+ * `HOST` / `HOSTNAME` are deliberately KEPT: the pod sets them to `0.0.0.0`
+ * so dev servers bind all interfaces and the preview proxy can reach them on
+ * the pod IP.
+ */
+export const DEV_SERVER_ENV_BLOCKLIST = [
+  'NEXT_ASSET_PREFIX',
+  'PORT',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+] as const;
+
+/**
+ * Build the environment for a spawned dev server: a copy of `baseEnv` with the
+ * cli-only vars removed, then `overrides` applied on top. Never mutates input.
+ */
+export function buildDevServerEnv(
+  baseEnv: Partial<NodeJS.ProcessEnv>,
+  overrides: Record<string, string> = {}
+): NodeJS.ProcessEnv {
+  const env: Record<string, string | undefined> = { ...baseEnv };
+  for (const key of DEV_SERVER_ENV_BLOCKLIST) {
+    delete env[key];
+  }
+  // Real callers pass process.env, so the result carries NODE_ENV etc.; the
+  // cast keeps the return assignable to spawn()'s env option.
+  return { ...env, ...overrides } as NodeJS.ProcessEnv;
+}

--- a/tests/unit/infrastructure/services/deployment/deployment.service.test.ts
+++ b/tests/unit/infrastructure/services/deployment/deployment.service.test.ts
@@ -95,6 +95,28 @@ describe('DeploymentService', () => {
       );
     });
 
+    it('should scrub cli-only env vars (NEXT_ASSET_PREFIX, PORT) from the spawned dev server', () => {
+      const prevPrefix = process.env.NEXT_ASSET_PREFIX;
+      const prevPort = process.env.PORT;
+      process.env.NEXT_ASSET_PREFIX = '/cli';
+      process.env.PORT = '3000';
+      try {
+        service.start('feature-1', '/project/path');
+
+        const spawnCall = (deps.spawn as ReturnType<typeof vi.fn>).mock.calls[0];
+        const env = spawnCall[2].env as NodeJS.ProcessEnv;
+        expect(env.NEXT_ASSET_PREFIX).toBeUndefined();
+        expect(env.PORT).toBeUndefined();
+        // Still wires through the recovery guard.
+        expect(env.SHEP_SKIP_RECOVERY).toBe('1');
+      } finally {
+        if (prevPrefix === undefined) delete process.env.NEXT_ASSET_PREFIX;
+        else process.env.NEXT_ASSET_PREFIX = prevPrefix;
+        if (prevPort === undefined) delete process.env.PORT;
+        else process.env.PORT = prevPort;
+      }
+    });
+
     it('should store entry in Map with Booting state', () => {
       service.start('feature-1', '/project/path');
 

--- a/tests/unit/infrastructure/services/deployment/dev-server-env.test.ts
+++ b/tests/unit/infrastructure/services/deployment/dev-server-env.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import {
+  DEV_SERVER_ENV_BLOCKLIST,
+  buildDevServerEnv,
+} from '@/infrastructure/services/deployment/dev-server-env.js';
+
+describe('buildDevServerEnv', () => {
+  it('strips cli-only vars that must not leak into user dev servers', () => {
+    const base = {
+      PATH: '/usr/bin',
+      NODE_ENV: 'production' as const,
+      NEXT_ASSET_PREFIX: '/cli',
+      PORT: '3000',
+      CLAUDE_CODE_OAUTH_TOKEN: 'secret',
+      ANTHROPIC_API_KEY: 'secret',
+      ANTHROPIC_AUTH_TOKEN: 'secret',
+    };
+
+    const env = buildDevServerEnv(base);
+
+    for (const key of DEV_SERVER_ENV_BLOCKLIST) {
+      expect(env[key]).toBeUndefined();
+    }
+    // Unrelated vars are preserved.
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.NODE_ENV).toBe('production');
+  });
+
+  it('keeps HOST/HOSTNAME (needed so dev servers bind 0.0.0.0 for the preview proxy)', () => {
+    const env = buildDevServerEnv({ HOST: '0.0.0.0', HOSTNAME: '0.0.0.0' });
+    expect(env.HOST).toBe('0.0.0.0');
+    expect(env.HOSTNAME).toBe('0.0.0.0');
+  });
+
+  it('applies overrides on top of the scrubbed env', () => {
+    const env = buildDevServerEnv({ NEXT_ASSET_PREFIX: '/cli' }, { SHEP_SKIP_RECOVERY: '1' });
+    expect(env.NEXT_ASSET_PREFIX).toBeUndefined();
+    expect(env.SHEP_SKIP_RECOVERY).toBe('1');
+  });
+
+  it('does not mutate the input env', () => {
+    const base = { NEXT_ASSET_PREFIX: '/cli' };
+    buildDevServerEnv(base);
+    expect(base.NEXT_ASSET_PREFIX).toBe('/cli');
+  });
+});


### PR DESCRIPTION
## Problem

Previewed dev servers on `<port>-<orgHex>.preview.shep.bot` loaded unstyled, with the browser console full of:

```
GET /cli/_next/static/chunks/*.js   404
GET /cli/_next/static/chunks/*.css  404
```

## Root cause

In the cloud org-runner pod, the cli process runs with pod-wide `NEXT_ASSET_PREFIX=/cli` and `PORT=3000` (so the cli's own Next.js UI is served correctly behind shep-cloud's `/cli` proxy). `DeploymentService.start()` spawned user dev servers with `env: { ...process.env }`, so a user's **Next.js dev server inherited `NEXT_ASSET_PREFIX=/cli`** → it emitted `/cli/_next/...` asset URLs → those 404 on the preview origin because a Next server serves its static assets at `/_next/...`, not `/cli/_next/...`.

Confirmed in prod: the failing requests' `Referer` was the preview host, and the dev-server process (`/bin/sh -c bun run dev`, pid 117) had `NEXT_ASSET_PREFIX=/cli` and `PORT=3000` in `/proc/<pid>/environ`.

The org-runner `env-scrub` PATH wrappers were supposed to prevent this, but they only intercept `npm/pnpm/yarn/bun/npx` resolved by name and are **bypassed** when the binary (here `bun`, or a globally-installed pnpm in `/data/.npm-global/bin`) resolves ahead of `/usr/local/sbin`.

## Fix

New `buildDevServerEnv()` deterministically strips cli-only vars (`NEXT_ASSET_PREFIX`, `PORT`, and the Anthropic creds) from the env at the spawn point — independent of PATH. Used for both the dependency install and the dev-server spawn. `HOST`/`HOSTNAME` are deliberately kept (the pod sets them to `0.0.0.0` so the preview proxy can reach the dev server on the pod IP).

## Tests

- `dev-server-env.test.ts` — unit tests for the helper (strips blocklist, keeps HOST/HOSTNAME, applies overrides, no input mutation).
- `deployment.service.test.ts` — asserts the spawned dev server's env has no `NEXT_ASSET_PREFIX`/`PORT` and still carries `SHEP_SKIP_RECOVERY`.

## Verification

- `pnpm vitest run tests/.../deployment/` — 105 passed ✅
- `pnpm typecheck` ✅  ·  `eslint` on changed files ✅  ·  `pnpm build` ✅

## Rollout

Ships to org pods via the next org-runner image (core.pin bump → rebuild). Existing dev servers must be restarted to pick up the scrubbed env. Note: shep-cloud PR #22 (mid-session image-roll) is a separate, unrelated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)