### PR TITLE
docs: add Lovable competitor profile

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -80,7 +80,7 @@ These target a different audience (non-developers, rapid prototyping) but share 
 
 | Tool                               | Tagline                                         |
 | ---------------------------------- | ----------------------------------------------- |
-| [Lovable](https://lovable.dev)     | Build apps by chatting — $100M ARR in 8 months  |
+| [Lovable](./lovable.md)            | Build apps by chatting — $100M ARR in 8 months  |
 | [Bolt.new](https://bolt.new)       | Full-stack app generation in the browser        |
 | [v0](https://v0.dev)               | Vercel's AI app builder trained on React/shadcn |
 | [Replit Agent](https://replit.com) | Prompt to deployed app with hosting             |

--- a/docs/competitors/lovable.md
+++ b/docs/competitors/lovable.md
@@ -1,0 +1,52 @@
+# Lovable
+
+> Stockholm's vibe-coding platform that ships full web apps from chat prompts.
+
+|                 |                                                                 |
+| --------------- | --------------------------------------------------------------- |
+| **Website**     | [lovable.dev](https://lovable.dev)                              |
+| **By**          | Lovable Labs                                                    |
+| **Tagline**     | "Build apps by chatting"                                        |
+| **Type**        | Browser-based app builder (no install)                          |
+| **Pricing**     | Free tier + paid plans                                          |
+| **Open Source** | No                                                              |
+
+---
+
+## What It Does
+
+Lovable is a chat-first app builder that turns natural-language prompts into working web apps. Users describe an idea, iterate in the browser, and publish without a local dev setup. The product targets founders, designers, and non-developers who want a deployed app fast rather than a hand-managed engineering workflow.
+
+### Key Features
+
+- **Chat-driven app generation** - Builds full-stack web apps from text or voice prompts, with the agent continuing work autonomously after each input
+- **Browser-based editing** - No local install required; projects live in Lovable's web workspace with cross-device continuity between desktop and mobile
+- **Deploy and hosting** - Ships working websites and web apps with publishing built into the product flow
+- **Lovable Mobile** - iOS and Android app launched April 28, 2026 for on-the-go prompting, background builds, and review notifications
+- **Google Cloud partnership** - Multi-year expansion announced June 3, 2026 with bundled Anthropic Claude and Google Gemini access, Wiz real-time vulnerability remediation, and distribution through Google's Gemini Enterprise Agent Gallery
+
+---
+
+## How Shep Compares
+
+|                        | Lovable                                 | Shep                            |
+| ---------------------- | --------------------------------------- | ------------------------------- |
+| **Audience**           | Non-developers, founders, designers     | Developers and engineering teams |
+| **Surface**            | Browser app (+ mobile)                  | CLI + web dashboard             |
+| **Code location**      | Lovable-hosted projects                 | Local repository + worktrees    |
+| **Lifecycle coverage** | Prompt -> deployed app                  | Idea -> PRD -> plan -> PR -> CI |
+| **Primary strength**   | Chat-first onboarding, deployed by default | Full-cycle ownership of engineering work |
+| **Open source**        | No                                      | Yes (MIT)                       |
+| **Pricing**            | Free tier + paid plans                  | Free                            |
+
+### What We Respect
+
+Lovable nails the shortest path from idea to live product for people who do not want to manage a repository. Chat-first onboarding, deployed-by-default output, and a mobile entry point make it unusually easy to capture an idea and get something working before a full engineering cycle begins.
+
+### Where Shep Differs
+
+Lovable wins when the job is "I want a deployed app from a chat prompt." Shep is aimed at a different handoff: taking a real feature into an existing codebase with requirements, research, reviewable plans, isolated worktrees, PR review, and CI repair before merge.
+
+---
+
+_Sources: [Lovable](https://lovable.dev), [Lovable mobile app announcement](https://lovable.dev/blog/mobile-app), [TechCrunch mobile launch](https://techcrunch.com/2026/04/28/lovable-launches-its-vibe-coding-app-on-ios-and-android/), [Google Cloud partnership](https://www.googlecloudpresscorner.com/2026-06-03-Lovable-Expands-Collaboration-With-Google-Cloud-to-Scale-AI-Powered-Software-Creation), [TechCrunch Google Cloud deal](https://techcrunch.com/2026/06/03/lovable-signs-multi-year-deal-with-google-cloud-to-up-usage-5x-source-says/)_


### PR DESCRIPTION
## Summary

Adds `docs/competitors/lovable.md` and links it from the App Builders table in `docs/competitors/README.md`.

Closes #767.

## What changed

- New Lovable competitor profile following the same shape as `mimo-code.md` / `v0.md`
- README external link replaced with `./lovable.md`

## Verification

- `pnpm exec prettier --check docs/competitors/lovable.md docs/competitors/README.md` passed
- Full `pnpm validate` not run (large repo; same scope as sibling docs PRs)

## Sources

Lovable site/blog, TechCrunch mobile launch coverage, Google Cloud partnership announcement.