### PR TITLE
fix(release): pin evidence URLs to release tag, validate tagline against commit types

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -921,3 +921,22 @@ How to apply:
 - Inventory / list / explorer views: include every non-Archived, non-deleted Feature. Render `branch` as the secondary identifier.
 - Scan / build / deploy actions: when the action requires an on-disk path, check `worktreePath` per row at action time and disable the action (or fall back) when it is missing — do not pre-filter the row out of the list.
 - Tests: pin down the "row with null worktreePath still appears" case explicitly. It is the more common shape in real data.
+
+## Release-notes generator: ground the tagline in commit types, pin evidence to an immutable ref
+
+Two bugs shipped together in the v1.210.0 GitHub release (custom `scripts/release-notes-*.mjs` semantic-release plugin):
+
+1. **Tagline contradicted the changelog.** Claude wrote _"Under the hood maintenance and housekeeping — no user-facing changes…"_ for a release whose only commit was a `feat` (gated behind a feature flag). A flagged feature still ships. The prompt let Claude reason "behind a flag ⇒ internal", and nothing validated the result against the actual commit types.
+2. **Evidence images 404'd.** PR bodies embedded `raw.githubusercontent.com/owner/repo/<feature-branch>/specs/.../evidence/*.png`. After squash-merge the branch is deleted ⇒ broken images. The extractor added PR-body URLs verbatim.
+
+Fixes:
+
+- `buildPrompt` now branches on `hasUserFacingChanges` (any feat/fix/perf) and explicitly forbids "maintenance / housekeeping / under the hood / behind the scenes / no user-facing changes" framings for user-facing releases. Plus a post-generation guard (`isMaintenanceOnlyFraming`) rejects a contradictory tagline and falls back to the static one.
+- `normalizeRepoMediaUrl` rewrites any repo-hosted raw/blob URL to the immutable release tag (`nextRelease.gitTag`), threaded through as `ref`. Bare `specs|docs|evidence` paths now also pin to the tag, not `main`.
+
+Rules:
+
+- A git **ref can contain slashes** (`feat/aspm-platform`). You cannot split ref-from-path positionally in a `raw.githubusercontent.com/owner/repo/<ref>/<path>` URL. Recover the path by locating the first known repo root segment (`specs`/`docs`/`evidence`), not by `slice(3)`.
+- Anything permanent (release notes, changelog) must reference an **immutable ref** (tag or commit SHA), never a branch — branches get deleted.
+- When an LLM writes user-facing copy from structured data, **validate the output against that same data** before publishing. Don't trust the prompt alone; add a deterministic guard that falls back on contradiction.
+- `.mjs` scripts under ESLint need browser/Node globals declared: `/* global fetch, URL */`.

--- a/scripts/release-notes-claude.mjs
+++ b/scripts/release-notes-claude.mjs
@@ -37,12 +37,53 @@ function stripMarkdownLinks(subject) {
   return String(subject).replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
 }
 
+/**
+ * Does this release ship anything a user would see? `feat`/`fix`/`perf`
+ * commits all surface in the release's changelog sections, so a tagline that
+ * calls the release "maintenance only" / "no user-facing changes" would
+ * directly contradict the notes printed right below it.
+ */
+function hasUserFacingChanges(commits) {
+  return (commits || []).some((c) => c && RELEVANT_COMMIT_TYPES.has(c.type));
+}
+
+// Framings that are only honest for a chore-only release. If the release
+// actually ships features/fixes, a tagline matching any of these contradicts
+// the changelog and must be rejected in favor of the static fallback.
+const MAINTENANCE_ONLY_PATTERNS = [
+  /no user-facing/i,
+  /under the hood/i,
+  /housekeeping/i,
+  /maintenance (?:release|only|and)/i,
+  /nothing user-facing/i,
+  /behind the scenes/i,
+];
+
+function isMaintenanceOnlyFraming(tagline) {
+  return MAINTENANCE_ONLY_PATTERNS.some((re) => re.test(tagline));
+}
+
 function buildPrompt({ commits, version }) {
   const summary = summarizeCommits(commits) || '- (chore-only release)';
+  const userFacing = hasUserFacingChanges(commits);
+  const naturePromptLines = userFacing
+    ? [
+        'This release SHIPS user-facing changes — the commits above appear as',
+        'Features / Bug Fixes / Performance sections in the published notes. Your',
+        'tagline MUST reflect that. NEVER describe it as "maintenance",',
+        '"housekeeping", "under the hood", "behind the scenes", or "no user-facing',
+        'changes" — even if a change is behind a feature flag, it still shipped.',
+      ]
+    : [
+        'This is a chore-only release with no feature/fix/perf commits. Keep the',
+        'tagline modest and honest — do not invent user-facing features.',
+      ];
   return [
     `You are writing the one-line tagline for the v${version} release of Shep — an autonomous AI-native SDLC platform that runs parallel AI agents in isolated git worktrees to automate the dev cycle from idea to deploy.`,
     '',
     'The tagline appears immediately below the version header in the GitHub release, before the changelog. It should capture the SOUL of THIS release based on the actual changes — not generic boilerplate.',
+    '',
+    ...naturePromptLines,
     '',
     'Commits in this release:',
     summary,
@@ -174,6 +215,12 @@ export async function generateTagline({
       logger.warn?.('[release-notes] Claude returned empty tagline; using static tagline.');
       return null;
     }
+    if (hasUserFacingChanges(commits) && isMaintenanceOnlyFraming(tagline)) {
+      logger.warn?.(
+        `[release-notes] Claude tagline framed a user-facing release as maintenance ("${tagline}"); using static tagline.`
+      );
+      return null;
+    }
     logger.info?.(`[release-notes] Generated tagline via Claude: ${tagline}`);
     return tagline;
   } catch (err) {
@@ -187,5 +234,7 @@ export const __test__ = {
   postProcessTagline,
   summarizeCommits,
   hasAuthCredentials,
+  hasUserFacingChanges,
+  isMaintenanceOnlyFraming,
   STATIC_TAGLINE,
 };

--- a/scripts/release-notes-evidence.mjs
+++ b/scripts/release-notes-evidence.mjs
@@ -1,4 +1,4 @@
-/* global fetch */
+/* global fetch, URL */
 
 /**
  * Evidence extraction for release notes.
@@ -52,6 +52,82 @@ function isVideoUrl(url) {
   return VIDEO_EXTS.some((ext) => lower.endsWith(`.${ext}`));
 }
 
+const RAW_HOST = 'raw.githubusercontent.com';
+const GITHUB_HOST = 'github.com';
+const BLOB_OR_RAW_SEGMENTS = new Set(['blob', 'raw']);
+
+// Top-level repo directories evidence lives under. Used to find where the
+// (possibly multi-segment) git ref ends and the repo-relative path begins —
+// a branch like `feat/aspm-platform` is two path segments, so we cannot split
+// ref-from-path positionally. Kept in sync with REPO_EVIDENCE_PATH_RE.
+const EVIDENCE_PATH_ROOTS = new Set(['specs', 'docs', 'evidence']);
+
+/**
+ * Recover the repo-relative path from a GitHub URL's path segments, tolerating
+ * multi-segment branch refs. Prefers the first known evidence root; falls back
+ * to assuming the ref is a single segment starting at `fallbackStart`.
+ */
+function recoverRepoPath(segments, fallbackStart) {
+  for (let i = fallbackStart; i < segments.length; i += 1) {
+    if (EVIDENCE_PATH_ROOTS.has(segments[i])) {
+      return segments.slice(i).join('/');
+    }
+  }
+  return segments.slice(fallbackStart).join('/');
+}
+
+/**
+ * Rewrite a GitHub-hosted media URL that points at THIS repo so it references
+ * a stable, permanent ref (the release tag / commit) instead of whatever ref
+ * the PR author happened to embed.
+ *
+ * PR bodies frequently embed evidence with branch-pinned URLs like
+ * `raw.githubusercontent.com/owner/repo/feat/my-branch/...png`. Once the PR is
+ * squash-merged the feature branch is deleted and the image 404s. Pinning to
+ * the release ref keeps the image resolving forever, because the evidence
+ * files committed in that PR exist at the release commit on the default branch.
+ *
+ * Non-repo URLs (external CDNs, github user-attachments, user-images) are
+ * returned unchanged — those are already immutable.
+ *
+ * @param {string} url
+ * @param {{ owner?: string, repo?: string, ref?: string }} opts
+ * @returns {string}
+ */
+export function normalizeRepoMediaUrl(url, { owner, repo, ref } = {}) {
+  if (!url || !owner || !repo || !ref) return url;
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  const repoMatches =
+    `${segments[0]}/${segments[1]}`.toLowerCase() === `${owner}/${repo}`.toLowerCase();
+  if (!repoMatches) return url;
+
+  // raw.githubusercontent.com/{owner}/{repo}/{ref}/{path...}
+  if (parsed.hostname === RAW_HOST && segments.length >= 4) {
+    const path = recoverRepoPath(segments, 3);
+    return `https://${RAW_HOST}/${owner}/${repo}/${ref}/${path}${parsed.search}`;
+  }
+
+  // github.com/{owner}/{repo}/(blob|raw)/{ref}/{path...} → serve raw bytes
+  if (
+    parsed.hostname === GITHUB_HOST &&
+    segments.length >= 5 &&
+    BLOB_OR_RAW_SEGMENTS.has(segments[2])
+  ) {
+    const path = recoverRepoPath(segments, 4);
+    return `https://${RAW_HOST}/${owner}/${repo}/${ref}/${path}`;
+  }
+
+  return url;
+}
+
 function deriveAlt(url) {
   const fileName = url.split('?')[0].split('/').pop() || 'evidence';
   return (
@@ -66,25 +142,28 @@ function deriveAlt(url) {
  * Extract evidence URLs from a PR body or commit body string.
  *
  * @param {string} body — raw markdown body (PR description, commit body)
- * @param {{ owner?: string, repo?: string, defaultBranch?: string }} [opts] — repo info
+ * @param {{ owner?: string, repo?: string, defaultBranch?: string, ref?: string }} [opts] — repo info.
+ *        `ref` is the stable release ref (tag/commit) that branch-pinned repo
+ *        URLs are normalized to; falls back to `defaultBranch`.
  * @returns {Array<{ url: string, alt: string, kind: 'image' | 'video' }>}
  */
 export function extractEvidenceFromBody(body, opts = {}) {
   const { owner, repo, defaultBranch = 'main' } = opts;
+  const ref = opts.ref || defaultBranch;
   if (typeof body !== 'string' || body.trim() === '') return [];
 
   const evidence = [];
   const seen = new Set();
 
-  function add(url, alt) {
-    if (!url) return;
-    const trimmed = url.trim();
-    if (seen.has(trimmed)) return;
-    seen.add(trimmed);
+  function add(rawUrl, alt) {
+    if (!rawUrl) return;
+    const url = normalizeRepoMediaUrl(rawUrl.trim(), { owner, repo, ref });
+    if (seen.has(url)) return;
+    seen.add(url);
     evidence.push({
-      url: trimmed,
-      alt: alt && alt.trim() ? alt.trim() : deriveAlt(trimmed),
-      kind: isVideoUrl(trimmed) ? 'video' : 'image',
+      url,
+      alt: alt && alt.trim() ? alt.trim() : deriveAlt(url),
+      kind: isVideoUrl(url) ? 'video' : 'image',
     });
   }
 
@@ -107,7 +186,7 @@ export function extractEvidenceFromBody(body, opts = {}) {
   if (owner && repo) {
     for (const match of body.matchAll(REPO_EVIDENCE_PATH_RE)) {
       const path = match[1];
-      const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${defaultBranch}/${path}`;
+      const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${path}`;
       add(rawUrl);
     }
   }
@@ -195,7 +274,7 @@ export async function fetchPrBody({ owner, repo, prNumber, token, fetcher = fetc
  * @returns The same commits array, mutated in place.
  */
 export async function attachEvidenceToCommits(commits, options = {}) {
-  const { owner, repo, token, fetcher, defaultBranch } = options;
+  const { owner, repo, token, fetcher, defaultBranch, ref } = options;
   if (!Array.isArray(commits) || commits.length === 0) return commits;
   if (!owner || !repo || !token) return commits;
 
@@ -207,7 +286,7 @@ export async function attachEvidenceToCommits(commits, options = {}) {
     for (const prNumber of prNumbers) {
       const body = await fetchPrBody({ owner, repo, prNumber, token, fetcher });
       if (!body) continue;
-      const items = extractEvidenceFromBody(body, { owner, repo, defaultBranch });
+      const items = extractEvidenceFromBody(body, { owner, repo, defaultBranch, ref });
       all.push(...items);
       if (all.length >= MAX_EVIDENCE_PER_COMMIT) break;
     }
@@ -237,5 +316,6 @@ export const __test__ = {
   REPO_EVIDENCE_PATH_RE,
   isVideoUrl,
   deriveAlt,
+  normalizeRepoMediaUrl,
   MAX_EVIDENCE_PER_COMMIT,
 };

--- a/scripts/release-notes-plugin.mjs
+++ b/scripts/release-notes-plugin.mjs
@@ -70,12 +70,17 @@ export async function generateNotes(pluginConfig = {}, context = {}) {
 
   if (repoInfo && token) {
     try {
+      const defaultBranch = pluginConfig.defaultBranch || DEFAULT_BRANCH;
+      // Pin evidence URLs to the immutable release tag so branch-pinned image
+      // links in PR bodies keep resolving after the feature branch is deleted.
+      const ref = pluginConfig.ref || context.nextRelease?.gitTag || defaultBranch;
       await attachEvidenceToCommits(augmentedCommits, {
         owner: repoInfo.owner,
         repo: repoInfo.repo,
         token,
         fetcher: pluginConfig.fetcher,
-        defaultBranch: pluginConfig.defaultBranch || DEFAULT_BRANCH,
+        defaultBranch,
+        ref,
       });
     } catch (err) {
       logger.warn?.(`[release-notes] evidence enrichment failed: ${err?.message ?? err}`);

--- a/tests/unit/scripts/release-notes-claude.test.ts
+++ b/tests/unit/scripts/release-notes-claude.test.ts
@@ -15,8 +15,18 @@ const internals = __test__ as unknown as {
   postProcessTagline: (raw: string) => string | null;
   summarizeCommits: (commits: unknown[]) => string;
   hasAuthCredentials: (env: Record<string, string | undefined>) => boolean;
+  hasUserFacingChanges: (commits: unknown[]) => boolean;
+  isMaintenanceOnlyFraming: (tagline: string) => boolean;
+  buildPrompt: (args: { commits: unknown[]; version: string }) => string;
 };
-const { postProcessTagline, summarizeCommits, hasAuthCredentials } = internals;
+const {
+  postProcessTagline,
+  summarizeCommits,
+  hasAuthCredentials,
+  hasUserFacingChanges,
+  isMaintenanceOnlyFraming,
+  buildPrompt,
+} = internals;
 
 function makeQuery(messages: unknown[]) {
   return vi.fn().mockReturnValue({
@@ -98,7 +108,73 @@ describe('hasAuthCredentials', () => {
   });
 });
 
+describe('hasUserFacingChanges', () => {
+  it('is true when any feat/fix/perf commit is present', () => {
+    expect(hasUserFacingChanges([{ type: 'chore' }, { type: 'feat' }])).toBe(true);
+    expect(hasUserFacingChanges([{ type: 'fix' }])).toBe(true);
+  });
+
+  it('is false for a chore/docs-only release', () => {
+    expect(hasUserFacingChanges([{ type: 'chore' }, { type: 'docs' }])).toBe(false);
+    expect(hasUserFacingChanges([])).toBe(false);
+  });
+});
+
+describe('isMaintenanceOnlyFraming', () => {
+  it('flags the contradictory framings that shipped in v1.210.0', () => {
+    expect(
+      isMaintenanceOnlyFraming(
+        "Under the hood maintenance and housekeeping — no user-facing changes, just a cleaner foundation for what's next."
+      )
+    ).toBe(true);
+    expect(isMaintenanceOnlyFraming('Behind the scenes cleanup')).toBe(true);
+  });
+
+  it('does not flag a legitimate feature tagline', () => {
+    expect(isMaintenanceOnlyFraming('Ship ASPM — _security posture_ at a glance.')).toBe(false);
+  });
+});
+
+describe('buildPrompt', () => {
+  it('forbids maintenance framing when the release is user-facing', () => {
+    const prompt = buildPrompt({
+      commits: [{ type: 'feat', subject: 'add aspm' }],
+      version: '1.210.0',
+    });
+    expect(prompt).toContain('SHIPS user-facing changes');
+    expect(prompt).toContain('behind a feature flag');
+  });
+
+  it('allows a modest framing for a chore-only release', () => {
+    const prompt = buildPrompt({
+      commits: [{ type: 'chore', subject: 'bump deps' }],
+      version: '1.0.0',
+    });
+    expect(prompt).toContain('chore-only release');
+  });
+});
+
 describe('generateTagline', () => {
+  it('rejects a maintenance-framed tagline when the release ships features', async () => {
+    const claudeQuery = makeQuery([
+      {
+        type: 'result',
+        subtype: 'success',
+        result: 'Under the hood maintenance — no user-facing changes.',
+      },
+    ]);
+
+    const tagline = await generateTagline({
+      commits: [{ type: 'feat', subject: 'add aspm module' }],
+      version: '1.210.0',
+      claudeQuery,
+      env: TEST_ENV,
+      logger: { info: () => undefined, warn: () => undefined },
+    });
+
+    expect(tagline).toBeNull();
+  });
+
   it('returns the Claude result string on success', async () => {
     const claudeQuery = makeQuery([
       {

--- a/tests/unit/scripts/release-notes-evidence.test.ts
+++ b/tests/unit/scripts/release-notes-evidence.test.ts
@@ -12,6 +12,7 @@ import {
   getPrNumbersFromCommit,
   fetchPrBody,
   attachEvidenceToCommits,
+  normalizeRepoMediaUrl,
 } from '../../../scripts/release-notes-evidence.mjs';
 
 const REPO = { owner: 'shep-ai', repo: 'shep' };
@@ -111,6 +112,81 @@ describe('extractEvidenceFromBody', () => {
     const body = '`specs/095-feature/evidence/screenshot.png`';
     const evidence = extractEvidenceFromBody(body, {});
     expect(evidence).toEqual([]);
+  });
+
+  it('rewrites branch-pinned repo image URLs to the stable release ref', () => {
+    const body =
+      '![dash](https://raw.githubusercontent.com/shep-ai/shep/feat/aspm-platform/specs/098-aspm-platform/evidence/app.png)';
+    const evidence = extractEvidenceFromBody(body, { ...REPO, ref: 'v1.210.0' });
+
+    expect(evidence[0].url).toBe(
+      'https://raw.githubusercontent.com/shep-ai/shep/v1.210.0/specs/098-aspm-platform/evidence/app.png'
+    );
+  });
+
+  it('pins bare repo evidence paths to ref when provided', () => {
+    const body = '`specs/098-aspm-platform/evidence/app.png`';
+    const evidence = extractEvidenceFromBody(body, { ...REPO, ref: 'v1.210.0' });
+
+    expect(evidence[0].url).toBe(
+      'https://raw.githubusercontent.com/shep-ai/shep/v1.210.0/specs/098-aspm-platform/evidence/app.png'
+    );
+  });
+
+  it('leaves external (non-repo) image URLs untouched', () => {
+    const body = '![x](https://cdn.example.com/feat/aspm/shot.png)';
+    const evidence = extractEvidenceFromBody(body, { ...REPO, ref: 'v1.210.0' });
+    expect(evidence[0].url).toBe('https://cdn.example.com/feat/aspm/shot.png');
+  });
+});
+
+describe('normalizeRepoMediaUrl', () => {
+  const opts = { owner: 'shep-ai', repo: 'shep', ref: 'v1.210.0' };
+
+  it('rewrites a branch-pinned raw URL to the ref', () => {
+    expect(
+      normalizeRepoMediaUrl(
+        'https://raw.githubusercontent.com/shep-ai/shep/feat/x/docs/a.png',
+        opts
+      )
+    ).toBe('https://raw.githubusercontent.com/shep-ai/shep/v1.210.0/docs/a.png');
+  });
+
+  it('preserves a query string on the raw URL', () => {
+    expect(
+      normalizeRepoMediaUrl(
+        'https://raw.githubusercontent.com/shep-ai/shep/main/docs/a.png?token=abc',
+        opts
+      )
+    ).toBe('https://raw.githubusercontent.com/shep-ai/shep/v1.210.0/docs/a.png?token=abc');
+  });
+
+  it('converts a github.com blob URL to a raw URL pinned at the ref', () => {
+    expect(
+      normalizeRepoMediaUrl('https://github.com/shep-ai/shep/blob/some-branch/docs/a.png', opts)
+    ).toBe('https://raw.githubusercontent.com/shep-ai/shep/v1.210.0/docs/a.png');
+  });
+
+  it('does not touch URLs for a different repo', () => {
+    const url = 'https://raw.githubusercontent.com/other/repo/main/docs/a.png';
+    expect(normalizeRepoMediaUrl(url, opts)).toBe(url);
+  });
+
+  it('does not touch non-github hosts or user-attachments', () => {
+    const cdn = 'https://cdn.example.com/x.png';
+    const attachment = 'https://github.com/user-attachments/assets/abc123';
+    expect(normalizeRepoMediaUrl(cdn, opts)).toBe(cdn);
+    expect(normalizeRepoMediaUrl(attachment, opts)).toBe(attachment);
+  });
+
+  it('is a no-op when ref is missing or url is malformed', () => {
+    expect(normalizeRepoMediaUrl('not a url', opts)).toBe('not a url');
+    expect(
+      normalizeRepoMediaUrl('https://raw.githubusercontent.com/shep-ai/shep/main/a.png', {
+        owner: 'shep-ai',
+        repo: 'shep',
+      })
+    ).toBe('https://raw.githubusercontent.com/shep-ai/shep/main/a.png');
   });
 });
 
@@ -247,6 +323,31 @@ describe('attachEvidenceToCommits', () => {
     });
     expect(commits[1]).not.toHaveProperty('evidenceMarkdown');
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes branch-pinned evidence URLs to the release ref', async () => {
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        body: '![dash](https://raw.githubusercontent.com/shep-ai/shep/feat/aspm/specs/098/evidence/app.png)',
+      }),
+    });
+    const commits = [{ type: 'feat', subject: 'add aspm (#628)', references: [{ issue: '628' }] }];
+
+    await attachEvidenceToCommits(commits as unknown[] as never[], {
+      owner: 'shep-ai',
+      repo: 'shep',
+      token: 'tok',
+      ref: 'v1.210.0',
+      fetcher: fetcher as unknown as typeof fetch,
+    });
+
+    expect(commits[0]).toMatchObject({
+      evidenceMarkdown: [
+        '![dash](https://raw.githubusercontent.com/shep-ai/shep/v1.210.0/specs/098/evidence/app.png)',
+      ],
+    });
   });
 
   it('is a no-op when token / repo are missing (graceful degrade)', async () => {

--- a/tests/unit/scripts/release-notes-plugin.test.ts
+++ b/tests/unit/scripts/release-notes-plugin.test.ts
@@ -178,6 +178,29 @@ describe('generateNotes (plugin)', () => {
     expect(notes).toContain('![dark-mode](https://example.com/screenshot.png)');
   });
 
+  it('rewrites branch-pinned evidence URLs to the release tag', async () => {
+    const context = makeContext({
+      commits: [makeRawCommit()],
+      env: {
+        CLAUDE_CODE_OAUTH_TOKEN: 'tok',
+        GITHUB_TOKEN: 'gh',
+      },
+    });
+    const fetcher = fakeFetcher({
+      '596':
+        '![dash](https://raw.githubusercontent.com/shep-ai/shep/feat/my-branch/specs/098/evidence/app.png)',
+    });
+    const claudeQuery = fakeClaudeQuery('shipped tabs');
+
+    const notes = await generateNotes({ claudeQuery, fetcher }, context as never);
+
+    // makeContext sets nextRelease.gitTag to v1.200.0
+    expect(notes).toContain(
+      '![dash](https://raw.githubusercontent.com/shep-ai/shep/v1.200.0/specs/098/evidence/app.png)'
+    );
+    expect(notes).not.toContain('feat/my-branch');
+  });
+
   it('falls back to the static tagline when Claude returns nothing', async () => {
     const context = makeContext({
       commits: [makeRawCommit()],


### PR DESCRIPTION
## What

Fixes two bugs in the release-notes generator that shipped in v1.210.0:

1. **Evidence images 404 after branch deletion.** PR bodies embed `raw.githubusercontent.com/owner/repo/<feature-branch>/specs/.../evidence/*.png` URLs. After squash-merge, the feature branch is deleted and images break. Now rewrites all repo-hosted media URLs to the immutable release tag.
2. **Tagline contradicted the changelog.** Claude wrote "Under the hood maintenance — no user-facing changes" for a release with a `feat` commit (gated behind a feature flag). A flagged feature still ships. Now validates the tagline against actual commit types and rejects contradictory framings.

## Why

Closes the two bugs documented in LESSONS.md. The fixes ensure:
- Evidence images in release notes remain accessible forever (pinned to immutable ref)
- Release taglines honestly reflect what shipped (validated against commit types, not just LLM output)

## How

**Evidence URL normalization:**
- Added `normalizeRepoMediaUrl()` to rewrite branch-pinned GitHub URLs to the release tag
- Handles multi-segment branch refs (e.g., `feat/aspm-platform`) by locating known repo root segments (`specs`/`docs`/`evidence`) instead of positional splitting
- Converts `github.com/blob` URLs to `raw.githubusercontent.com` for consistency
- Leaves external CDN and user-attachment URLs untouched
- Threaded `ref` parameter through `extractEvidenceFromBody()` and `attachEvidenceToCommits()`

**Tagline validation:**
- Added `hasUserFacingChanges()` to detect feat/fix/perf commits
- Added `isMaintenanceOnlyFraming()` to flag contradictory language patterns
- Updated `buildPrompt()` to branch on user-facing status and explicitly forbid maintenance framings for feature releases
- Added post-generation guard in `generateTagline()` to reject contradictory taglines and fall back to static copy

## Testing

- Added 9 new unit tests covering URL normalization (raw/blob URLs, multi-segment refs, external URLs, query strings)
- Added 4 new tests for tagline validation (user-facing detection, maintenance framing detection, prompt branching)
- Added integration test verifying evidence URLs are rewritten in the full plugin flow
- All existing tests pass; no regressions

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (new tests added)
- [x] Updated LESSONS.md with the pattern and rules learned
- [x] Commit messages follow Conventional Commits (`fix(release)`)

https://claude.ai/code/session_01DYeF6rfQ5oc4ppWCFoPG5o