### PR TITLE
test(web): seed deterministic e2e feature

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig, devices } from '@playwright/test';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import {
+  cleanupE2eShepHomeOnExit,
+  hasAssignedE2eShepHome,
+  resolveE2eShepHome,
+} from './tests/e2e/web/helpers/e2e-shep-home';
 
-const e2eShepHome = join(tmpdir(), `shep-e2e-web-${process.pid}`);
-process.env.SHEP_HOME = e2eShepHome;
+const ownsE2eShepHome = !hasAssignedE2eShepHome();
+const e2eShepHome = resolveE2eShepHome();
+if (ownsE2eShepHome) cleanupE2eShepHomeOnExit();
 
 /**
  * Playwright configuration for Shep AI Web UI E2E tests.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const e2eShepHome = join(tmpdir(), `shep-e2e-web-${process.pid}`);
+process.env.SHEP_HOME = e2eShepHome;
 
 /**
  * Playwright configuration for Shep AI Web UI E2E tests.
@@ -7,6 +12,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/e2e/web',
   globalSetup: './tests/e2e/web/global-setup.ts',
+  globalTeardown: './tests/e2e/web/global-teardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -45,9 +51,16 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'pnpm dev:web',
-    env: { PORT: '3001', SHEP_COLLABORATION_FLAG: '1', SHEP_MOCK_GATEWAY: '1' },
+    env: {
+      PORT: '3001',
+      SHEP_COLLABORATION_FLAG: '1',
+      SHEP_MOCK_GATEWAY: '1',
+      SHEP_HOME: e2eShepHome,
+    },
     url: 'http://localhost:3001',
-    reuseExistingServer: !process.env.CI,
+    // The fixture database and web server must share the isolated SHEP_HOME.
+    // Reusing an arbitrary local server would make this suite data-dependent.
+    reuseExistingServer: false,
     timeout: 120 * 1000,
   },
 });

--- a/tests/e2e/web/global-setup.ts
+++ b/tests/e2e/web/global-setup.ts
@@ -1,4 +1,5 @@
 import { openShepDb, setCollaborationFlag } from './helpers/collaboration-flag';
+import { seedOptimisticClickFeature } from './helpers/feature-fixtures';
 
 /**
  * Playwright global setup: flips the `collaboration` feature flag on in the
@@ -17,12 +18,8 @@ export default async function globalSetup(): Promise<void> {
   let db: ReturnType<typeof openShepDb> | null = null;
   try {
     db = openShepDb();
+    await seedOptimisticClickFeature(db);
     setCollaborationFlag(db, true);
-  } catch (err) {
-    // If the DB does not yet exist (very fresh CI env), the dev server will
-    // create it on boot with defaults. The supervisor / question tests will
-    // skip themselves in that case via the `flagPrecondition` check.
-    console.warn('[e2e global-setup] failed to enable collaboration flag:', err);
   } finally {
     db?.close();
   }

--- a/tests/e2e/web/global-teardown.ts
+++ b/tests/e2e/web/global-teardown.ts
@@ -1,0 +1,12 @@
+import { openShepDb } from './helpers/collaboration-flag';
+import { removeOptimisticClickFeature } from './helpers/feature-fixtures';
+
+export default async function globalTeardown(): Promise<void> {
+  let db: ReturnType<typeof openShepDb> | null = null;
+  try {
+    db = openShepDb();
+    await removeOptimisticClickFeature(db);
+  } finally {
+    db?.close();
+  }
+}

--- a/tests/e2e/web/helpers/collaboration-flag.ts
+++ b/tests/e2e/web/helpers/collaboration-flag.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
+import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 /**
  * Resolves the path to the singleton Shep SQLite database the dev server uses.
@@ -14,7 +15,9 @@ export function getShepDbPath(): string {
 }
 
 export function openShepDb(): Database.Database {
-  return new Database(getShepDbPath());
+  const dbPath = getShepDbPath();
+  mkdirSync(dirname(dbPath), { recursive: true });
+  return new Database(dbPath);
 }
 
 /**

--- a/tests/e2e/web/helpers/e2e-shep-home.ts
+++ b/tests/e2e/web/helpers/e2e-shep-home.ts
@@ -1,0 +1,54 @@
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const E2E_SHEP_HOME = 'SHEP_E2E_ISOLATED_HOME';
+
+export function hasAssignedE2eShepHome(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env[E2E_SHEP_HOME]);
+}
+
+/**
+ * Assigns one isolated SHEP_HOME to the entire Playwright run.
+ *
+ * Playwright evaluates its config in the runner, setup, and worker processes.
+ * Those child processes inherit this marker, so they must reuse the first
+ * directory instead of deriving another directory from their own PID.
+ */
+export function resolveE2eShepHome(
+  env: NodeJS.ProcessEnv = process.env,
+  pid = process.pid,
+  tempDirectory = tmpdir()
+): string {
+  const inheritedHome = env[E2E_SHEP_HOME];
+  if (inheritedHome) {
+    env.SHEP_HOME = inheritedHome;
+    return inheritedHome;
+  }
+
+  const isolatedHome = join(tempDirectory, `shep-e2e-web-${pid}`);
+  env[E2E_SHEP_HOME] = isolatedHome;
+  env.SHEP_HOME = isolatedHome;
+  return isolatedHome;
+}
+
+/** Removes only a directory that this E2E run marked as its own. */
+export function cleanupE2eShepHome(env: NodeJS.ProcessEnv = process.env): void {
+  const isolatedHome = env[E2E_SHEP_HOME];
+  if (!isolatedHome) return;
+
+  rmSync(isolatedHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  if (env.SHEP_HOME === isolatedHome) delete env.SHEP_HOME;
+  delete env[E2E_SHEP_HOME];
+}
+
+/** Schedules cleanup in the owner process, after Playwright stops its web server. */
+export function cleanupE2eShepHomeOnExit(env: NodeJS.ProcessEnv = process.env): void {
+  process.once('exit', () => {
+    try {
+      cleanupE2eShepHome(env);
+    } catch {
+      // The test result must not be replaced by a best-effort temp cleanup error.
+    }
+  });
+}

--- a/tests/e2e/web/helpers/feature-fixtures.ts
+++ b/tests/e2e/web/helpers/feature-fixtures.ts
@@ -1,0 +1,66 @@
+import 'reflect-metadata';
+import type Database from 'better-sqlite3';
+import type { IFeatureRepository } from '@/application/ports/output/repositories/feature-repository.interface.js';
+import type { Feature } from '@/domain/generated/output.js';
+import { BuildMode, SdlcLifecycle } from '@/domain/generated/output.js';
+import { runSQLiteMigrations } from '@/infrastructure/persistence/sqlite/migrations.js';
+import { SQLiteFeatureRepository } from '@/infrastructure/repositories/sqlite-feature.repository.js';
+
+export const OPTIMISTIC_CLICK_FEATURE_ID = 'e2e-optimistic-click-feature';
+export const OPTIMISTIC_CLICK_FEATURE_NAME = 'E2E Clickable Feature';
+
+const FIXTURE_DATE = new Date('2026-01-01T00:00:00.000Z');
+
+function createOptimisticClickFeature(): Feature {
+  return {
+    id: OPTIMISTIC_CLICK_FEATURE_ID,
+    name: OPTIMISTIC_CLICK_FEATURE_NAME,
+    slug: 'e2e-clickable-feature',
+    description: 'Deterministic fixture for optimistic node clickability tests',
+    userQuery: 'Verify that persisted feature nodes remain clickable during optimistic creation',
+    repositoryPath: '/test/repo',
+    branch: 'test/e2e-clickable-feature',
+    lifecycle: SdlcLifecycle.Requirements,
+    messages: [],
+    relatedArtifacts: [],
+    buildMode: BuildMode.Application,
+    fast: false,
+    push: false,
+    openPr: false,
+    forkAndPr: false,
+    commitSpecs: true,
+    ciWatchEnabled: false,
+    enableEvidence: false,
+    injectSkills: false,
+    commitEvidence: false,
+    approvalGates: { allowPrd: false, allowPlan: false, allowMerge: false },
+    createdAt: FIXTURE_DATE,
+    updatedAt: FIXTURE_DATE,
+  };
+}
+
+async function createFeatureRepository(db: Database.Database): Promise<IFeatureRepository> {
+  await runSQLiteMigrations(db);
+  return new SQLiteFeatureRepository(db);
+}
+
+export async function seedOptimisticClickFeature(db: Database.Database): Promise<void> {
+  const repository = await createFeatureRepository(db);
+  const fixture = createOptimisticClickFeature();
+  const existing = await repository.findById(OPTIMISTIC_CLICK_FEATURE_ID);
+
+  if (existing) {
+    await repository.update(fixture);
+    return;
+  }
+
+  // A previous interrupted run may have soft-deleted the fixture. Hard-delete
+  // by deterministic ID before creating so repeated setup remains idempotent.
+  await repository.delete(OPTIMISTIC_CLICK_FEATURE_ID);
+  await repository.create(fixture);
+}
+
+export async function removeOptimisticClickFeature(db: Database.Database): Promise<void> {
+  const repository = await createFeatureRepository(db);
+  await repository.delete(OPTIMISTIC_CLICK_FEATURE_ID);
+}

--- a/tests/e2e/web/optimistic-node-clickability.spec.ts
+++ b/tests/e2e/web/optimistic-node-clickability.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+import { OPTIMISTIC_CLICK_FEATURE_NAME } from './helpers/feature-fixtures';
+
+function seededFeatureCard(page: Page) {
+  return page.locator('[data-testid="feature-node-card"]').filter({
+    has: page.getByRole('heading', { name: OPTIMISTIC_CLICK_FEATURE_NAME, exact: true }),
+  });
+}
 
 test.describe('Feature node clickability — drawer opens after feature creation', () => {
   test('clicking existing feature nodes opens the detail drawer after submitting the create form', async ({
@@ -41,19 +48,8 @@ test.describe('Feature node clickability — drawer opens after feature creation
     // Navigate to control center
     await page.goto('/control-center');
 
-    // Check if any feature nodes exist
-    const featureCards = page.locator('[data-testid="feature-node-card"]');
-    const hasFeatures = await featureCards
-      .first()
-      .isVisible({ timeout: 10000 })
-      .catch(() => false);
-    test.skip(!hasFeatures, 'Need at least 1 existing feature node to test clickability');
-
-    // Remember the name of the first existing feature node for drawer verification
-    const firstNodeHeading = page
-      .locator('[data-testid="feature-node-card"]:not([aria-busy="true"]) h3')
-      .first();
-    const firstNodeName = await firstNodeHeading.textContent();
+    const existingFeature = seededFeatureCard(page);
+    await expect(existingFeature).toBeVisible({ timeout: 10000 });
 
     // Step 1: Open the create-feature drawer by navigating to /create with repo selected
     await page.goto('/create?repo=/test/repo');
@@ -79,9 +75,7 @@ test.describe('Feature node clickability — drawer opens after feature creation
     });
 
     // Step 4: While the server action is still in-flight, click on an existing feature node
-    const clickableNode = page
-      .locator('[data-testid="feature-node-card"]:not([aria-busy="true"])')
-      .first();
+    const clickableNode = seededFeatureCard(page);
     await expect(clickableNode).toBeVisible();
     await clickableNode.click();
 
@@ -89,52 +83,18 @@ test.describe('Feature node clickability — drawer opens after feature creation
     const drawerHeader = page.locator('[data-testid="feature-drawer-header"]');
     await expect(drawerHeader).toBeVisible({ timeout: 5000 });
 
-    // The drawer should show the name of the clicked feature
-    if (firstNodeName) {
-      await expect(drawerHeader).toContainText(firstNodeName);
-    }
-
-    // Step 6: Close the drawer by pressing Escape
-    await page.keyboard.press('Escape');
-    await expect(drawerHeader).not.toBeVisible({ timeout: 3000 });
-
-    // Step 7: Click a different existing node (if available) to verify multiple clicks work
-    const secondClickableNode = page
-      .locator('[data-testid="feature-node-card"]:not([aria-busy="true"])')
-      .nth(1);
-
-    if ((await secondClickableNode.count()) > 0) {
-      await secondClickableNode.click();
-
-      // Drawer should open again for the second node
-      await expect(drawerHeader).toBeVisible({ timeout: 5000 });
-
-      // Close again
-      await page.keyboard.press('Escape');
-      await expect(drawerHeader).not.toBeVisible({ timeout: 3000 });
-    }
+    await expect(drawerHeader).toContainText(OPTIMISTIC_CLICK_FEATURE_NAME);
   });
 });
 
-test.describe('All feature nodes open a drawer on click', () => {
-  test('clicking each non-creating feature node opens some drawer', async ({ page }) => {
+test.describe('Persisted feature nodes open a drawer on click', () => {
+  test('clicking the seeded non-creating feature opens its drawer', async ({ page }) => {
     // Navigate to control center
     await page.goto('/control-center');
 
-    // Check if any feature nodes exist (use isVisible with short timeout to avoid blocking)
-    const featureCards = page.locator('[data-testid="feature-node-card"]');
-    const hasFeatures = await featureCards
-      .first()
-      .isVisible({ timeout: 10000 })
-      .catch(() => false);
-    test.skip(!hasFeatures, 'Need at least 1 feature node to test drawer opening');
-
-    // Get all non-creating feature nodes
-    const clickableNodes = page.locator(
-      '[data-testid="feature-node-card"]:not([aria-busy="true"])'
-    );
+    const clickableNodes = seededFeatureCard(page);
+    await expect(clickableNodes).toBeVisible({ timeout: 10000 });
     const clickableCount = await clickableNodes.count();
-    test.skip(clickableCount < 1, 'Need at least 1 non-creating feature node');
 
     const drawerHeader = page.locator('[data-testid="feature-drawer-header"]');
 

--- a/tests/unit/e2e/web/e2e-shep-home.test.ts
+++ b/tests/unit/e2e/web/e2e-shep-home.test.ts
@@ -1,0 +1,54 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  cleanupE2eShepHome,
+  hasAssignedE2eShepHome,
+  resolveE2eShepHome,
+} from '../../../e2e/web/helpers/e2e-shep-home';
+
+const environmentsToClean = new Set<NodeJS.ProcessEnv>();
+
+afterEach(() => {
+  for (const env of environmentsToClean) cleanupE2eShepHome(env);
+  environmentsToClean.clear();
+});
+
+describe('E2E SHEP_HOME lifecycle', () => {
+  it('reuses the inherited home when Playwright evaluates config in another process', () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: 'test' };
+    const firstHome = resolveE2eShepHome(env, 101, tmpdir());
+    environmentsToClean.add(env);
+
+    expect(hasAssignedE2eShepHome(env)).toBe(true);
+    expect(resolveE2eShepHome(env, 202, tmpdir())).toBe(firstHome);
+    expect(env.SHEP_HOME).toBe(firstHome);
+  });
+
+  it('does not reuse a developer SHEP_HOME as the isolated test database', () => {
+    const env: NodeJS.ProcessEnv = {
+      NODE_ENV: 'test',
+      SHEP_HOME: join(tmpdir(), 'personal-shep-home'),
+    };
+    const isolatedHome = resolveE2eShepHome(env, 202, tmpdir());
+    environmentsToClean.add(env);
+
+    expect(isolatedHome).not.toBe(join(tmpdir(), 'personal-shep-home'));
+    expect(env.SHEP_HOME).toBe(isolatedHome);
+  });
+
+  it('removes the isolated home after the suite', () => {
+    const env: NodeJS.ProcessEnv = { NODE_ENV: 'test' };
+    const home = resolveE2eShepHome(env, 303, tmpdir());
+    environmentsToClean.add(env);
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, 'sentinel'), 'test');
+
+    cleanupE2eShepHome(env);
+    environmentsToClean.delete(env);
+
+    expect(existsSync(home)).toBe(false);
+    expect(env.SHEP_HOME).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

- seed a domain-valid feature through `IFeatureRepository` during Playwright global setup
- run web E2E tests against an isolated `SHEP_HOME` shared with the managed web server
- target the deterministic fixture instead of ambient database rows
- remove the three data-dependent skip paths and clean up the fixture in global teardown

## Why

The clickability suite could report a green run without executing its assertions when the local SQLite database contained no features. A deterministic persisted fixture makes missing setup fail loudly and keeps the tests independent of developer data.

The `creating` node is intentionally not persisted: it is a client-only optimistic state already produced by the delayed create action in the first test. The seeded persisted feature supplies the non-creating node that must remain clickable during that state.

## Validation

- `pnpm run typecheck`
- `pnpm run tsp:compile`
- ESLint and Prettier checks for all changed files
- focused Chromium suite twice consecutively: 2 passed, 0 skipped on both runs

Closes #624
