### PR TITLE
docs(cli): add plugin command help examples

### DIFF
--- a/src/presentation/cli/commands/plugin/add.command.ts
+++ b/src/presentation/cli/commands/plugin/add.command.ts
@@ -37,6 +37,13 @@ export function createAddCommand(): Command {
   const t = getCliI18n().t;
   return new Command('add')
     .description(t('cli:commands.plugin.add.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin add mempalace                                              Install from the curated catalog
+  $ shep plugin add --name my-tool --type mcp --command "npx my-mcp" --transport stdio   Install a custom plugin`
+    )
     .argument('[catalogName]', t('cli:commands.plugin.add.nameArg'))
     .option('--name <name>', t('cli:commands.plugin.add.nameOption'))
     .option('--type <type>', t('cli:commands.plugin.add.typeOption'))

--- a/src/presentation/cli/commands/plugin/configure.command.ts
+++ b/src/presentation/cli/commands/plugin/configure.command.ts
@@ -17,6 +17,12 @@ export function createConfigureCommand(): Command {
   const t = getCliI18n().t;
   return new Command('configure')
     .description(t('cli:commands.plugin.configure.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin configure ruflo --tool-groups implement,test   Limit ruflo to the implement + test tool groups`
+    )
     .argument('<name>', t('cli:commands.plugin.configure.nameArg'))
     .option('--tool-groups <groups>', t('cli:commands.plugin.configure.toolGroupsOption'))
     .action(async (name: string, options: { toolGroups?: string }) => {

--- a/src/presentation/cli/commands/plugin/list.command.ts
+++ b/src/presentation/cli/commands/plugin/list.command.ts
@@ -35,6 +35,12 @@ export function createListCommand(): Command {
   const t = getCliI18n().t;
   return new Command('list')
     .description(t('cli:commands.plugin.list.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin list                                       Show all installed plugins with health + enable status`
+    )
     .action(async () => {
       try {
         const useCase = container.resolve(ListPluginsUseCase);

--- a/src/presentation/cli/commands/plugin/status.command.ts
+++ b/src/presentation/cli/commands/plugin/status.command.ts
@@ -88,6 +88,13 @@ export function createStatusCommand(): Command {
   const t = getCliI18n().t;
   return new Command('status')
     .description(t('cli:commands.plugin.status.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin status                Health-check every installed plugin and print a table
+  $ shep plugin status mempalace      Show detailed health + config for one plugin`
+    )
     .argument('[name]', t('cli:commands.plugin.status.nameArg'))
     .action(async (name?: string) => {
       try {


### PR DESCRIPTION
## Summary
- add `Examples:` help blocks to `shep plugin add`, `list`, `configure`, and `status`
- copy the example invocations from each command's existing JSDoc usage block
- keep the change limited to CLI help output only

Closes #745

## Verification
- `SHEP_HOME=$(mktemp -d) pnpm dev:cli plugin <sub> --help` for `add`, `list`, `configure`, and `status` prints the new `Examples:` sections
- `pnpm exec prettier --check src/presentation/cli/commands/plugin/add.command.ts src/presentation/cli/commands/plugin/list.command.ts src/presentation/cli/commands/plugin/configure.command.ts src/presentation/cli/commands/plugin/status.command.ts`
- `pnpm run typecheck`
- `PATH="/Users/vsc_agent/.nvm/versions/node/v22.21.0/bin:$PATH" pnpm run validate`