### PR TITLE
fix(web): add Codex CLI model display metadata entries

### DIFF
--- a/src/presentation/web/lib/model-metadata.ts
+++ b/src/presentation/web/lib/model-metadata.ts
@@ -27,8 +27,18 @@ const MODEL_METADATA: Record<string, ModelMeta> = {
 
   // OpenAI models
   'gpt-5.4-high': { displayName: 'GPT-5.4', description: 'Latest reasoning model' },
-  'gpt-5.2': { displayName: 'GPT-5.2', description: 'Flagship model' },
+  'gpt-5.4': { displayName: 'GPT-5.4', description: 'Codex flagship' },
+  'gpt-5.4-mini': { displayName: 'GPT-5.4 Mini', description: 'Fast, lower cost' },
   'gpt-5.3-codex': { displayName: 'GPT-5.3 Codex', description: 'Code specialist' },
+  'gpt-5.3-codex-spark': { displayName: 'GPT-5.3 Codex Spark', description: 'Codex 5.3, lower cost' },
+  'gpt-5.2-codex': { displayName: 'GPT-5.2 Codex', description: 'Previous Codex specialist' },
+  'gpt-5.2': { displayName: 'GPT-5.2', description: 'Flagship model' },
+  'gpt-5.1-codex-max': { displayName: 'GPT-5.1 Codex Max', description: 'Long-context Codex' },
+  'gpt-5.1-codex': { displayName: 'GPT-5.1 Codex', description: 'Codex 5.1' },
+  'gpt-5.1': { displayName: 'GPT-5.1', description: 'Legacy reasoning model' },
+  'gpt-5-codex': { displayName: 'GPT-5 Codex', description: 'Original Codex specialist' },
+  'gpt-5-codex-mini': { displayName: 'GPT-5 Codex Mini', description: 'Original Codex, lightweight' },
+  'gpt-5': { displayName: 'GPT-5', description: 'Legacy flagship' },
 
   // Other
   'composer-1.5': { displayName: 'Composer 1.5', description: 'Multi-file editing' },

--- a/src/presentation/web/lib/model-metadata.ts
+++ b/src/presentation/web/lib/model-metadata.ts
@@ -30,14 +30,20 @@ const MODEL_METADATA: Record<string, ModelMeta> = {
   'gpt-5.4': { displayName: 'GPT-5.4', description: 'Codex flagship' },
   'gpt-5.4-mini': { displayName: 'GPT-5.4 Mini', description: 'Fast, lower cost' },
   'gpt-5.3-codex': { displayName: 'GPT-5.3 Codex', description: 'Code specialist' },
-  'gpt-5.3-codex-spark': { displayName: 'GPT-5.3 Codex Spark', description: 'Codex 5.3, lower cost' },
+  'gpt-5.3-codex-spark': {
+    displayName: 'GPT-5.3 Codex Spark',
+    description: 'Codex 5.3, lower cost',
+  },
   'gpt-5.2-codex': { displayName: 'GPT-5.2 Codex', description: 'Previous Codex specialist' },
   'gpt-5.2': { displayName: 'GPT-5.2', description: 'Flagship model' },
   'gpt-5.1-codex-max': { displayName: 'GPT-5.1 Codex Max', description: 'Long-context Codex' },
   'gpt-5.1-codex': { displayName: 'GPT-5.1 Codex', description: 'Codex 5.1' },
   'gpt-5.1': { displayName: 'GPT-5.1', description: 'Legacy reasoning model' },
   'gpt-5-codex': { displayName: 'GPT-5 Codex', description: 'Original Codex specialist' },
-  'gpt-5-codex-mini': { displayName: 'GPT-5 Codex Mini', description: 'Original Codex, lightweight' },
+  'gpt-5-codex-mini': {
+    displayName: 'GPT-5 Codex Mini',
+    description: 'Original Codex, lightweight',
+  },
   'gpt-5': { displayName: 'GPT-5', description: 'Legacy flagship' },
 
   // Other

--- a/tests/unit/presentation/web/components/features/settings/AgentModelPicker.test.tsx
+++ b/tests/unit/presentation/web/components/features/settings/AgentModelPicker.test.tsx
@@ -127,7 +127,7 @@ describe('AgentModelPicker', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('combobox')).toHaveTextContent('Codex CLI');
-      expect(screen.getByRole('combobox')).toHaveTextContent('GPT 5.4');
+      expect(screen.getByRole('combobox')).toHaveTextContent('GPT-5.4');
     });
   });
 
@@ -163,7 +163,7 @@ describe('AgentModelPicker', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('combobox')).toHaveTextContent('Codex CLI');
-      expect(screen.getByRole('combobox')).toHaveTextContent('GPT 5.4');
+      expect(screen.getByRole('combobox')).toHaveTextContent('GPT-5.4');
     });
 
     deferred.resolve({ ok: false, error: 'Could not save pinned config' });
@@ -245,7 +245,7 @@ describe('AgentModelPicker', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('combobox')).toHaveTextContent('Codex CLI');
-      expect(screen.getByRole('combobox')).toHaveTextContent('GPT 5.4');
+      expect(screen.getByRole('combobox')).toHaveTextContent('GPT-5.4');
     });
 
     expect(onAgentModelChange).toHaveBeenCalledWith('codex-cli', 'gpt-5.4');


### PR DESCRIPTION
## Summary

Add `MODEL_METADATA` display-name entries for ten OpenAI Codex CLI model IDs that already ship in `CODEX_CLI_MODELS` but previously had no metadata entry, causing the agent model picker to show prettified labels with incorrect casing (e.g. "Gpt-5.4 Mini" instead of "GPT-5.4 Mini").

## Motivation

The Codex CLI model picker calls `getModelMeta(modelId).displayName` for each model ID. Without explicit entries, models fall through to the prettifier fallback and render with wrong casing.

Fixes #720

## Changes

- Added metadata entries for: `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`, `gpt-5.2-codex`, `gpt-5.1-codex-max`, `gpt-5.1-codex`, `gpt-5.1`, `gpt-5-codex`, `gpt-5-codex-mini`, `gpt-5`
- Preserved existing entries for `gpt-5.4-high`, `gpt-5.2`, and `gpt-5.3-codex`
- No changes to `CODEX_CLI_MODELS` or `getModelMeta()` behavior

## Tests

- `pnpm validate` (lint:fix, format, typecheck, tsp:compile) — passed

## Notes

Presentation-layer data only; no new dependencies or behavior changes.