### PR TITLE
Docs: add Lovable competitor profile

### DIFF
--- a/docs/competitors/README.md
+++ b/docs/competitors/README.md
@@ -88,9 +88,7 @@ These target a different audience (non-developers, rapid prototyping) but share 
 
 | Tool                               | Tagline                                         |
 | ---------------------------------- | ----------------------------------------------- |
-| [Lovable](https://lovable.dev)     | Build apps by chatting — $100M ARR in 8 months  |
-| [Bolt.new](https://bolt.new)       | Full-stack app generation in the browser        |
-| [v0](./v0.md)                      | Vercel's AI app builder trained on React/shadcn |
+| [Lovable](./lovable.md)            | Build apps by chatting — $100M ARR in 8 months  |
 | [Bolt.new](./bolt-new.md)          | Full-stack app generation in the browser        |
 | [v0](https://v0.dev)               | Vercel's AI app builder trained on React/shadcn |
 | [Replit Agent](https://replit.com) | Prompt to deployed app with hosting             |

--- a/docs/competitors/lovable.md
+++ b/docs/competitors/lovable.md
@@ -1,0 +1,51 @@
+# Lovable
+
+> Browser-based app builder for turning chat prompts into deployed web apps.
+
+|                 |                                              |
+| --------------- | -------------------------------------------- |
+| **Website**     | [lovable.dev](https://lovable.dev)           |
+| **Tagline**     | "Build apps by chatting"                     |
+| **Type**        | Browser-based app builder (no install)       |
+| **Pricing**     | Free tier + paid plans                       |
+| **Open Source** | No                                           |
+
+---
+
+## What It Does
+
+Lovable is a chat-first app builder for people who want to describe an app and get a working browser-hosted product without setting up a local development environment. It focuses on fast generation, visual iteration, and deployment from the web.
+
+### Key Features
+
+- **Chat-driven app generation** - Users describe what they want, then Lovable generates the app structure and code-backed experience
+- **Browser-based editing** - The main workflow runs in the browser, with prompt iteration and visual editing for generated apps
+- **Deploy and hosting flow** - Apps can be previewed, published, and hosted from the Lovable product experience
+- **Mobile entry point** - Lovable launched iOS and Android apps on April 28, 2026 so ideas can be started from a phone
+- **Google Cloud expansion** - Lovable announced a June 2026 Google Cloud expansion covering Gemini models, AI-optimized infrastructure, and Wiz security tooling
+- **Enterprise integration path** - Lovable documentation includes Gemini Enterprise integration for apps built on connected company data
+
+---
+
+## How Shep Compares
+
+|                        | Lovable                                 | Shep                                      |
+| ---------------------- | --------------------------------------- | ----------------------------------------- |
+| **Audience**           | Non-developers and rapid prototypers    | Developers and engineering teams          |
+| **Surface**            | Browser app + mobile apps               | CLI + Web dashboard                       |
+| **Lifecycle coverage** | Prompt -> generated deployed app        | Idea -> PRD -> plan -> CI gates -> PR     |
+| **Ownership model**    | Hosted app-builder workflow             | Local repo and worktree-centered workflow |
+| **Open source**        | No                                      | MIT                                       |
+| **Best fit**           | Ship a simple app quickly from prompts  | Own a full engineering change end-to-end  |
+
+### What We Respect
+
+Lovable makes the first step feel almost frictionless: a chat box, a deployed-by-default mental model, and a mobile entry point all reduce the gap between an idea and something a user can click. Wix's 2026 layoffs also show why AI-native app builders are now part of the strategic conversation for established site-builder companies.
+
+### Where Shep Differs
+
+Lovable wins when a non-developer wants a deployed app fast and is comfortable working inside a hosted builder. Shep is for developers who want full-cycle ownership of an engineering project: requirements, technical research, planning, code changes in a real repository, CI gates, and PR-ready review.
+
+---
+
+_Sources: [Lovable](https://lovable.dev), [Lovable blog](https://lovable.dev/blog), [Lovable docs](https://docs.lovable.dev/integrations/gemini-enterprise), [TechCrunch Google Cloud deal](https://techcrunch.com/2026/06/03/lovable-signs-multi-year-deal-with-google-cloud-to-up-usage-5x-source-says/), [TechCrunch mobile launch](https://techcrunch.com/2026/04/28/lovable-launches-its-vibe-coding-app-on-ios-and-android/), [TNW on Wix layoffs](https://thenextweb.com/news/wix-is-cutting-20-of-its-workforce-as-a-strong-shekel-and-ai-competition-squeeze-the-website-builder-from-both-sides)_


### PR DESCRIPTION
# Docs: add Lovable competitor profile

## Summary
- Add `docs/competitors/lovable.md` with a Lovable competitor profile matching the existing docs structure.
- Update `docs/competitors/README.md` so the App Builders table links to the new local profile.

## Testing
- `pnpm --config.verify-deps-before-run=false exec prettier --check docs/competitors/README.md docs/competitors/lovable.md`
- `git diff --check`

## Notes
- `pnpm --config.verify-deps-before-run=false validate` was attempted. It passed lint/format before failing in `vitest.config.ts:43` because of an existing Vite/Jiti duplicate dependency-path type mismatch unrelated to this docs-only change.
- Bounty Code Review Agent found no issues.
- No public GitHub claim, comment, push, or PR has been made.

