### PR TITLE
docs: add Bolt.new competitor profile

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -81,7 +81,7 @@ These target a different audience (non-developers, rapid prototyping) but share 
 | Tool                               | Tagline                                         |
 | ---------------------------------- | ----------------------------------------------- |
 | [Lovable](https://lovable.dev)     | Build apps by chatting — $100M ARR in 8 months  |
-| [Bolt.new](https://bolt.new)       | Full-stack app generation in the browser        |
+| [Bolt.new](./bolt-new.md)          | Full-stack app generation in the browser        |
 | [v0](https://v0.dev)               | Vercel's AI app builder trained on React/shadcn |
 | [Replit Agent](https://replit.com) | Prompt to deployed app with hosting             |
 

--- a/docs/competitors/bolt-new.md
+++ b/docs/competitors/bolt-new.md
@@ -1,0 +1,52 @@
+# Bolt.new
+
+> StackBlitz's browser-based full-stack app builder powered by WebContainers.
+
+|                 |                                                                 |
+| --------------- | --------------------------------------------------------------- |
+| **Website**     | [bolt.new](https://bolt.new)                                    |
+| **By**          | StackBlitz                                                      |
+| **Tagline**     | "Prompt, run, edit, and deploy full-stack web apps"             |
+| **Type**        | Browser-based app builder (WebContainers)                       |
+| **Pricing**     | Free tier + paid plans                                          |
+| **Open Source** | No                                                              |
+
+---
+
+## What It Does
+
+Bolt.new is a prompt-to-app builder that runs entirely in the browser. StackBlitz's WebContainers technology brings Node.js, npm, and Vite into the tab so users can generate, edit, and deploy full-stack web apps without installing a local toolchain.
+
+### Key Features
+
+- **Prompt-to-app generation** - Turns natural-language prompts into working frontend and backend code inside a browser IDE
+- **WebContainers runtime** - Runs Node.js, npm installs, and Vite dev servers client-side without a remote VM
+- **One-click deploy** - Publishes projects to Netlify or Cloudflare Pages directly from the editor
+- **Figma-to-app import** - Imports design context from Figma to accelerate UI generation
+- **Mobile-friendly editor** - Supports building and iterating from mobile browsers when a full laptop setup is not available
+
+---
+
+## How Shep Compares
+
+|                        | Bolt.new                                | Shep                            |
+| ---------------------- | --------------------------------------- | ------------------------------- |
+| **Audience**           | Mixed prosumer, founders, developers    | Developers and engineering teams |
+| **Surface**            | Browser-only                            | CLI + web dashboard + local worktrees |
+| **Code location**      | Browser workspace / hosted deploy       | Local repository + worktrees    |
+| **Lifecycle coverage** | Prompt -> deployed prototype            | Idea -> PRD -> plan -> PR -> CI |
+| **Primary strength**   | Zero-install onboarding, deploy by default | Full-cycle ownership of engineering work |
+| **Open source**        | No                                      | Yes (MIT)                       |
+| **Pricing**            | Free tier + paid plans                  | Free                            |
+
+### What We Respect
+
+Bolt.new nails zero-install onboarding. Running a full Node.js stack inside the browser via WebContainers is a genuine technical leap, and the deploy-by-default UX makes it unusually fast to get from a prompt to a shareable prototype.
+
+### Where Shep Differs
+
+Bolt.new wins when the job is "I want a deployed prototype in ten minutes without touching a local repo." Shep is aimed at a different handoff: taking a real feature into an existing codebase with requirements, research, reviewable plans, isolated worktrees, PR review, and CI repair before merge.
+
+---
+
+_Sources: [Bolt.new](https://bolt.new), [StackBlitz blog](https://blog.stackblitz.com), [WebContainers](https://webcontainers.io), [Wix layoffs reporting naming Bolt.new](https://www.reuters.com/business/wix-cuts-jobs-ai-shift-2025-05-28/)_


### PR DESCRIPTION
Adds \docs/competitors/bolt-new.md\ and links from App Builders table.\n\nCloses #768.\n\nVerification: \pnpm exec prettier --check docs/competitors/bolt-new.md docs/competitors/README.md\ passed.

Made with [Cursor](https://cursor.com)