### PR TITLE
docs: add help texts to aspm commands

### DIFF
--- a/src/presentation/cli/commands/aspm/aspm-ai-review-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-ai-review-command.ts
@@ -42,7 +42,14 @@ interface AiReviewGraduateOpts {
 }
 
 export function createAspmAiReviewCommand(): Command {
-  const cmd = new Command('ai-review').description('Triage AI-change risk signals');
+  const cmd = new Command('ai-review').description('Triage AI-change risk signals').addHelpText(
+    'after',
+    `
+Examples:
+  $ shep aspm ai-review list --app my-app --state Open --limit 50
+  $ shep aspm ai-review dismiss sig_123 --actor "Jane Doe" --justification "Intentional test code"
+  $ shep aspm ai-review graduate sig_123 --owner user_456`
+  );
 
   cmd
     .command('list')

--- a/src/presentation/cli/commands/aspm/aspm-campaigns-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-campaigns-command.ts
@@ -54,7 +54,15 @@ interface CampaignsProgressOpts {
 }
 
 export function createAspmCampaignsCommand(): Command {
-  const cmd = new Command('campaigns').description('Manage ASPM remediation campaigns');
+  const cmd = new Command('campaigns').description('Manage ASPM remediation campaigns').addHelpText(
+    'after',
+    `
+Examples:
+  $ shep aspm campaigns list --status Active --owner user_123
+  $ shep aspm campaigns create --name "Q3 Cleanup" --description "Fix high severity bugs" --severity Critical,High
+  $ shep aspm campaigns close cmp_123 --status Completed
+  $ shep aspm campaigns progress cmp_123`
+  );
 
   cmd
     .command('list')

--- a/src/presentation/cli/commands/aspm/aspm-exceptions-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-exceptions-command.ts
@@ -24,7 +24,13 @@ interface ListExpiringOpts {
 }
 
 export function createAspmExceptionsCommand(): Command {
-  const cmd = new Command('exceptions').description('Manage ASPM risk exceptions');
+  const cmd = new Command('exceptions').description('Manage ASPM risk exceptions').addHelpText(
+    'after',
+    `
+Examples:
+  $ shep aspm exceptions list-expiring --within 14
+  $ shep aspm exceptions list-expiring --json`
+  );
 
   cmd
     .command('list-expiring')

--- a/src/presentation/cli/commands/aspm/aspm-findings-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-findings-command.ts
@@ -42,8 +42,16 @@ interface FindingsShowOptions {
 }
 
 export function createAspmFindingsCommand(): Command {
-  const cmd = new Command('findings').description('List and inspect ASPM security findings');
-
+  const cmd = new Command('findings')
+    .description('List and inspect ASPM security findings')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm findings list --app my-app --severity Critical,High
+  $ shep aspm findings list --owner user_123 --state Open --kev --limit 25
+  $ shep aspm findings show fnd_abc123 --json`
+    );
   cmd
     .command('list')
     .description('List findings (paginated, filterable)')

--- a/src/presentation/cli/commands/aspm/aspm-ingest-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-ingest-command.ts
@@ -53,6 +53,14 @@ export function createAspmIngestCommand(): Command {
     .option('--sarif <file>', 'Path to a SARIF v2.1.0 document')
     .option('--sbom <file>', 'Path to a CycloneDX 1.5+ SBOM document')
     .option('--json', 'Emit a structured JSON summary on stdout')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm ingest --sarif results.sarif --application my-app
+  $ shep aspm ingest --sbom sbom.json --application my-app
+  $ shep aspm ingest --sarif results.sarif --application my-app --json`
+    )
     .action(async (options: IngestOptions) => {
       try {
         if (!options.sarif && !options.sbom) {

--- a/src/presentation/cli/commands/aspm/aspm-posture-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-posture-command.ts
@@ -33,6 +33,14 @@ export function createAspmPostureCommand(): Command {
     .option('--app <slug>', 'Show per-application posture')
     .option('--top <n>', 'Number of top at-risk apps to include', '5')
     .option('--json', 'Emit JSON instead of a formatted view')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm posture
+  $ shep aspm posture --app my-app
+  $ shep aspm posture --top 10 --json`
+    )
     .action(async (opts: PostureOptions) => {
       try {
         if (opts.app) {

--- a/src/presentation/cli/commands/aspm/aspm-scan-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-scan-command.ts
@@ -71,6 +71,14 @@ function buildCommand(
       'Comma-separated stages to run (sbom,sca,secrets,sast,container,iac)'
     )
     .option('--json', 'Emit a structured JSON summary on stdout')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm \${name} --app my-app
+  $ shep aspm \${name} --app my-app --stages sbom,secrets,sast
+  $ shep aspm \${name} --app my-app --json`
+    )
     .action(async (options: ScanOptions) => {
       try {
         const resolved = await resolveApplication(options.app);


### PR DESCRIPTION
hey, saw this issue to add help text examples for the new aspm commands. added the `.addHelpText('after', ...)` block to all 7 command files as described. let me know if any of the examples need adjusting!