### PR TITLE
ci: disable daily good-first-issues automation, keep manual trigger

### DIFF
--- a/.github/workflows/generate-good-first-issues.yml
+++ b/.github/workflows/generate-good-first-issues.yml
@@ -1,7 +1,12 @@
-name: Generate good-first-issues (daily)
+name: Generate good-first-issues (manual)
 
+# DISABLED BY DEFAULT — this automation no longer runs on a schedule.
+# It is retained as a manually-triggered workflow only. To run it,
+# dispatch it explicitly from the Actions tab (or `gh workflow run`).
+# To re-enable daily automation, restore the `schedule:` trigger below.
+#
 # Runs an agent that scans the codebase + current AI trends and opens
-# up to 10 NEW good-first-issues per day in shep-ai/shep.
+# up to 10 NEW good-first-issues per run in shep-ai/shep.
 #
 # What it does:
 #   1. Checks out the repo (shallow — agent only needs to read)
@@ -23,11 +28,12 @@ name: Generate good-first-issues (daily)
 #                              permission below grants issue-create rights
 
 on:
-  schedule:
-    # Daily at 13:05 UTC (09:05 ET / 14:05 CET / 15:05 IST).
-    # Picked to run AFTER ai-tldr's 12:00 UTC sweep so the trends
-    # file we curl is fresh (ai-tldr runs every 2h at minute 0).
-    - cron: '5 13 * * *'
+  # Schedule disabled by default. Re-enable by uncommenting the cron
+  # below — it ran daily at 13:05 UTC (after ai-tldr's 12:00 UTC sweep
+  # so the trends file we curl is fresh; ai-tldr runs every 2h at
+  # minute 0).
+  # schedule:
+  #   - cron: '5 13 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -47,9 +53,9 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     # Sized for one ~25m agent run + a few minutes of setup. No
-    # retry pattern here — if the agent fails, the daily cron just
-    # tries again tomorrow. (Unlike ai-tldr's release sweep, missing
-    # a day of issue generation is not a data-loss event.)
+    # retry pattern here — if the agent fails, just re-dispatch the
+    # workflow manually. (Unlike ai-tldr's release sweep, missing
+    # a run of issue generation is not a data-loss event.)
     timeout-minutes: 35
 
     env:


### PR DESCRIPTION
## What

Disabled the daily scheduled automation for the good-first-issues workflow and converted it to manual-only (`workflow_dispatch`). The workflow can still be triggered explicitly from the Actions tab or via `gh workflow run`, but no longer runs on a cron schedule.

## Why

The daily automation is no longer needed. By disabling the schedule trigger while retaining the workflow file and manual dispatch capability, we preserve the ability to run issue generation on-demand without the overhead of daily executions. The schedule can be easily re-enabled in the future by uncommenting the cron configuration.

## Screenshots / Recording

N/A — non-UI change.

## Testing

No testing needed. This is a workflow configuration change that:
- Removes the `schedule` trigger (commented out with clear re-enable instructions)
- Retains the `workflow_dispatch` trigger for manual runs
- Updates documentation comments to reflect the new behavior
- Does not affect any code logic or dependencies

The workflow can be manually tested by dispatching it from the Actions tab.

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`ci:` scope for workflow changes)
- [x] No code logic changes — configuration only
- [x] Documentation comments updated to explain disabled state and re-enable instructions

https://claude.ai/code/session_013rR6SgRnZEtkBUyssrHu65