### PR TITLE
feat(cli): add Examples help text to 7 feat subcommands

### DIFF
--- a/src/presentation/cli/commands/feat/adopt.command.ts
+++ b/src/presentation/cli/commands/feat/adopt.command.ts
@@ -20,6 +20,13 @@ export function createAdoptCommand(): Command {
   const t = getCliI18n().t;
   return new Command('adopt')
     .description(t('cli:commands.feat.adopt.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat adopt <branch>              Adopt a branch into feature tracking
+  $ shep feat adopt <branch> -r /path/to/repo   Adopt from a specific repository`
+    )
     .argument('<branch>', t('cli:commands.feat.adopt.branchArgument'))
     .option('-r, --repo <path>', t('cli:commands.feat.adopt.repoOption'))
     .action(async (branch: string, options: { repo?: string }) => {

--- a/src/presentation/cli/commands/feat/archive.command.ts
+++ b/src/presentation/cli/commands/feat/archive.command.ts
@@ -30,6 +30,13 @@ export function createArchiveCommand(): Command {
   const t = getCliI18n().t;
   return new Command('archive')
     .description(t('cli:commands.feat.archive.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat archive feat-123            Archive a feature (prompts for confirmation)
+  $ shep feat archive feat-123 --force    Archive without confirmation`
+    )
     .argument('<id>', t('cli:commands.feat.archive.idArgument'))
     .option('-f, --force', t('cli:commands.feat.archive.forceOption'))
     .action(async (featureId: string, options: ArchiveOptions) => {

--- a/src/presentation/cli/commands/feat/del.command.ts
+++ b/src/presentation/cli/commands/feat/del.command.ts
@@ -34,6 +34,15 @@ export function createDelCommand(): Command {
   const t = getCliI18n().t;
   return new Command('del')
     .description(t('cli:commands.feat.del.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat del feat-123                           Delete a feature (prompts for confirmation)
+  $ shep feat del feat-123 --force                   Delete without confirmation
+  $ shep feat del feat-123 --force --no-cleanup      Delete but keep worktree and branches
+  $ shep feat del feat-123 --force --no-close-pr     Delete but leave the open PR open`
+    )
     .argument('<id>', t('cli:commands.feat.del.idArgument'))
     .option('-f, --force', t('cli:commands.feat.del.forceOption'))
     .option('--no-cleanup', t('cli:commands.feat.del.noCleanupOption'))

--- a/src/presentation/cli/commands/feat/feedback.command.ts
+++ b/src/presentation/cli/commands/feat/feedback.command.ts
@@ -21,6 +21,13 @@ export function createFeedbackCommand(): Command {
   const t = getCliI18n().t;
   return new Command('feedback')
     .description(t('cli:commands.feat.feedback.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat feedback <id> <feedback-text>                              Send feedback on an exploration prototype
+  $ shep feat feedback feat-123 "Make the sidebar collapsible on mobile" Iterate on a design with concrete feedback`
+    )
     .argument('<id>', t('cli:commands.feat.feedback.idArgument'))
     .argument('<feedback>', t('cli:commands.feat.feedback.feedbackArgument'))
     .action(async (featureId: string, feedback: string) => {

--- a/src/presentation/cli/commands/feat/promote.command.ts
+++ b/src/presentation/cli/commands/feat/promote.command.ts
@@ -24,6 +24,13 @@ export function createPromoteCommand(): Command {
   const t = getCliI18n().t;
   return new Command('promote')
     .description(t('cli:commands.feat.promote.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat promote <id>          Promote to Regular mode
+  $ shep feat promote <id> --fast   Promote to Fast mode`
+    )
     .argument('<id>', t('cli:commands.feat.promote.idArgument'))
     .option('--fast', t('cli:commands.feat.promote.fastOption'))
     .action(async (featureId: string, options: PromoteOptions) => {

--- a/src/presentation/cli/commands/feat/review.command.ts
+++ b/src/presentation/cli/commands/feat/review.command.ts
@@ -79,6 +79,13 @@ export function createReviewCommand(): Command {
   const t = getCliI18n().t;
   return new Command('review')
     .description(t('cli:commands.feat.review.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat review              Auto-pick the single waiting feature
+  $ shep feat review feat-123     Review a specific feature by id`
+    )
     .argument('[id]', t('cli:commands.feat.review.idArgument'))
     .action(async (featureId?: string) => {
       try {

--- a/src/presentation/cli/commands/feat/unarchive.command.ts
+++ b/src/presentation/cli/commands/feat/unarchive.command.ts
@@ -24,6 +24,12 @@ export function createUnarchiveCommand(): Command {
   const t = getCliI18n().t;
   return new Command('unarchive')
     .description(t('cli:commands.feat.unarchive.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep feat unarchive feat-123    Restore an archived feature to its previous lifecycle`
+    )
     .argument('<id>', t('cli:commands.feat.unarchive.idArgument'))
     .action(async (featureId: string) => {
       try {


### PR DESCRIPTION
## Summary

Adds `addHelpText('after', ...)` Examples sections to seven `shep feat` subcommands, mirroring the pattern in `ui.command.ts`.

## Motivation

New users discover subcommands via `shep feat <cmd> --help`. These seven commands previously ended at the flag list with no runnable examples, even though each file's JSDoc/Usage header already documented the intended invocations.

## Changes

| Command | Examples |
|---------|----------|
| `feat adopt` | 2 |
| `feat archive` | 2 |
| `feat del` | 4 |
| `feat feedback` | 2 (includes concrete feedback string) |
| `feat promote` | 2 |
| `feat review` | 2 |
| `feat unarchive` | 1 |

Example invocations are taken from existing file-level Usage / `@example` headers — no new flag combinations were introduced.

## Tests

- [x] `pnpm validate` (format, lint, typecheck, tsp:compile)
- [x] `pnpm dev:cli feat adopt --help`
- [x] `pnpm dev:cli feat archive --help`
- [x] `pnpm dev:cli feat del --help`
- [x] `pnpm dev:cli feat feedback --help`
- [x] `pnpm dev:cli feat promote --help`
- [x] `pnpm dev:cli feat review --help`
- [x] `pnpm dev:cli feat unarchive --help`

## Notes

- Documentation-only change; no runtime behavior changes.
- Example descriptions use inline English strings (not i18n), consistent with `ui.command.ts` and other CLI help examples.

Fixes #790