### PR TITLE
docs(cli): add ASPM help examples

### DIFF
--- a/src/presentation/cli/commands/aspm/aspm-ai-review-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-ai-review-command.ts
@@ -42,7 +42,14 @@ interface AiReviewGraduateOpts {
 }
 
 export function createAspmAiReviewCommand(): Command {
-  const cmd = new Command('ai-review').description('Triage AI-change risk signals');
+  const cmd = new Command('ai-review').description('Triage AI-change risk signals').addHelpText(
+    'after',
+    `
+Examples:
+  $ shep aspm ai-review list --app api --state Open --limit 50              Review open AI-change signals
+  $ shep aspm ai-review dismiss signal_123 --actor alice --justification "false positive"  Dismiss a signal
+  $ shep aspm ai-review graduate signal_123 --owner team-security --json    Create a finding from a signal`
+  );
 
   cmd
     .command('list')

--- a/src/presentation/cli/commands/aspm/aspm-campaigns-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-campaigns-command.ts
@@ -54,7 +54,15 @@ interface CampaignsProgressOpts {
 }
 
 export function createAspmCampaignsCommand(): Command {
-  const cmd = new Command('campaigns').description('Manage ASPM remediation campaigns');
+  const cmd = new Command('campaigns').description('Manage ASPM remediation campaigns').addHelpText(
+    'after',
+    `
+Examples:
+  $ shep aspm campaigns list --status Active --owner team-security          List active campaigns by owner
+  $ shep aspm campaigns create --name "Critical fixes" --description "Patch exposed secrets" --severity Critical,High --due 2026-07-01 --actor alice
+  $ shep aspm campaigns close campaign_123 --status Completed --actor alice --note "all findings resolved"
+  $ shep aspm campaigns progress campaign_123 --json                        Export progress metrics`
+  );
 
   cmd
     .command('list')

--- a/src/presentation/cli/commands/aspm/aspm-exceptions-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-exceptions-command.ts
@@ -24,7 +24,13 @@ interface ListExpiringOpts {
 }
 
 export function createAspmExceptionsCommand(): Command {
-  const cmd = new Command('exceptions').description('Manage ASPM risk exceptions');
+  const cmd = new Command('exceptions').description('Manage ASPM risk exceptions').addHelpText(
+    'after',
+    `
+Examples:
+  $ shep aspm exceptions list-expiring --within 30        Review exceptions expiring this month
+  $ shep aspm exceptions list-expiring --within 7 --json  Export exceptions expiring this week`
+  );
 
   cmd
     .command('list-expiring')

--- a/src/presentation/cli/commands/aspm/aspm-findings-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-findings-command.ts
@@ -42,7 +42,16 @@ interface FindingsShowOptions {
 }
 
 export function createAspmFindingsCommand(): Command {
-  const cmd = new Command('findings').description('List and inspect ASPM security findings');
+  const cmd = new Command('findings')
+    .description('List and inspect ASPM security findings')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm findings list --app api --severity Critical,High --limit 25  Review critical and high findings
+  $ shep aspm findings list --state Open --kev --json                       Export open KEV findings
+  $ shep aspm findings show finding_123 --json                              Inspect one finding`
+    );
 
   cmd
     .command('list')

--- a/src/presentation/cli/commands/aspm/aspm-ingest-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-ingest-command.ts
@@ -53,6 +53,13 @@ export function createAspmIngestCommand(): Command {
     .option('--sarif <file>', 'Path to a SARIF v2.1.0 document')
     .option('--sbom <file>', 'Path to a CycloneDX 1.5+ SBOM document')
     .option('--json', 'Emit a structured JSON summary on stdout')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm ingest --sarif reports/app.sarif --application api       Ingest SARIF findings
+  $ shep aspm ingest --sbom reports/bom.json --application api --json  Ingest an SBOM and print JSON`
+    )
     .action(async (options: IngestOptions) => {
       try {
         if (!options.sarif && !options.sbom) {

--- a/src/presentation/cli/commands/aspm/aspm-posture-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-posture-command.ts
@@ -33,6 +33,13 @@ export function createAspmPostureCommand(): Command {
     .option('--app <slug>', 'Show per-application posture')
     .option('--top <n>', 'Number of top at-risk apps to include', '5')
     .option('--json', 'Emit JSON instead of a formatted view')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm posture --top 10          Show the ten highest-risk applications
+  $ shep aspm posture --app api --json  Export one application's posture`
+    )
     .action(async (opts: PostureOptions) => {
       try {
         if (opts.app) {

--- a/src/presentation/cli/commands/aspm/aspm-scan-command.ts
+++ b/src/presentation/cli/commands/aspm/aspm-scan-command.ts
@@ -71,6 +71,13 @@ function buildCommand(
       'Comma-separated stages to run (sbom,sca,secrets,sast,container,iac)'
     )
     .option('--json', 'Emit a structured JSON summary on stdout')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep aspm scan --app web --stages sbom,secrets --json       Run selected stages and print JSON
+  $ shep aspm rescan --app api --stages secrets                 Re-run only the secrets stage`
+    )
     .action(async (options: ScanOptions) => {
       try {
         const resolved = await resolveApplication(options.app);


### PR DESCRIPTION
## What

Adds `Examples:` help blocks to the seven ASPM CLI command files called out in #734: `scan`/`rescan`, `findings`, `ai-review`, `exceptions`, `campaigns`, `posture`, and `ingest`.

## Why

Closes #734. The ASPM commands already expose useful flags, but their `--help` output did not show concrete usage examples. These examples make the command surface easier to discover without changing runtime behavior.

## Screenshots / Recording

N/A — non-UI change.

## Testing

```sh
pnpm validate
pnpm test:unit
pnpm test:int
pnpm build
```

I also verified the rendered CLI help output for:

```sh
pnpm --silent dev:cli aspm scan --help
pnpm --silent dev:cli aspm rescan --help
pnpm --silent dev:cli aspm findings --help
pnpm --silent dev:cli aspm ai-review --help
pnpm --silent dev:cli aspm exceptions --help
pnpm --silent dev:cli aspm campaigns --help
pnpm --silent dev:cli aspm posture --help
pnpm --silent dev:cli aspm ingest --help
```

Each command now shows an `Examples:` block.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` and `pnpm test:int` pass
- [x] `pnpm build` succeeds
- [x] No `application/` or `presentation/` file imports anything from `infrastructure/`
- [x] Commit messages follow Conventional Commits