### PR TITLE
docs(cli): add --help examples to shep project subcommands

### DIFF
--- a/src/presentation/cli/commands/project/del.command.ts
+++ b/src/presentation/cli/commands/project/del.command.ts
@@ -24,6 +24,13 @@ export function createDelCommand(): Command {
     .description('Delete a project')
     .argument('<slug>', 'Project slug or ID')
     .option('-f, --force', 'Skip confirmation prompt')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep project del my-project
+  $ shep project del my-project --force`
+    )
     .action(async (slug: string, options: DelOptions) => {
       try {
         const getProject = container.resolve(GetPmProjectUseCase);

--- a/src/presentation/cli/commands/project/ls.command.ts
+++ b/src/presentation/cli/commands/project/ls.command.ts
@@ -13,33 +13,41 @@ import { ListPmProjectsUseCase } from '@/application/use-cases/pm-projects/list-
 import { colors, messages, renderListView } from '../../ui/index.js';
 
 export function createLsCommand(): Command {
-  return new Command('ls').description('List all projects').action(async () => {
-    try {
-      const useCase = container.resolve(ListPmProjectsUseCase);
-      const projects = await useCase.execute();
+  return new Command('ls')
+    .description('List all projects')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep project ls`
+    )
+    .action(async () => {
+      try {
+        const useCase = container.resolve(ListPmProjectsUseCase);
+        const projects = await useCase.execute();
 
-      const rows = projects.map((p) => [
-        p.identifierPrefix,
-        p.name,
-        String(p.workItemCounter),
-        p.description ?? colors.muted('—'),
-      ]);
+        const rows = projects.map((p) => [
+          p.identifierPrefix,
+          p.name,
+          String(p.workItemCounter),
+          p.description ?? colors.muted('—'),
+        ]);
 
-      renderListView({
-        title: 'Projects',
-        columns: [
-          { label: 'Prefix', width: 8 },
-          { label: 'Name', width: 28 },
-          { label: 'Items', width: 8 },
-          { label: 'Description', width: 40 },
-        ],
-        rows,
-        emptyMessage: 'No projects found. Create one with: shep project new',
-      });
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      messages.error('Failed to list projects', err);
-      process.exitCode = 1;
-    }
-  });
+        renderListView({
+          title: 'Projects',
+          columns: [
+            { label: 'Prefix', width: 8 },
+            { label: 'Name', width: 28 },
+            { label: 'Items', width: 8 },
+            { label: 'Description', width: 40 },
+          ],
+          rows,
+          emptyMessage: 'No projects found. Create one with: shep project new',
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        messages.error('Failed to list projects', err);
+        process.exitCode = 1;
+      }
+    });
 }

--- a/src/presentation/cli/commands/project/new.command.ts
+++ b/src/presentation/cli/commands/project/new.command.ts
@@ -26,6 +26,14 @@ export function createNewCommand(): Command {
     .option('-n, --name <name>', 'Project name')
     .option('-p, --prefix <prefix>', 'Identifier prefix (1-5 uppercase letters)')
     .option('-d, --description <description>', 'Project description')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep project new
+  $ shep project new --name "My Project" --prefix MP --description "A sample project"
+  $ shep project new -n "My Project" -p MP -d "A sample project"`
+    )
     .action(async (options: NewOptions) => {
       try {
         const name =

--- a/src/presentation/cli/commands/project/show.command.ts
+++ b/src/presentation/cli/commands/project/show.command.ts
@@ -27,6 +27,12 @@ export function createShowCommand(): Command {
   return new Command('show')
     .description('Show project details')
     .argument('<slug>', 'Project slug or ID')
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep project show <slug>`
+    )
     .action(async (slug: string) => {
       try {
         const getProject = container.resolve(GetPmProjectUseCase);

--- a/tests/unit/presentation/cli/commands/project/project-help.command.test.ts
+++ b/tests/unit/presentation/cli/commands/project/project-help.command.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Project subcommand help text unit tests
+ *
+ * Verifies that the four `shep project` subcommands expose copy-pasteable
+ * Examples blocks via Commander's addHelpText('after', ...) hook.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Command } from 'commander';
+import { createLsCommand } from '../../../../../../src/presentation/cli/commands/project/ls.command.js';
+import { createNewCommand } from '../../../../../../src/presentation/cli/commands/project/new.command.js';
+import { createShowCommand } from '../../../../../../src/presentation/cli/commands/project/show.command.js';
+import { createDelCommand } from '../../../../../../src/presentation/cli/commands/project/del.command.js';
+
+function captureHelp(cmd: Command): string {
+  let helpOutput = '';
+  cmd.configureOutput({ writeOut: (str) => (helpOutput += str) });
+  cmd.outputHelp();
+  return helpOutput;
+}
+
+describe('project subcommand help text', () => {
+  it('ls --help includes an Examples block with shep project ls', () => {
+    const helpOutput = captureHelp(createLsCommand());
+    expect(helpOutput).toContain('Examples:');
+    expect(helpOutput).toContain('shep project ls');
+  });
+
+  it('new --help includes examples for --name, --prefix, and --description flags', () => {
+    const helpOutput = captureHelp(createNewCommand());
+    expect(helpOutput).toContain('Examples:');
+    expect(helpOutput).toContain('--name');
+    expect(helpOutput).toContain('--prefix');
+    expect(helpOutput).toContain('--description');
+    expect(helpOutput).toContain('-n');
+    expect(helpOutput).toContain('-p');
+    expect(helpOutput).toContain('-d');
+  });
+
+  it('show --help includes an example with a <slug> argument', () => {
+    const helpOutput = captureHelp(createShowCommand());
+    expect(helpOutput).toContain('Examples:');
+    expect(helpOutput).toContain('shep project show');
+    expect(helpOutput).toContain('<slug>');
+  });
+
+  it('del --help includes confirm and --force examples', () => {
+    const helpOutput = captureHelp(createDelCommand());
+    expect(helpOutput).toContain('Examples:');
+    expect(helpOutput).toContain('shep project del my-project');
+    expect(helpOutput).toContain('--force');
+  });
+});


### PR DESCRIPTION
## What

Add `Examples:` blocks to the four `shep project` subcommands (`ls`, `new`, `show`, `del`) so their `--help` output includes copy-pasteable usage examples, matching the pattern already used by other command groups.

## Why

Closes #668

The `shep project` group was one of the last command groups whose `--help` showed flags but no examples. Example-rich help makes the CLI self-teaching for agent-driven terminal workflows.

## Screenshots / Recording

N/A — non-UI change.

## Testing

- `pnpm validate` — passes (includes lint, typecheck, unit/int tests, build)
- Manually verified help text placement follows the same `.addHelpText('after', ...)` pattern as `supervisor/status.command.ts`

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` and `pnpm test:int` pass
- [x] `pnpm build` succeeds
- [x] No `application/` or `presentation/` file imports anything from `infrastructure/`
- [x] Commit messages follow Conventional Commits