### PR TITLE
feat(agents): add Claude Fable 5 and Sonnet 5 to model catalog

### DIFF
--- a/packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts
+++ b/packages/core/src/infrastructure/services/agents/common/agent-model-catalog.ts
@@ -8,9 +8,11 @@
  */
 
 export const CLAUDE_CODE_MODELS: string[] = [
+  'claude-fable-5',
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
+  'claude-sonnet-5',
   'claude-sonnet-4-6',
   'claude-haiku-4-5',
   'glm-5.2',
@@ -29,6 +31,7 @@ export const CURSOR_MODELS: string[] = [
   'claude-opus-4-8',
   'claude-opus-4-7',
   'claude-opus-4-6',
+  'claude-sonnet-5',
   'claude-sonnet-4-6',
   'gpt-5.4-high',
   'gpt-5.2',

--- a/src/presentation/web/lib/model-metadata.ts
+++ b/src/presentation/web/lib/model-metadata.ts
@@ -9,9 +9,11 @@ export interface ModelMeta {
  */
 const MODEL_METADATA: Record<string, ModelMeta> = {
   // Claude models
+  'claude-fable-5': { displayName: 'Fable 5', description: 'Most capable, long-horizon agentic' },
   'claude-opus-4-8': { displayName: 'Opus 4.8', description: 'Most capable, complex tasks' },
   'claude-opus-4-7': { displayName: 'Opus 4.7', description: 'Previous flagship' },
   'claude-opus-4-6': { displayName: 'Opus 4.6', description: 'Legacy flagship' },
+  'claude-sonnet-5': { displayName: 'Sonnet 5', description: 'Near-Opus quality, fast' },
   'claude-sonnet-4-6': { displayName: 'Sonnet 4.6', description: 'Fast & balanced' },
   'claude-haiku-4-5': { displayName: 'Haiku 4.5', description: 'Lightweight & quick' },
 

--- a/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
+++ b/tests/unit/infrastructure/services/agents/agent-executor-factory.test.ts
@@ -349,9 +349,11 @@ describe('AgentExecutorFactory', () => {
       const models = factory.getSupportedModels(AgentType.ClaudeCode);
 
       expect(models).toEqual([
+        'claude-fable-5',
         'claude-opus-4-8',
         'claude-opus-4-7',
         'claude-opus-4-6',
+        'claude-sonnet-5',
         'claude-sonnet-4-6',
         'claude-haiku-4-5',
         'glm-5.2',
@@ -378,6 +380,7 @@ describe('AgentExecutorFactory', () => {
         'claude-opus-4-8',
         'claude-opus-4-7',
         'claude-opus-4-6',
+        'claude-sonnet-5',
         'claude-sonnet-4-6',
         'gpt-5.4-high',
         'gpt-5.2',


### PR DESCRIPTION
## Summary

The shep model catalog was missing Anthropic's two newest models. This adds them to the single source of truth and everything that reads from it (CLI, web pickers, Storybook mocks).

- **`claude-fable-5`** — most capable, long-horizon agentic
- **`claude-sonnet-5`** — near-Opus quality, fast

## Changes

- `agent-model-catalog.ts`
  - `CLAUDE_CODE_MODELS` (native Anthropic agent): + `claude-fable-5`, + `claude-sonnet-5`
  - `CURSOR_MODELS`: + `claude-sonnet-5` (GA in Cursor)
- `model-metadata.ts`: display name/description entries for both new IDs
- Updated the pinned `getSupportedModels` `toEqual` assertions (claude-code + cursor) to match

## Not included (needs product decision)

Left these third-party lists untouched to avoid claiming availability that isn't confirmed:
- `COPILOT_CLI_MODELS` (dot-notation) — could add `claude-sonnet-5` if Copilot exposes it
- `OPENROUTER_MODELS` — could add `anthropic/claude-sonnet-5`
- Fable 5 left off Cursor (premium/newest; unconfirmed there)

## Verification

- `pnpm typecheck` + `pnpm typecheck:web` clean
- `agent-executor-factory.test.ts` — 42/42 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)