### PR TITLE
docs: add MiMo Code competitor profile

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -69,6 +69,7 @@ Idea → Requirements → Research → Plan → Code → Tests → PR → CI →
 | [Gas Town](./gastown.md)        | Steve Yegge's multi-agent fleet orchestrator           | Frontier experimentation  |
 | [OpenHands](./openhands.md)     | Composable AI agent platform (formerly OpenDevin)      | Largest open-source agent |
 | [OpenCode](./opencode.md)       | Terminal AI coding agent with 120K+ stars              | Biggest community         |
+| [MiMo Code](./mimo-code.md)     | Xiaomi's terminal coding agent, OpenCode fork with cross-session memory | OpenCode-shaped, MIT |
 | [Aider](./aider.md)             | AI pair programming in the terminal                    | Git-first pioneer         |
 | [Cline](./cline.md)             | VS Code agent with plan/act modes                      | 4M+ installs              |
 | [Codex](./codex.md) | OpenAI's terminal coding agent | OpenAI ecosystem |
@@ -95,6 +96,7 @@ Every tool in this space taught us something:
 - **Gas Town** showed that parallel agent orchestration is the frontier
 - **Aider** demonstrated that git-first design matters
 - **Spec Kitty** confirmed that structured workflows beat ad-hoc prompting
+- **MiMo Code** showed that OpenCode forks can specialize on memory and voice without rewriting the agent loop
 - **OpenHands** showed the power of an open-source community around autonomous agents
 
 We built Shep to combine these insights: spec-driven lifecycle, parallel worktree isolation, configurable approval gates, agent-agnostic design, and a visual dashboard — all in one open-source CLI.

--- a/docs/competitors/mimo-code.md
+++ b/docs/competitors/mimo-code.md
@@ -1,0 +1,53 @@
+# MiMo Code
+
+> Xiaomi's OpenCode-based terminal coding agent with persistent memory for long-horizon tasks.
+
+|             |                                                                                 |
+| ----------- | ------------------------------------------------------------------------------- |
+| **GitHub**  | [github.com/XiaomiMiMo/MiMo-Code](https://github.com/XiaomiMiMo/MiMo-Code)      |
+| **Tagline** | "An open-source AI coding agent with cross-session memory."                     |
+| **Type**    | CLI (TypeScript, OpenCode fork)                                                 |
+| **Pricing** | Free (open source)                                                              |
+| **License** | MIT                                                                             |
+
+---
+
+## What It Does
+
+MiMo Code is a terminal-native coding assistant from Xiaomi's MiMo team. It reads and writes code, runs commands, manages Git, and uses persistent memory to carry project context across sessions while building on OpenCode's terminal-agent foundation.
+
+### Key Features
+
+- **Published benchmark results** — Xiaomi reports MiMo Code + MiMo-V2.5-Pro at 82% on SWE-bench Verified, 62% on SWE-bench Pro, and 73% on Terminal Bench 2
+- **Cross-session memory** — Maintains project memory, checkpoints, scratch notes, and per-task progress logs
+- **OpenCode lineage** — Keeps OpenCode's provider, TUI, LSP, MCP, and plugin base while adding Xiaomi-specific orchestration
+- **Voice input** — Supports streaming voice input for logged-in MiMo users
+- **Multiple agents** — Includes build, plan, and compose modes for coding, analysis, and specs-driven workflows
+- **MIT source license** — The GitHub repository ships under MIT, with hosted service and trademark terms documented separately
+
+---
+
+## How Shep Compares
+
+|                       | MiMo Code                  | Shep                   |
+| --------------------- | -------------------------- | ---------------------- |
+| **Language**          | TypeScript                 | TypeScript             |
+| **Interface**         | Terminal TUI               | CLI + Web dashboard    |
+| **Requirements**      | Compose workflow           | AI-generated PRD       |
+| **Research phase**    | Not highlighted            | Built-in               |
+| **Full SDLC**         | Agent loop + workflows     | Requirements → Merge   |
+| **Parallel features** | Subagents and Max Mode     | Git worktree isolation |
+| **Dashboard**         | Terminal only              | Interactive web graph  |
+| **CI fix loop**       | Not highlighted            | Automatic              |
+
+### What We Respect
+
+MiMo Code shows how an OpenCode fork can specialize around long-running state: memory files, checkpoints, task logs, and completion verification all target the point where single-session agents usually lose continuity.
+
+### Where Shep Differs
+
+MiMo Code is strongest as a terminal coding harness. Shep focuses on a broader feature-development lifecycle: requirements, research, parallel isolated implementation, review, CI repair, and merge readiness with a dashboard for tracking the work.
+
+---
+
+_Sources: [GitHub](https://github.com/XiaomiMiMo/MiMo-Code), [MiMo Code blog](https://mimo.xiaomi.com/blog/mimo-code-long-horizon), [MiMo Code product page](https://mimo.xiaomi.com/mimocode), [Hugging Face](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro)_


### PR DESCRIPTION
Closes #744.

## Summary
- add `docs/competitors/mimo-code.md` following the OpenCode-style competitor profile structure
- link MiMo Code from the Open Source CLI Tools table
- add a short What We Learned note about OpenCode forks specializing around memory and voice

## Source checks
- verified XiaomiMiMo/MiMo-Code README for memory, voice input, OpenCode lineage, and MIT licensing
- verified GitHub release `v0.1.0` was published on 2026-06-10
- inspected Xiaomi MiMo Code benchmark image from the official blog for 82% SWE-bench Verified, 62% SWE-bench Pro, and 73% Terminal Bench 2

## Verification
- `git diff --check`
- competitor profile acceptance Node check
- `pnpm exec prettier --check docs/competitors/mimo-code.md docs/competitors/README.md`
- `pnpm validate`