### PR TITLE
docs(cli): add plugin command help examples

### DIFF
--- a/src/presentation/cli/commands/plugin/catalog.command.ts
+++ b/src/presentation/cli/commands/plugin/catalog.command.ts
@@ -17,6 +17,14 @@ export function createCatalogCommand(): Command {
   const t = getCliI18n().t;
   return new Command('catalog')
     .description(t('cli:commands.plugin.catalog.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin catalog              Browse the curated plugin catalog
+  $ shep plugin catalog | grep mcp   Find MCP plugins before installing one
+  $ shep plugin add mempalace        Install a catalog plugin by slug`
+    )
     .action(async () => {
       try {
         const useCase = container.resolve(GetPluginCatalogUseCase);

--- a/src/presentation/cli/commands/plugin/disable.command.ts
+++ b/src/presentation/cli/commands/plugin/disable.command.ts
@@ -17,6 +17,13 @@ export function createDisableCommand(): Command {
   const t = getCliI18n().t;
   return new Command('disable')
     .description(t('cli:commands.plugin.disable.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin disable mempalace    Disable a plugin by name
+  $ shep plugin disable plugin_123   Disable a plugin by id`
+    )
     .argument('<name>', t('cli:commands.plugin.disable.nameArg'))
     .action(async (name: string) => {
       try {

--- a/src/presentation/cli/commands/plugin/enable.command.ts
+++ b/src/presentation/cli/commands/plugin/enable.command.ts
@@ -17,6 +17,13 @@ export function createEnableCommand(): Command {
   const t = getCliI18n().t;
   return new Command('enable')
     .description(t('cli:commands.plugin.enable.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin enable mempalace     Enable a plugin by name
+  $ shep plugin enable plugin_123    Enable a plugin by id`
+    )
     .argument('<name>', t('cli:commands.plugin.enable.nameArg'))
     .action(async (name: string) => {
       try {

--- a/src/presentation/cli/commands/plugin/remove.command.ts
+++ b/src/presentation/cli/commands/plugin/remove.command.ts
@@ -17,6 +17,13 @@ export function createRemoveCommand(): Command {
   const t = getCliI18n().t;
   return new Command('remove')
     .description(t('cli:commands.plugin.remove.description'))
+    .addHelpText(
+      'after',
+      `
+Examples:
+  $ shep plugin remove mempalace     Remove an installed plugin by name
+  $ shep plugin remove plugin_123    Remove an installed plugin by id`
+    )
     .argument('<name>', t('cli:commands.plugin.remove.nameArg'))
     .action(async (name: string) => {
       try {


### PR DESCRIPTION
## Summary
- add runtime `Examples:` blocks for `shep plugin catalog`
- add matching examples for `plugin enable`, `plugin disable`, and `plugin remove`
- keep the change to help output only

Closes #815.

## Test
- SHEP_HOME=$(mktemp -d) pnpm dev:cli plugin catalog --help
- SHEP_HOME=$(mktemp -d) pnpm dev:cli plugin disable --help
- SHEP_HOME=$(mktemp -d) pnpm dev:cli plugin enable --help
- SHEP_HOME=$(mktemp -d) pnpm dev:cli plugin remove --help
- pnpm validate