### PR TITLE
Add use case JSDoc

### DIFF
--- a/packages/core/src/application/use-cases/activity-log/list-activity-log.use-case.ts
+++ b/packages/core/src/application/use-cases/activity-log/list-activity-log.use-case.ts
@@ -1,3 +1,9 @@
+/**
+ * List Activity Log Use Case
+ *
+ * Returns the activity feed for a work item through IActivityLogRepository.
+ */
+
 import { injectable, inject } from 'tsyringe';
 import type { ActivityEntry } from '../../../domain/generated/output.js';
 import type { IActivityLogRepository } from '../../ports/output/repositories/activity-log-repository.interface.js';

--- a/packages/core/src/application/use-cases/custom-properties/manage-custom-properties.use-case.ts
+++ b/packages/core/src/application/use-cases/custom-properties/manage-custom-properties.use-case.ts
@@ -1,8 +1,16 @@
+/**
+ * Manage Custom Properties Use Case
+ *
+ * Orchestrates project custom property list, create, update, and delete operations through
+ * ICustomPropertyRepository.
+ */
+
 import { injectable, inject } from 'tsyringe';
 import { randomUUID } from 'node:crypto';
 import type { CustomProperty } from '../../../domain/generated/output.js';
 import type { ICustomPropertyRepository } from '../../ports/output/repositories/custom-property-repository.interface.js';
 
+/** Input required to create a custom property schema entry for a project. */
 export interface CreateCustomPropertyInput {
   projectId: string;
   name: string;
@@ -12,6 +20,7 @@ export interface CreateCustomPropertyInput {
   displayOrder?: number;
 }
 
+/** Result envelope returned by custom property management operations. */
 export type ManageCustomPropertyResult =
   | { ok: true; property?: CustomProperty; properties?: CustomProperty[] }
   | { ok: false; error: string };

--- a/packages/core/src/application/use-cases/import-export/export-work-items-csv.use-case.ts
+++ b/packages/core/src/application/use-cases/import-export/export-work-items-csv.use-case.ts
@@ -1,3 +1,12 @@
+/**
+ * Export Work Items CSV Use Case
+ *
+ * Builds CSV output from work items through IWorkItemRepository, ICycleRepository,
+ * IWorkItemStateRepository, and ILabelRepository.
+ *
+ * Callers provide the explicit ExportColumn list used for headers and row values.
+ */
+
 import { injectable, inject } from 'tsyringe';
 import Papa from 'papaparse';
 import type { WorkItem, WorkItemState, Label } from '../../../domain/generated/output.js';

--- a/packages/core/src/application/use-cases/import-export/import-work-items-csv.use-case.ts
+++ b/packages/core/src/application/use-cases/import-export/import-work-items-csv.use-case.ts
@@ -1,3 +1,12 @@
+/**
+ * Import Work Items CSV Use Case
+ *
+ * Creates work items from mapped CSV rows through IPmProjectRepository, IWorkItemRepository,
+ * IWorkItemStateRepository, and IActivityLogRepository.
+ *
+ * By default skipHeaderRow drops the first CSV row; set it to false when there is no header.
+ */
+
 import { injectable, inject } from 'tsyringe';
 import { randomUUID } from 'node:crypto';
 import Papa from 'papaparse';

--- a/packages/core/src/application/use-cases/search/global-search.use-case.ts
+++ b/packages/core/src/application/use-cases/search/global-search.use-case.ts
@@ -1,3 +1,11 @@
+/**
+ * Global Search Use Case
+ *
+ * Searches projects, work items, and pages through the injected Database token.
+ *
+ * User input is sanitized for FTS5 special characters before appending the prefix wildcard.
+ */
+
 import { injectable, inject } from 'tsyringe';
 import type Database from 'better-sqlite3';
 


### PR DESCRIPTION
## Summary

- Add file-top JSDoc blocks to the five use-case files listed in #799.
- Document the custom property input/result types requested by the issue.
- Call out the explicit export column list, import `skipHeaderRow` behavior, and FTS5 sanitization behavior.

Closes #799

## Validation

- `corepack pnpm dlx prettier@3.0.0 --no-config --semi true --single-quote --tab-width 2 --trailing-comma es5 --print-width 100 --bracket-spacing --arrow-parens always --end-of-line lf --check <changed files>`
- `git diff --check`
- PowerShell smoke check that all five files begin with `/**`, the two custom-property type comments exist, and the `skipHeaderRow`/FTS5 callouts are present

## Note

`corepack pnpm validate` could not run in this local checkout because dependencies were not installed. I attempted `corepack pnpm install --frozen-lockfile --ignore-scripts`, but it timed out after five minutes without completing, so I kept validation to the changed TypeScript files and a direct acceptance-criteria check.