### PR TITLE
fix(release): reject overused release note openers and retry

### DIFF
--- a/scripts/release-notes-claude.mjs
+++ b/scripts/release-notes-claude.mjs
@@ -63,6 +63,16 @@ function isMaintenanceOnlyFraming(tagline) {
   return MAINTENANCE_ONLY_PATTERNS.some((re) => re.test(tagline));
 }
 
+// Openers Claude keeps reaching for on quiet releases, to the point they've
+// become boilerplate in their own right (e.g. "Keeping the lights on" opened
+// 7 of the last 9 releases). Reject and retry rather than let a tagline meant
+// to fight staleness become exactly as repetitive as the text it replaced.
+const OVERUSED_OPENER_PATTERNS = [/^keeping the lights on\b/i, /^housekeeping\b/i];
+
+function isOverusedOpener(tagline) {
+  return OVERUSED_OPENER_PATTERNS.some((re) => re.test(String(tagline).trim()));
+}
+
 function buildPrompt({ commits, version }) {
   const summary = summarizeCommits(commits) || '- (chore-only release)';
   const userFacing = hasUserFacingChanges(commits);
@@ -76,7 +86,10 @@ function buildPrompt({ commits, version }) {
       ]
     : [
         'This is a chore-only release with no feature/fix/perf commits. Keep the',
-        'tagline modest and honest — do not invent user-facing features.',
+        'tagline modest and honest — do not invent user-facing features. Ground it',
+        'in something concrete from the commits/scope below (which area of the',
+        'codebase, what kind of chore) instead of a vague label, so it reads',
+        "differently release over release — don't just reach for a generic label.",
       ];
   return [
     `You are writing the one-line tagline for the v${version} release of Shep — an autonomous AI-native SDLC platform that runs parallel AI agents in isolated git worktrees to automate the dev cycle from idea to deploy.`,
@@ -96,6 +109,9 @@ function buildPrompt({ commits, version }) {
     '- Do NOT include the leading ">" markdown blockquote character.',
     '- Do NOT prefix with "We\'re excited" / "Introducing" / "In this release".',
     '- Do NOT wrap in quotes.',
+    '- NEVER open with "Keeping the lights on" or "Housekeeping..." — these',
+    '  exact openers have been overused across past releases; find fresh,',
+    '  specific phrasing every time, even for a quiet release.',
     '',
     'Output ONLY the tagline text, nothing else.',
   ].join('\n');
@@ -209,15 +225,29 @@ export async function generateTagline({
 
   try {
     const prompt = buildPrompt({ commits, version });
-    const raw = await runQuery(queryFn, prompt, queryOptions);
-    const tagline = postProcessTagline(raw);
+    let tagline = postProcessTagline(await runQuery(queryFn, prompt, queryOptions));
+
+    if (tagline && shouldRejectTagline(tagline, commits)) {
+      logger.info?.(
+        `[release-notes] Claude tagline was overused/contradictory ("${tagline}"); retrying with stronger guidance.`
+      );
+      const retryPrompt = [
+        prompt,
+        '',
+        `Your previous attempt was: "${tagline}"`,
+        'That repeats an overused opener or contradicts the shipped changes. Write a',
+        'completely different tagline this time — different opening words, different structure.',
+      ].join('\n');
+      tagline = postProcessTagline(await runQuery(queryFn, retryPrompt, queryOptions));
+    }
+
     if (!tagline) {
       logger.warn?.('[release-notes] Claude returned empty tagline; using static tagline.');
       return null;
     }
-    if (hasUserFacingChanges(commits) && isMaintenanceOnlyFraming(tagline)) {
+    if (shouldRejectTagline(tagline, commits)) {
       logger.warn?.(
-        `[release-notes] Claude tagline framed a user-facing release as maintenance ("${tagline}"); using static tagline.`
+        `[release-notes] Claude tagline still overused/contradictory after retry ("${tagline}"); using static tagline.`
       );
       return null;
     }
@@ -229,6 +259,11 @@ export async function generateTagline({
   }
 }
 
+function shouldRejectTagline(tagline, commits) {
+  if (isOverusedOpener(tagline)) return true;
+  return hasUserFacingChanges(commits) && isMaintenanceOnlyFraming(tagline);
+}
+
 export const __test__ = {
   buildPrompt,
   postProcessTagline,
@@ -236,5 +271,6 @@ export const __test__ = {
   hasAuthCredentials,
   hasUserFacingChanges,
   isMaintenanceOnlyFraming,
+  isOverusedOpener,
   STATIC_TAGLINE,
 };

--- a/tests/unit/scripts/release-notes-claude.test.ts
+++ b/tests/unit/scripts/release-notes-claude.test.ts
@@ -17,6 +17,7 @@ const internals = __test__ as unknown as {
   hasAuthCredentials: (env: Record<string, string | undefined>) => boolean;
   hasUserFacingChanges: (commits: unknown[]) => boolean;
   isMaintenanceOnlyFraming: (tagline: string) => boolean;
+  isOverusedOpener: (tagline: string) => boolean;
   buildPrompt: (args: { commits: unknown[]; version: string }) => string;
 };
 const {
@@ -25,6 +26,7 @@ const {
   hasAuthCredentials,
   hasUserFacingChanges,
   isMaintenanceOnlyFraming,
+  isOverusedOpener,
   buildPrompt,
 } = internals;
 
@@ -135,6 +137,23 @@ describe('isMaintenanceOnlyFraming', () => {
   });
 });
 
+describe('isOverusedOpener', () => {
+  it('flags "Keeping the lights on" regardless of what follows', () => {
+    expect(isOverusedOpener('Keeping the lights on — a quiet release.')).toBe(true);
+    expect(isOverusedOpener('keeping the lights on with a few small fixes.')).toBe(true);
+  });
+
+  it('flags a bare "Housekeeping" opener', () => {
+    expect(isOverusedOpener('Housekeeping only — no user-facing changes.')).toBe(true);
+    expect(isOverusedOpener('Housekeeping under the hood this release.')).toBe(true);
+  });
+
+  it('does not flag a fresh, specific tagline', () => {
+    expect(isOverusedOpener('Tabs galore — every spec now has a story.')).toBe(false);
+    expect(isOverusedOpener('Small fixes, steady hands this time around.')).toBe(false);
+  });
+});
+
 describe('buildPrompt', () => {
   it('forbids maintenance framing when the release is user-facing', () => {
     const prompt = buildPrompt({
@@ -151,6 +170,19 @@ describe('buildPrompt', () => {
       version: '1.0.0',
     });
     expect(prompt).toContain('chore-only release');
+  });
+
+  it('warns against the overused "Keeping the lights on" opener for every release', () => {
+    const featPrompt = buildPrompt({
+      commits: [{ type: 'feat', subject: 'add aspm' }],
+      version: '1.210.0',
+    });
+    const chorePrompt = buildPrompt({
+      commits: [{ type: 'chore', subject: 'bump deps' }],
+      version: '1.0.0',
+    });
+    expect(featPrompt).toContain('Keeping the lights on');
+    expect(chorePrompt).toContain('Keeping the lights on');
   });
 });
 
@@ -245,6 +277,59 @@ describe('generateTagline', () => {
     const tagline = await generateTagline({ commits: [], claudeQuery, env: TEST_ENV } as never);
     expect(tagline).toBeNull();
     expect(claudeQuery).not.toHaveBeenCalled();
+  });
+
+  it('retries once with fresh guidance when the first attempt uses an overused opener', async () => {
+    const claudeQuery = vi
+      .fn()
+      .mockReturnValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield {
+            type: 'result',
+            subtype: 'success',
+            result: 'Keeping the lights on — a quiet release.',
+          };
+        },
+      })
+      .mockReturnValueOnce({
+        [Symbol.asyncIterator]: async function* () {
+          yield { type: 'result', subtype: 'success', result: 'Small fixes, steady hands.' };
+        },
+      });
+
+    const tagline = await generateTagline({
+      commits: [{ type: 'chore', subject: 'bump deps' }],
+      version: '1.0.0',
+      claudeQuery,
+      env: TEST_ENV,
+      logger: { info: () => undefined, warn: () => undefined },
+    });
+
+    expect(tagline).toBe('Small fixes, steady hands.');
+    expect(claudeQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to null when both attempts use an overused opener', async () => {
+    const claudeQuery = vi.fn().mockReturnValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Keeping the lights on — a quiet release.',
+        };
+      },
+    });
+
+    const tagline = await generateTagline({
+      commits: [{ type: 'chore', subject: 'bump deps' }],
+      version: '1.0.0',
+      claudeQuery,
+      env: TEST_ENV,
+      logger: { info: () => undefined, warn: () => undefined },
+    });
+
+    expect(tagline).toBeNull();
+    expect(claudeQuery).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## What

Added detection and rejection of overused release note openers ("Keeping the lights on" and "Housekeeping") in Claude-generated taglines. When detected, the system now retries with stronger guidance to encourage fresh, specific phrasing. Falls back to static tagline if both attempts fail.

## Why

Claude has been reaching for the same generic openers repeatedly — "Keeping the lights on" opened 7 of the last 9 releases. These phrases, meant to fight staleness, have become boilerplate themselves. This change enforces variety by rejecting them and requesting different opening words and structure on retry, ensuring each release tagline reads distinctly.

## Testing

Added comprehensive unit tests covering:
- `isOverusedOpener()` function detects both "Keeping the lights on" and "Housekeeping" openers (case-insensitive)
- `buildPrompt()` includes explicit guidance against overused openers
- `generateTagline()` retries once when first attempt uses an overused opener
- `generateTagline()` falls back to null when both attempts fail the check

All tests pass; existing test suite remains green.

## Checklist

- [x] `pnpm test:unit` passes (new tests added and passing)
- [x] No breaking changes to public API
- [x] Follows Conventional Commits format

N/A — non-UI change.

https://claude.ai/code/session_01U3yNt3gQRYPfJ64jTxZpZB