### PR TITLE
docs: add Replit Agent competitor profile

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -83,7 +83,7 @@ These target a different audience (non-developers, rapid prototyping) but share 
 | [Lovable](https://lovable.dev)     | Build apps by chatting — $100M ARR in 8 months  |
 | [Bolt.new](https://bolt.new)       | Full-stack app generation in the browser        |
 | [v0](https://v0.dev)               | Vercel's AI app builder trained on React/shadcn |
-| [Replit Agent](https://replit.com) | Prompt to deployed app with hosting             |
+| [Replit Agent](./replit-agent.md)  | Prompt to deployed app with hosting             |
 
 ---
 

--- a/docs/competitors/replit-agent.md
+++ b/docs/competitors/replit-agent.md
@@ -1,0 +1,52 @@
+# Replit Agent
+
+> Replit's chat-driven builder for prompt-to-deployed-app workflows on hosted runtimes.
+
+|                 |                                                                 |
+| --------------- | --------------------------------------------------------------- |
+| **Website**     | [replit.com](https://replit.com)                                |
+| **By**          | Replit                                                          |
+| **Tagline**     | "Turn your ideas into apps"                                     |
+| **Type**        | Browser-based AI app builder with hosted runtime                |
+| **Pricing**     | Free tier + Replit Core / Teams paid plans                      |
+| **Open Source** | No                                                              |
+
+---
+
+## What It Does
+
+Replit Agent is Replit's prompt-to-app product layered on the company's hosted development environment. Users describe an app in chat, Replit provisions a runtime, generates code, runs it in the cloud, and publishes without local setup.
+
+### Key Features
+
+- **Prompt-to-app generation** - Builds full applications from natural-language prompts inside Replit's browser IDE
+- **Hosted runtime + deploy** - Provisions cloud runtimes and supports one-click deployment on Replit hosting
+- **Multiplayer collaboration** - Lets multiple people edit and iterate on the same project in real time
+- **GitHub and Git integration** - Syncs generated projects with external repositories for review and handoff
+- **Trusted Agent Protocol direction** - Visa joined Replit's Trusted Agent Protocol in May 2026, extending the agent stack toward verified payments across merchant networks
+
+---
+
+## How Shep Compares
+
+|                        | Replit Agent                            | Shep                            |
+| ---------------------- | --------------------------------------- | ------------------------------- |
+| **Audience**           | Students, hackathons, mixed prosumer    | Developers and engineering teams |
+| **Surface**            | Browser + hosted runtime                | CLI + web dashboard + local worktrees |
+| **Code location**      | Replit-hosted projects                  | Local repository + worktrees    |
+| **Lifecycle coverage** | Prompt -> deployed app on Replit        | Idea -> PRD -> plan -> PR -> CI |
+| **Primary strength**   | Collaborative hosted prototyping        | Full-cycle ownership of engineering work |
+| **Open source**        | No                                      | Yes (MIT)                       |
+| **Pricing**            | Free tier + paid plans                  | Free                            |
+
+### What We Respect
+
+Replit Agent combines collaborative editing with a hosted runtime that removes the local-setup hump. The payments-aware agent direction through the Trusted Agent Protocol shows how app builders are stretching beyond code generation into verified real-world actions.
+
+### Where Shep Differs
+
+Replit Agent wins when the job is "I want a hosted prototype with classmates in ten minutes." Shep is aimed at a different handoff: taking a real feature into an existing codebase with requirements, research, reviewable plans, isolated worktrees, PR review, and CI repair before merge.
+
+---
+
+_Sources: [Replit](https://replit.com), [Replit pricing](https://replit.com/pricing), [Visa Trusted Agent Protocol announcement](https://investor.visa.com/news/news-details/2025/Visa-Invests-in-Replit-and-Joins-Trusted-Agent-Protocol/default.aspx), [Replit blog](https://blog.replit.com)_


### PR DESCRIPTION
Adds \docs/competitors/replit-agent.md\ and links from App Builders table.\n\nCloses #775.\n\nVerification: \pnpm exec prettier --check docs/competitors/replit-agent.md docs/competitors/README.md\ passed.

Made with [Cursor](https://cursor.com)