### PR TITLE
docs: add v0 competitor profile

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -82,7 +82,7 @@ These target a different audience (non-developers, rapid prototyping) but share 
 | ---------------------------------- | ----------------------------------------------- |
 | [Lovable](https://lovable.dev)     | Build apps by chatting — $100M ARR in 8 months  |
 | [Bolt.new](https://bolt.new)       | Full-stack app generation in the browser        |
-| [v0](https://v0.dev)               | Vercel's AI app builder trained on React/shadcn |
+| [v0](./v0.md)                      | Vercel's AI app builder trained on React/shadcn |
 | [Replit Agent](https://replit.com) | Prompt to deployed app with hosting             |
 
 ---

--- a/docs/competitors/v0.md
+++ b/docs/competitors/v0.md
@@ -1,0 +1,53 @@
+# v0
+
+> Vercel's browser-based AI agent for turning prompts into working web apps.
+
+|                 |                                                                 |
+| --------------- | --------------------------------------------------------------- |
+| **Website**     | [v0.app](https://v0.app)                                        |
+| **By**          | Vercel                                                         |
+| **Tagline**     | "Build full-stack apps, ask questions, and more."              |
+| **Type**        | Browser-based AI app builder                                   |
+| **Pricing**     | Free tier + paid Team, Business, and Enterprise plans           |
+| **Open Source** | No                                                              |
+
+---
+
+## What It Does
+
+v0 is Vercel's prompt-to-app builder for creating real code, full-stack apps, and live prototypes from natural-language descriptions. It is especially strong at fast UI iteration: users can describe an idea, generate or refine high-fidelity interfaces, preview the result in the browser, and publish the app on Vercel.
+
+### Key Features
+
+- **Prompt-to-app generation** - Turns natural-language prompts into working web apps, pages, components, and prototypes
+- **React-oriented output** - Generates modern frontend code, with Vercel sources highlighting React, Next.js, Tailwind CSS, and shadcn/ui workflows
+- **Vercel-native deployment** - Publishes v0 applications to Vercel with a single click and creates or updates the related Vercel Project
+- **Design iteration** - Supports visual editing through Design Mode, plus Figma, screenshots, files, and design-system context
+- **GitHub workflow** - Can sync with GitHub and open pull requests for review
+- **Registry entry points** - Supports "Open in v0" flows for design-system registries, components, and blocks
+
+---
+
+## How Shep Compares
+
+|                        | v0                                      | Shep                            |
+| ---------------------- | --------------------------------------- | ------------------------------- |
+| **Audience**           | Designers, PMs, founders, developers    | Developers and engineering teams |
+| **Surface**            | Browser app                             | CLI + web dashboard             |
+| **Code location**      | Vercel-hosted projects and previews     | Local repository + worktrees    |
+| **Lifecycle coverage** | Prompt -> prototype/app -> deployment   | Idea -> PRD -> plan -> PR -> CI |
+| **Primary strength**   | Fast visual prototyping and publishing  | Shipping into existing codebases |
+| **Open source**        | No                                      | Yes (MIT)                       |
+| **Pricing**            | Free tier + paid plans                  | Free                            |
+
+### What We Respect
+
+v0 nails the short path from idea to live UI. The combination of component-library-aware generation, visual refinement, GitHub sync, and one-click Vercel deployment makes it unusually approachable for people who need to show a working interface before a full engineering cycle begins.
+
+### Where Shep Differs
+
+v0 wins when the job is "I want a deployed UI in five minutes." Shep is aimed at a different handoff: taking a real feature into an existing repository with requirements, research, reviewable plans, isolated worktrees, PR review, and CI repair before merge.
+
+---
+
+_Sources: [v0 docs](https://v0.app/docs), [v0 pricing](https://v0.app/pricing), [Vercel integration](https://v0.app/docs/vercel-integration), [Design systems](https://v0.app/docs/design-systems), [Vercel v0 launch post](https://vercel.com/blog/announcing-v0-generative-ui)_


### PR DESCRIPTION
## Summary
- add a v0 competitor profile following the existing docs/competitors structure
- update the App Builders table to link v0 to the new local profile

## Verification
- `pnpm exec prettier --check docs/competitors/v0.md docs/competitors/README.md`

Note: I also attempted `pnpm validate`, but it did not complete within the local 5 minute timeout after running the full-repo validation pipeline.

Closes #774
