### PR TITLE
feat(web): add storybook stories for toggle and toggle-group

### DIFF
--- a/src/presentation/web/components/ui/toggle-group.stories.tsx
+++ b/src/presentation/web/components/ui/toggle-group.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Bold, Italic, Underline } from 'lucide-react';
+import { ToggleGroup, ToggleGroupItem } from './toggle-group';
+
+const meta = {
+  title: 'Primitives/ToggleGroup',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Single: Story = {
+  render: () => (
+    <ToggleGroup type="single" defaultValue="bold">
+      <ToggleGroupItem value="bold" aria-label="Toggle bold">
+        <Bold className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Toggle italic">
+        <Italic className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Toggle underline">
+        <Underline className="size-4" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <ToggleGroup type="multiple" defaultValue={['bold', 'italic']}>
+      <ToggleGroupItem value="bold" aria-label="Toggle bold">
+        <Bold className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Toggle italic">
+        <Italic className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Toggle underline">
+        <Underline className="size-4" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+export const OutlineJoined: Story = {
+  render: () => (
+    <ToggleGroup type="single" variant="outline" spacing={0} defaultValue="bold">
+      <ToggleGroupItem value="bold" aria-label="Toggle bold outline joined">
+        <Bold className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Toggle italic outline joined">
+        <Italic className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Toggle underline outline joined">
+        <Underline className="size-4" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+export const OutlineSpaced: Story = {
+  render: () => (
+    <ToggleGroup type="single" variant="outline" spacing={2} defaultValue="bold">
+      <ToggleGroupItem value="bold" aria-label="Toggle bold outline spaced">
+        <Bold className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Toggle italic outline spaced">
+        <Italic className="size-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Toggle underline outline spaced">
+        <Underline className="size-4" />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};

--- a/src/presentation/web/components/ui/toggle.stories.tsx
+++ b/src/presentation/web/components/ui/toggle.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Bold, Italic, Underline } from 'lucide-react';
+import { Toggle } from './toggle';
+
+const meta = {
+  title: 'Primitives/Toggle',
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Toggle aria-label="Toggle bold">
+      <Bold className="size-4" />
+    </Toggle>
+  ),
+};
+
+export const Outline: Story = {
+  render: () => (
+    <Toggle variant="outline" aria-label="Toggle italic">
+      <Italic className="size-4" />
+    </Toggle>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Toggle size="sm" aria-label="Toggle bold small">
+        <Bold className="size-4" />
+      </Toggle>
+      <Toggle size="default" aria-label="Toggle bold default">
+        <Bold className="size-4" />
+      </Toggle>
+      <Toggle size="lg" aria-label="Toggle bold large">
+        <Bold className="size-4" />
+      </Toggle>
+    </div>
+  ),
+};
+
+export const OnState: Story = {
+  render: () => (
+    <Toggle defaultPressed aria-label="Toggle underline on">
+      <Underline className="size-4" />
+    </Toggle>
+  ),
+};


### PR DESCRIPTION
## What

Adds colocated Storybook `.stories.tsx` files for the `Toggle` and `ToggleGroup` presentation components.

## Why

This resolves the long-standing gap on the mandatory rule in `CLAUDE.md` that *"Every web UI component MUST have a colocated .stories.tsx file."* These are the final two primitives in `components/ui/` that did not have stories. 

Closes #765

## Screenshots / Recording

*N/A — Visual layout verification checked locally via Storybook.*

## Testing

Verified using the following locally:
1. Ran typescript verification: `pnpm typecheck`
2. Verified Storybook build output: `pnpm build:storybook`
3. Storybook states covered:
   - **Toggle**: `Default`, `Outline`, `Sizes` (rendering sm, default, and lg side-by-side), and `OnState` (using `defaultPressed`).
   - **ToggleGroup**: `Single` selection, `Multiple` selection, `OutlineJoined` (`spacing={0}`), and `OutlineSpaced` (`spacing={2}`).

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build:storybook` succeeds and every new component has a colocated `.stories.tsx`
- [x] Commit messages follow Conventional Commits
- [x] No `application/` or `presentation/` file imports anything from `infrastructure/`
