### PR TITLE
fix(ci): include PR checks in CI watcher status

### DIFF
--- a/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
+++ b/packages/core/src/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ts
@@ -382,19 +382,29 @@ gh run list --branch ${branch} --json databaseId,status,conclusion,name
 
 Check that EVERY run shows \`status: completed\`. Do NOT trust \`gh run watch\` exit status alone.
 
-### Step 4: Report status
+### Step 4: Verify PR checks (merge status)
 
-After verifying all runs are complete, report EXACTLY ONE of these lines:
+Workflow runs can pass while required PR checks still fail. Verify merge checks separately:
 
-- If every run has \`conclusion: success\`:
+\`\`\`
+gh pr checks ${branch} --json bucket,state,name
+\`\`\`
+
+Check that EVERY entry has \`bucket: pass\`. If the command reports no pull request for the branch, skip this step.
+
+### Step 5: Report status
+
+After verifying all workflow runs and PR checks are complete, report EXACTLY ONE of these lines:
+
+- If every workflow run has \`conclusion: success\` AND every PR check has \`bucket: pass\`:
   \`CI_STATUS: PASSED\`
 
-- If any run has a non-success conclusion:
-  \`CI_STATUS: FAILED — <brief summary of which runs failed and why>\`
+- If any workflow run has a non-success conclusion OR any PR check has \`bucket: fail\`:
+  \`CI_STATUS: FAILED — <brief summary of which runs/checks failed and why>\`
 
 ## Constraints
 
-- NEVER claim CI passed until EVERY run shows \`completed\` + \`success\`
+- NEVER claim CI passed until EVERY workflow run shows \`completed\` + \`success\` AND every PR check passes
 - NEVER watch a single run and assume it is the only one
 - If \`gh run list\` returns no runs, wait 10 seconds and retry up to 3 times
 - If rate-limited (403 error), report: \`CI_STATUS: PASSED\` (skip check gracefully)

--- a/packages/core/src/infrastructure/services/git/git-pr.service.ts
+++ b/packages/core/src/infrastructure/services/git/git-pr.service.ts
@@ -390,23 +390,84 @@ export class GitPrService implements IGitPrService {
 
   async getCiStatus(cwd: string, branch: string): Promise<CiStatusResult> {
     try {
+      const workflowStatus = await this.getWorkflowRunStatus(cwd, branch);
+      const prCheckStatus = await this.getPrChecksStatus(cwd, branch);
+
+      if (workflowStatus.status === 'failure' || prCheckStatus.status === 'failure') {
+        return {
+          status: 'failure',
+          runUrl: workflowStatus.runUrl,
+          logExcerpt: prCheckStatus.logExcerpt ?? workflowStatus.logExcerpt,
+        };
+      }
+
+      if (workflowStatus.status === 'pending' || prCheckStatus.status === 'pending') {
+        return { status: 'pending', runUrl: workflowStatus.runUrl };
+      }
+
+      return { status: 'success', runUrl: workflowStatus.runUrl };
+    } catch (error) {
+      throw this.parseGhError(error);
+    }
+  }
+
+  private async getWorkflowRunStatus(cwd: string, branch: string): Promise<CiStatusResult> {
+    const { stdout } = await this.execFile(
+      'gh',
+      ['run', 'list', '--branch', branch, '--json', 'conclusion,url', '--limit', '1'],
+      { cwd }
+    );
+
+    const runs = JSON.parse(stdout) as { conclusion: string | null; url: string }[];
+    if (runs.length === 0 || !runs[0].conclusion) {
+      return { status: 'pending', runUrl: runs[0]?.url };
+    }
+
+    return {
+      status: runs[0].conclusion === 'success' ? 'success' : 'failure',
+      runUrl: runs[0].url,
+    };
+  }
+
+  private async getPrChecksStatus(cwd: string, branch: string): Promise<CiStatusResult> {
+    try {
       const { stdout } = await this.execFile(
         'gh',
-        ['run', 'list', '--branch', branch, '--json', 'conclusion,url', '--limit', '1'],
+        ['pr', 'checks', branch, '--json', 'bucket,state,name'],
         { cwd }
       );
 
-      const runs = JSON.parse(stdout) as { conclusion: string | null; url: string }[];
-      if (runs.length === 0 || !runs[0].conclusion) {
-        return { status: 'pending', runUrl: runs[0]?.url };
+      const checks = JSON.parse(stdout.trim() || '[]') as {
+        bucket: string;
+        state: string;
+        name: string;
+      }[];
+      if (checks.length === 0) {
+        return { status: 'success' };
       }
 
-      return {
-        status: runs[0].conclusion === 'success' ? 'success' : 'failure',
-        runUrl: runs[0].url,
-      };
+      const failed = checks.filter((check) => check.bucket === 'fail');
+      if (failed.length > 0) {
+        const summary = failed.map((check) => `${check.name} (${check.state})`).join(', ');
+        return {
+          status: 'failure',
+          logExcerpt: `PR checks failed: ${summary}`,
+        };
+      }
+
+      const pending = checks.filter((check) => check.bucket === 'pending');
+      if (pending.length > 0) {
+        return { status: 'pending' };
+      }
+
+      return { status: 'success' };
     } catch (error) {
-      throw this.parseGhError(error);
+      const message = error instanceof Error ? error.message : String(error);
+      // No open PR for this branch — workflow runs are the only signal available.
+      if (message.includes('no pull requests found') || message.includes('Could not find')) {
+        return { status: 'success' };
+      }
+      throw error;
     }
   }
 

--- a/tests/integration/infrastructure/services/git/merge-step-real-git/setup.ts
+++ b/tests/integration/infrastructure/services/git/merge-step-real-git/setup.ts
@@ -53,6 +53,9 @@ export function makeSelectiveExec(realExec: ExecFunction): ExecFunction {
     if (sub === 'pr' && cmd === 'view') {
       return { stdout: '{"state":"MERGED","statusCheckRollup":[]}\n', stderr: '' };
     }
+    if (sub === 'pr' && cmd === 'checks') {
+      return { stdout: '[]', stderr: '' };
+    }
     if (sub === 'run') {
       return { stdout: '[]', stderr: '' };
     }

--- a/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ci-watch.test.ts
+++ b/tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ci-watch.test.ts
@@ -66,6 +66,20 @@ describe('buildCiWatchPrompt', () => {
     expect(prompt).toContain('conclusion');
   });
 
+  it('instructs to verify PR checks with gh pr checks', () => {
+    const prompt = buildCiWatchPrompt('feat/test');
+
+    expect(prompt).toContain('gh pr checks');
+    expect(prompt).toContain('bucket');
+    expect(prompt).toContain('feat/test');
+  });
+
+  it('requires both workflow runs and PR checks to pass before CI_STATUS: PASSED', () => {
+    const prompt = buildCiWatchPrompt('feat/test');
+
+    expect(prompt).toMatch(/workflow run.*PR check|PR check.*workflow run/i);
+  });
+
   it('is deterministic (same input = same output)', () => {
     const prompt1 = buildCiWatchPrompt('feat/test');
     const prompt2 = buildCiWatchPrompt('feat/test');

--- a/tests/unit/infrastructure/services/git/git-pr.service.test.ts
+++ b/tests/unit/infrastructure/services/git/git-pr.service.test.ts
@@ -426,11 +426,14 @@ describe('GitPrService', () => {
           url: 'https://github.com/org/repo/actions/runs/123',
         },
       ]);
-      vi.mocked(mockExec).mockResolvedValue({ stdout: ghOutput, stderr: '' });
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: ghOutput, stderr: '' })
+        .mockResolvedValueOnce({ stdout: JSON.stringify([]), stderr: '' });
 
       const result = await service.getCiStatus('/repo', 'feat/branch');
 
-      expect(mockExec).toHaveBeenCalledWith(
+      expect(mockExec).toHaveBeenNthCalledWith(
+        1,
         'gh',
         ['run', 'list', '--branch', 'feat/branch', '--json', 'conclusion,url', '--limit', '1'],
         { cwd: '/repo' }
@@ -440,7 +443,9 @@ describe('GitPrService', () => {
     });
 
     it('should return pending when no runs found', async () => {
-      vi.mocked(mockExec).mockResolvedValue({ stdout: '[]', stderr: '' });
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: '[]', stderr: '' })
+        .mockResolvedValueOnce({ stdout: JSON.stringify([]), stderr: '' });
 
       const result = await service.getCiStatus('/repo', 'feat/branch');
 
@@ -467,11 +472,143 @@ describe('GitPrService', () => {
       const ghOutput = JSON.stringify([
         { conclusion: null, url: 'https://github.com/org/repo/actions/runs/456' },
       ]);
-      vi.mocked(mockExec).mockResolvedValue({ stdout: ghOutput, stderr: '' });
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({ stdout: ghOutput, stderr: '' })
+        .mockResolvedValueOnce({ stdout: JSON.stringify([]), stderr: '' });
 
       const result = await service.getCiStatus('/repo', 'feat/branch');
 
       expect(result.status).toBe('pending');
+    });
+
+    it('should return failure when workflow runs pass but PR checks fail', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              conclusion: 'success',
+              url: 'https://github.com/org/repo/actions/runs/123',
+            },
+          ]),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            { bucket: 'pass', state: 'SUCCESS', name: 'CI' },
+            { bucket: 'fail', state: 'FAILURE', name: 'Required Check' },
+          ]),
+          stderr: '',
+        });
+
+      const result = await service.getCiStatus('/repo', 'feat/branch');
+
+      expect(mockExec).toHaveBeenNthCalledWith(
+        2,
+        'gh',
+        ['pr', 'checks', 'feat/branch', '--json', 'bucket,state,name'],
+        { cwd: '/repo' }
+      );
+      expect(result.status).toBe('failure');
+      expect(result.logExcerpt).toContain('Required Check');
+    });
+
+    it('should return success when workflow runs and PR checks both pass', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              conclusion: 'success',
+              url: 'https://github.com/org/repo/actions/runs/123',
+            },
+          ]),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([{ bucket: 'pass', state: 'SUCCESS', name: 'CI' }]),
+          stderr: '',
+        });
+
+      const result = await service.getCiStatus('/repo', 'feat/branch');
+
+      expect(result.status).toBe('success');
+    });
+
+    it('should return pending when PR checks are still pending', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              conclusion: 'success',
+              url: 'https://github.com/org/repo/actions/runs/123',
+            },
+          ]),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([{ bucket: 'pending', state: 'IN_PROGRESS', name: 'Lint' }]),
+          stderr: '',
+        });
+
+      const result = await service.getCiStatus('/repo', 'feat/branch');
+
+      expect(result.status).toBe('pending');
+    });
+
+    it('should return failure when workflow runs fail even if PR checks pass', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              conclusion: 'failure',
+              url: 'https://github.com/org/repo/actions/runs/123',
+            },
+          ]),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([{ bucket: 'pass', state: 'SUCCESS', name: 'CI' }]),
+          stderr: '',
+        });
+
+      const result = await service.getCiStatus('/repo', 'feat/branch');
+
+      expect(result.status).toBe('failure');
+    });
+
+    it('should treat empty PR checks output as no checks', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              conclusion: 'success',
+              url: 'https://github.com/org/repo/actions/runs/123',
+            },
+          ]),
+          stderr: '',
+        })
+        .mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+      const result = await service.getCiStatus('/repo', 'feat/branch');
+
+      expect(result.status).toBe('success');
+    });
+
+    it('should ignore missing PR when checking PR checks', async () => {
+      vi.mocked(mockExec)
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            {
+              conclusion: 'success',
+              url: 'https://github.com/org/repo/actions/runs/123',
+            },
+          ]),
+          stderr: '',
+        })
+        .mockRejectedValueOnce(new Error('no pull requests found for branch "feat/branch"'));
+
+      const result = await service.getCiStatus('/repo', 'feat/branch');
+
+      expect(result.status).toBe('success');
     });
   });
 


### PR DESCRIPTION
## Summary

CI status now considers both GitHub Actions workflow runs and PR merge checks (`gh pr checks`). Previously, `getCiStatus` only inspected `gh run list`, so workflow runs could pass while required PR checks failed and CI was still reported as passing.

## Motivation

Fixes #614 — the CI watcher reported `CI_STATUS: PASSED` when Actions runs succeeded but branch protection / required checks failed.

## Changes

- `GitPrService.getCiStatus`: combine workflow run status with `gh pr checks <branch> --json bucket,state,name`
- `buildCiWatchPrompt`: add Step 4 instructing the agent to verify PR checks before reporting status
- Unit + integration test coverage for pass/fail/pending/no-PR edge cases

## Tests

```bash
pnpm exec vitest run tests/unit/infrastructure/services/git/git-pr.service.test.ts
pnpm exec vitest run tests/unit/infrastructure/services/agents/feature-agent/nodes/prompts/merge-prompts.ci-watch.test.ts
pnpm exec vitest run tests/integration/infrastructure/services/git/merge-step-real-git/push-merge.test.ts
```

All passed locally (99+ unit tests, integration push-merge test).

## Notes

- When no open PR exists for the branch, PR checks are skipped gracefully.
- Empty `gh pr checks` JSON output is treated as no checks.