### PR TITLE
feat(agents): add Z.ai GLM-5.2 and GLM-5.1 to model catalog

### DIFF
--- a/.storybook/mocks/app/actions/get-all-agent-models.ts
+++ b/.storybook/mocks/app/actions/get-all-agent-models.ts
@@ -10,6 +10,8 @@ const CATALOG: { agentType: string; label: string; models: string[] }[] = [
       'claude-opus-4-6',
       'claude-sonnet-4-6',
       'claude-haiku-4-5',
+      'glm-5.2',
+      'glm-5.1',
     ],
   },
   {

--- a/packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts
@@ -13,6 +13,8 @@ export const CLAUDE_CODE_MODELS: string[] = [
   'claude-opus-4-6',
   'claude-sonnet-4-6',
   'claude-haiku-4-5',
+  'glm-5.2',
+  'glm-5.1',
 ];
 
 export const GEMINI_CLI_MODELS: string[] = [

--- a/src/presentation/web/lib/model-metadata.ts
+++ b/src/presentation/web/lib/model-metadata.ts
@@ -34,6 +34,10 @@ const MODEL_METADATA: Record<string, ModelMeta> = {
   'composer-1.5': { displayName: 'Composer 1.5', description: 'Multi-file editing' },
   'grok-code': { displayName: 'Grok Code', description: 'xAI code model' },
 
+  // Z.ai models
+  'glm-5.2': { displayName: 'GLM-5.2', description: 'Z.ai 1M-context coding flagship' },
+  'glm-5.1': { displayName: 'GLM-5.1', description: 'Z.ai open-weights coding model' },
+
   // Demo / fun models
   'gpt-8': { displayName: 'GPT-8', description: 'Writes code before you think it' },
   'opus-7': { displayName: 'Opus 7', description: 'Achieved consciousness, ships on time' },

--- a/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
@@ -354,6 +354,8 @@ describe('AgentExecutorFactory', () => {
         'claude-opus-4-6',
         'claude-sonnet-4-6',
         'claude-haiku-4-5',
+        'glm-5.2',
+        'glm-5.1',
       ]);
     });
 


### PR DESCRIPTION
Closes #751 — adds `glm-5.2` and `glm-5.1` to `CLAUDE_CODE_MODELS`, mirrors
them in the Storybook mock, and registers display metadata so the picker
shows canonical names. Updates the one existing test in
`agent-executor-factory` that hardcoded the old 5-item list.

<!--
Thanks for contributing to Shep! Fill in each section. The grooming agent and
reviewers use these fields directly — keep them short, concrete, and honest.
-->

## What

Adds two Z.ai model IDs (`glm-5.2`, `glm-5.1`) to the static Claude Code
model catalog, mirrors them in the Storybook mock catalog, and adds
matching `MODEL_METADATA` entries so the model picker renders the
canonical display names (`GLM-5.2`, `GLM-5.1`) instead of falling
through to the raw-ID prettifier in `getModelMeta()`. Pure data update.

## Why

Closes #751.

Z.ai released **GLM-5.2 on 2026-06-13** — a 1M-context coding flagship
that integrates with Claude Code, Cline, OpenCode, Roo Code, Crush, and
Goose by overriding `ANTHROPIC_DEFAULT_OPUS_MODEL`. Shep's Claude Code
adapter already supports that override; the only thing standing between
a shep user and GLM-5.2 today is a missing entry in the picker.

This slots into the existing model-catalog-refresh backlog alongside
#720 (OpenAI Codex display names), #739 (Anthropic Fable 5 / Mythos 5),
and #743 (Kimi K2.7-Code, North Mini Code, DiffusionGemma) — same
shape, different vendor.

## Screenshots / Recording

N/A — non-UI change. The `displayName` change is visible in the model
picker, but the change is a 4-line data addition to `MODEL_METADATA`
that is exercised by the existing Storybook catalog mock
(`.storybook/mocks/app/actions/get-all-agent-models.ts`).

## Testing

Local verification (all on the same commit, run before pushing):

- `pnpm validate` — exit 0 (lint + format + typecheck + `tsp:compile`)
- `pnpm build:storybook` — exit 0 (built in ~12s, mock catalog compiled)
- `pnpm test:unit` — 9,803 / 9,803 pass

The pre-existing test
`tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts:347-358`
hardcoded an exact-match `toEqual` against the 5-item `CLAUDE_CODE_MODELS`
list. It was updated (2-line diff) to expect the new 7-item list. No
new tests added — this is a pure data change, per the issue's
acceptance criteria.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` and `pnpm test:int` pass
- [x] `pnpm build` succeeds
- [x] (UI only) `pnpm build:storybook` succeeds and every new component has a colocated `.stories.tsx` covering Default / Loading / Empty / Error — N/A (no new components, only catalog metadata)
- [x] (Domain changes) `pnpm tsp:compile` ran and `packages/core/src/domain/generated/output.ts` is committed — N/A (no domain changes; generated file was intentionally not modified)
- [ ] (New use case) Tests landed RED-first per the [TDD guide](./docs/development/tdd-guide.md) — N/A (no new use case; updated one existing test)
- [x] No `application/` or `presentation/` file imports anything from `infrastructure/`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — releasing types (`feat`, `fix`) used for user-visible changes
- [ ] Updated [LESSONS.md](./LESSONS.md) if I learned something a future contributor should know — N/A (no new lesson surfaced)
