### PR TITLE
fix(cli): surface actionable error when better-sqlite3 binding fails to load

### DIFF
--- a/LESSONS.md
+++ b/LESSONS.md
@@ -1,5 +1,16 @@
 # Lessons Learned
 
+## Native modules (better-sqlite3) break global installs — surface a fix, don't crash
+
+A user's `npm i -g @shepai/cli` crashed at startup with `Could not locate the bindings file` from `better-sqlite3`. `better-sqlite3` is a native addon: its compiled `.node` binary must match the running Node ABI, and a global install can end up with no binary at all (install scripts skipped via `ignore-scripts`, no prebuilt for a brand-new Node like v24/ABI 137, or a stale binary after a Node upgrade). The raw error is a meaningless multi-line stack to an end user.
+
+Rules:
+
+1. **Any `new Database()` (or other native-addon load) at bootstrap MUST be wrapped** so the raw failure becomes a typed, actionable error. See `infrastructure/errors/sqlite-native-binding-error.ts` (`isSqliteNativeBindingError`/`toSqliteNativeBindingError`) + the try/catch in `sqlite/connection.ts`. The CLI bootstrap prints `err.remediation`, not a stack.
+2. **`bootstrap()` opens the DB before ANY command (including `doctor`) is parsed.** So a `shep doctor` diagnostic that probes the binding is UNREACHABLE in the exact failure it targets — the process dies at DB init first. Don't add a doctor check for a bootstrap-fatal dependency; fix it on the failure path (runtime error) + install path (postinstall guard) instead.
+3. **Migrating shep's own persistence to `node:sqlite` would NOT remove `better-sqlite3`** — `@langchain/langgraph-checkpoint-sqlite`'s `SqliteSaver` depends on it directly (confirmed in `pnpm-lock.yaml`). Before scoping a "drop the native dep" migration, grep the lockfile for transitive dependents; the dep often survives the migration via a library you don't control.
+4. **A `files`-allowlisted `postinstall` guard must never fail the install.** `scripts/verify-native-bindings.mjs` probes the addon, attempts ONE `npm rebuild`, prints guidance, and always `exit(0)`. A throwing postinstall bricks `npm i`. Remember to add the script path to `package.json` `files` or it won't ship in the tarball.
+
 ## Adding Enum Members — Grep String Literals, Not Just `Enum.Member`
 
 Adding `Analyzing`/`Installing` to `DeploymentState` (spec 103, task-14) required updating every place that treats a deployment as "active". Grepping for `DeploymentState\.` found the touchpoints written as `deploy.status === DeploymentState.Booting`, but missed FIVE more call sites that compared against raw **string literals** instead: `deployAction.status === 'Booting' || deployAction.status === 'Ready'` in `base-drawer.tsx`, `repository-node.tsx`, `feature-node.tsx`, `repository-drawer-client.tsx`, and `feature-drawer-client.tsx`. All five happened to reuse the exact variable name `isDeploymentActive`/`isDeployActive` — a strong signal it should have been one shared helper from the start.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -231,10 +231,17 @@ export default tseslint.config(
   },
 
   // =============================================================================
-  // Dev tooling scripts - console output is their user interface
+  // Dev tooling scripts - console output is their user interface, and plain
+  // .mjs/.cjs helpers run in Node with its globals available.
   // =============================================================================
   {
-    files: ['scripts/**/*.ts'],
+    files: ['scripts/**/*.ts', 'scripts/**/*.mjs', 'scripts/**/*.cjs', 'scripts/**/*.js'],
+    languageOptions: {
+      globals: {
+        process: 'readonly',
+        console: 'readonly',
+      },
+    },
     rules: {
       'no-console': 'off',
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -231,17 +231,10 @@ export default tseslint.config(
   },
 
   // =============================================================================
-  // Dev tooling scripts - console output is their user interface, and plain
-  // .mjs/.cjs helpers run in Node with its globals available.
+  // Dev tooling scripts - console output is their user interface
   // =============================================================================
   {
-    files: ['scripts/**/*.ts', 'scripts/**/*.mjs', 'scripts/**/*.cjs', 'scripts/**/*.js'],
-    languageOptions: {
-      globals: {
-        process: 'readonly',
-        console: 'readonly',
-      },
-    },
+    files: ['scripts/**/*.ts'],
     rules: {
       'no-console': 'off',
     },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "apis",
     "dist",
     "web",
+    "scripts/verify-native-bindings.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -88,6 +89,7 @@
     "spec:validate": "tsx scripts/spec-validate.ts",
     "cli": "tsx src/presentation/cli/index.ts",
     "prepare": "husky",
+    "postinstall": "node scripts/verify-native-bindings.mjs",
     "validate": "pnpm run lint:fix && pnpm run format && pnpm run typecheck && pnpm run tsp:compile",
     "electron:dev": "pnpm --filter @shepai/electron dev",
     "apps:dev": "cross-env ELECTRON_RUN_AS_NODE= SHEP_SHELL_VARIANT=apps-only pnpm --filter @shepai/electron dev",

--- a/packages/core/src/infrastructure/errors/sqlite-native-binding-error.ts
+++ b/packages/core/src/infrastructure/errors/sqlite-native-binding-error.ts
@@ -1,0 +1,115 @@
+/**
+ * SQLite Native Binding Error
+ *
+ * `better-sqlite3` is a native addon: it needs a compiled `better_sqlite3.node`
+ * binary that matches the exact Node.js ABI on the user's machine. When that
+ * binary is missing (install scripts were skipped, no prebuilt exists for the
+ * running Node version, or the toolchain couldn't compile it) or targets a
+ * different ABI (Node was upgraded after install), opening a connection throws
+ * a raw, multi-line "Could not locate the bindings file" / NODE_MODULE_VERSION
+ * error with a stack trace that means nothing to an end user.
+ *
+ * This module classifies those raw failures and turns them into a typed error
+ * carrying concise, cross-platform remediation — surfaced by `connection.ts`
+ * so the CLI can print a fix instead of a stack trace.
+ */
+
+export enum SqliteNativeBindingErrorCode {
+  /** No compiled `.node` binary could be located at all. */
+  BINDINGS_NOT_FOUND = 'BINDINGS_NOT_FOUND',
+  /** A binary exists but was built for a different Node ABI (NODE_MODULE_VERSION). */
+  ABI_MISMATCH = 'ABI_MISMATCH',
+}
+
+const NATIVE_MODULE = 'better-sqlite3';
+
+/** Substrings that uniquely identify a native-binding load failure. */
+const BINDINGS_NOT_FOUND_MARKER = 'could not locate the bindings file';
+const ABI_MISMATCH_MARKER = 'node_module_version';
+const DLOPEN_FAILED_CODE = 'ERR_DLOPEN_FAILED';
+
+function extractMessage(err: unknown): string | null {
+  if (err instanceof Error) return err.message;
+  return null;
+}
+
+function extractCode(err: unknown): string | null {
+  if (err !== null && typeof err === 'object' && 'code' in err) {
+    const code = (err as { code?: unknown }).code;
+    return typeof code === 'string' ? code : null;
+  }
+  return null;
+}
+
+/**
+ * Returns true when the given value is a native-binding load failure from
+ * `better-sqlite3` (missing binary or ABI mismatch), as opposed to an ordinary
+ * SQL/runtime error.
+ */
+export function isSqliteNativeBindingError(err: unknown): boolean {
+  const message = extractMessage(err);
+  if (message !== null) {
+    const lower = message.toLowerCase();
+    if (lower.includes(BINDINGS_NOT_FOUND_MARKER) || lower.includes(ABI_MISMATCH_MARKER)) {
+      return true;
+    }
+  }
+  return extractCode(err) === DLOPEN_FAILED_CODE;
+}
+
+function classify(err: unknown): SqliteNativeBindingErrorCode {
+  const lower = (extractMessage(err) ?? '').toLowerCase();
+  if (lower.includes(ABI_MISMATCH_MARKER)) {
+    return SqliteNativeBindingErrorCode.ABI_MISMATCH;
+  }
+  return SqliteNativeBindingErrorCode.BINDINGS_NOT_FOUND;
+}
+
+/**
+ * Builds a concise, cross-platform remediation block. Kept free of ANSI colour
+ * so it renders identically in logs, CI output, and the terminal.
+ */
+function buildRemediation(nodeVersion: string): string {
+  return [
+    `The '${NATIVE_MODULE}' native module could not be loaded for Node ${nodeVersion}.`,
+    'This usually means its compiled binary is missing or was built for a different Node version.',
+    '',
+    'Try, in order:',
+    `  1. Rebuild the binary:   npm rebuild -g ${NATIVE_MODULE}`,
+    '  2. Reinstall shep:       npm install -g @shepai/cli --foreground-scripts',
+    '  3. If it still fails, install a compiler toolchain, then retry step 2:',
+    '       macOS:   xcode-select --install',
+    '       Linux:   install build-essential + python3',
+    '       Windows: npm install -g windows-build-tools (or install Visual Studio Build Tools)',
+    '',
+    'If you recently upgraded Node, the old binary no longer matches the new ABI — step 1 fixes that.',
+  ].join('\n');
+}
+
+export class SqliteNativeBindingError extends Error {
+  readonly code: SqliteNativeBindingErrorCode;
+  readonly remediation: string;
+
+  constructor(code: SqliteNativeBindingErrorCode, remediation: string, cause?: unknown) {
+    super(`Failed to load the ${NATIVE_MODULE} native database module`, { cause });
+    this.name = 'SqliteNativeBindingError';
+    this.code = code;
+    this.remediation = remediation;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Wraps a raw native-binding failure in a typed {@link SqliteNativeBindingError}
+ * with actionable remediation. Callers should guard with
+ * {@link isSqliteNativeBindingError} first.
+ *
+ * @param err - The original error thrown by `better-sqlite3`.
+ * @param nodeVersion - Running Node version (defaults to `process.version`).
+ */
+export function toSqliteNativeBindingError(
+  err: unknown,
+  nodeVersion: string = process.version
+): SqliteNativeBindingError {
+  return new SqliteNativeBindingError(classify(err), buildRemediation(nodeVersion), err);
+}

--- a/packages/core/src/infrastructure/persistence/sqlite/connection.ts
+++ b/packages/core/src/infrastructure/persistence/sqlite/connection.ts
@@ -10,6 +10,10 @@ import {
   ensureShepDirectory,
   getShepDbPath,
 } from '../../services/filesystem/shep-directory.service.js';
+import {
+  isSqliteNativeBindingError,
+  toSqliteNativeBindingError,
+} from '../../errors/sqlite-native-binding-error.js';
 
 /**
  * Singleton database instance.
@@ -45,11 +49,21 @@ export async function getSQLiteConnection(): Promise<Database.Database> {
   // Get database path
   const dbPath = getShepDbPath();
 
-  // Create database connection
-  dbInstance = new Database(dbPath, {
-    // eslint-disable-next-line no-console
-    verbose: process.env.DEBUG_SQL ? console.log : undefined,
-  });
+  // Create database connection. better-sqlite3 is a native addon; if its
+  // compiled binary is missing or built for a different Node ABI, construction
+  // throws a raw "Could not locate the bindings file" error. Translate that
+  // into a typed, actionable error so the CLI can print a fix, not a stack.
+  try {
+    dbInstance = new Database(dbPath, {
+      // eslint-disable-next-line no-console
+      verbose: process.env.DEBUG_SQL ? console.log : undefined,
+    });
+  } catch (err) {
+    if (isSqliteNativeBindingError(err)) {
+      throw toSqliteNativeBindingError(err);
+    }
+    throw err;
+  }
 
   // Configure pragmas for production use
   // WAL mode: Better concurrency, write performance

--- a/scripts/verify-native-bindings.mjs
+++ b/scripts/verify-native-bindings.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* global process, console */
 /**
  * Post-install native-binding guard.
  *

--- a/scripts/verify-native-bindings.mjs
+++ b/scripts/verify-native-bindings.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Post-install native-binding guard.
+ *
+ * `better-sqlite3` is a native addon shep needs at startup. When it's installed
+ * globally (`npm i -g @shepai/cli`) its compiled binary can end up missing —
+ * install scripts skipped, no prebuilt for the running Node ABI, or a stale
+ * binary after a Node upgrade — and the CLI then crashes on first run with a
+ * raw "Could not locate the bindings file" error.
+ *
+ * This script runs after install, probes whether the addon actually loads, and
+ * if not makes ONE attempt to rebuild it, then prints clear guidance. It is
+ * intentionally best-effort: it NEVER fails the install (always exits 0) so a
+ * probe hiccup can't brick `npm i`. The runtime error in connection.ts is the
+ * backstop if this can't recover.
+ */
+
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+
+const require = createRequire(import.meta.url);
+const NATIVE_MODULE = 'better-sqlite3';
+
+/**
+ * Try to load better-sqlite3 and open an in-memory database.
+ * @returns {{ ok: true } | { ok: false, resolvable: boolean, error: Error }}
+ */
+function probe() {
+  let Database;
+  try {
+    Database = require(NATIVE_MODULE);
+  } catch (error) {
+    // MODULE_NOT_FOUND means the package itself isn't here — nothing to rebuild.
+    const resolvable = !(error && error.code === 'MODULE_NOT_FOUND');
+    return { ok: false, resolvable, error };
+  }
+  try {
+    const db = new Database(':memory:');
+    db.close();
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, resolvable: true, error };
+  }
+}
+
+function attemptRebuild() {
+  try {
+    console.log(
+      `[shep] Rebuilding the ${NATIVE_MODULE} native module for Node ${process.version}...`
+    );
+    execFileSync('npm', ['rebuild', NATIVE_MODULE], {
+      stdio: 'inherit',
+      timeout: 5 * 60 * 1000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function printManualGuidance() {
+  const lines = [
+    '',
+    `[shep] Could not load the ${NATIVE_MODULE} native module for Node ${process.version}.`,
+    '[shep] shep needs it to run. Try, in order:',
+    `[shep]   1. npm rebuild -g ${NATIVE_MODULE}`,
+    '[shep]   2. npm install -g @shepai/cli --foreground-scripts',
+    '[shep]   3. Install a compiler toolchain, then retry step 2:',
+    '[shep]        macOS:   xcode-select --install',
+    '[shep]        Linux:   build-essential + python3',
+    '[shep]        Windows: Visual Studio Build Tools',
+    '',
+  ];
+  console.warn(lines.join('\n'));
+}
+
+function main() {
+  const first = probe();
+  if (first.ok) return;
+
+  // Package not present (e.g. --ignore-scripts stripped it, or a partial
+  // install): a rebuild can't help, so just point the user at the fix.
+  if (!first.resolvable) {
+    printManualGuidance();
+    return;
+  }
+
+  if (attemptRebuild() && probe().ok) {
+    console.log(`[shep] ${NATIVE_MODULE} rebuilt successfully.`);
+    return;
+  }
+
+  printManualGuidance();
+}
+
+try {
+  main();
+} catch {
+  // Never let this guard fail the install — the runtime error handles the
+  // missing-binding case with the same guidance.
+}
+process.exit(0);

--- a/src/presentation/cli/index.ts
+++ b/src/presentation/cli/index.ts
@@ -78,6 +78,7 @@ import { startDaemon } from './commands/daemon/start-daemon.js';
 
 // DI container and settings
 import { initializeContainer, container } from '@/infrastructure/di/container.js';
+import { SqliteNativeBindingError } from '@/infrastructure/errors/sqlite-native-binding-error.js';
 import { InitializeSettingsUseCase } from '@/application/use-cases/settings/initialize-settings.use-case.js';
 import { initializeSettings } from '@/infrastructure/services/settings.service.js';
 import { initI18n as initCliI18n } from './i18n.js';
@@ -95,8 +96,15 @@ async function bootstrap() {
       // Expose the DI container on globalThis for the web UI's server-side code
       (globalThis as Record<string, unknown>).__shepContainer = container;
     } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      messages.error('Failed to initialize database', err);
+      if (error instanceof SqliteNativeBindingError) {
+        // Native addon couldn't load — print the fix, not a stack trace.
+        messages.error(error.message);
+        messages.newline();
+        messages.log(error.remediation);
+      } else {
+        const err = error instanceof Error ? error : new Error(String(error));
+        messages.error('Failed to initialize database', err);
+      }
       throw error; // Re-throw to trigger outer catch
     }
 

--- a/tests/unit/infrastructure/errors/sqlite-native-binding-error.test.ts
+++ b/tests/unit/infrastructure/errors/sqlite-native-binding-error.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  SqliteNativeBindingError,
+  SqliteNativeBindingErrorCode,
+  isSqliteNativeBindingError,
+  toSqliteNativeBindingError,
+} from '@/infrastructure/errors/sqlite-native-binding-error.js';
+
+/**
+ * The real error better-sqlite3 throws when the compiled `.node` addon is
+ * absent (e.g. install scripts were skipped, or no prebuilt binary exists
+ * for the running Node ABI). Trimmed from a real report on Node 24 / arm64.
+ */
+const BINDINGS_NOT_FOUND_MESSAGE = [
+  'Could not locate the bindings file. Tried:',
+  ' → /usr/lib/node_modules/@shepai/cli/node_modules/better-sqlite3/build/better_sqlite3.node',
+  ' → /usr/lib/node_modules/@shepai/cli/node_modules/better-sqlite3/lib/binding/node-v137-darwin-arm64/better_sqlite3.node',
+].join('\n');
+
+/**
+ * The error thrown when a prebuilt/compiled binary exists but targets a
+ * different Node ABI than the runtime (typical after a Node upgrade).
+ */
+const ABI_MISMATCH_MESSAGE =
+  'The module was compiled against a different Node.js version using ' +
+  'NODE_MODULE_VERSION 127. This version of Node.js requires ' +
+  'NODE_MODULE_VERSION 137. Please try re-compiling or re-installing the module.';
+
+describe('isSqliteNativeBindingError', () => {
+  it('detects the "Could not locate the bindings file" failure', () => {
+    expect(isSqliteNativeBindingError(new Error(BINDINGS_NOT_FOUND_MESSAGE))).toBe(true);
+  });
+
+  it('detects a NODE_MODULE_VERSION ABI mismatch', () => {
+    expect(isSqliteNativeBindingError(new Error(ABI_MISMATCH_MESSAGE))).toBe(true);
+  });
+
+  it('detects an ERR_DLOPEN_FAILED code on the error', () => {
+    const err = Object.assign(new Error('dlopen failed'), { code: 'ERR_DLOPEN_FAILED' });
+    expect(isSqliteNativeBindingError(err)).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isSqliteNativeBindingError(new Error('database is locked'))).toBe(false);
+  });
+
+  it('returns false for non-error values', () => {
+    expect(isSqliteNativeBindingError(null)).toBe(false);
+    expect(isSqliteNativeBindingError(undefined)).toBe(false);
+    expect(isSqliteNativeBindingError('Could not locate the bindings file')).toBe(false);
+  });
+});
+
+describe('toSqliteNativeBindingError', () => {
+  it('wraps the raw error, preserving it as the cause', () => {
+    const raw = new Error(BINDINGS_NOT_FOUND_MESSAGE);
+    const wrapped = toSqliteNativeBindingError(raw);
+
+    expect(wrapped).toBeInstanceOf(SqliteNativeBindingError);
+    expect(wrapped.name).toBe('SqliteNativeBindingError');
+    expect(wrapped.cause).toBe(raw);
+  });
+
+  it('classifies a missing-bindings error as BINDINGS_NOT_FOUND', () => {
+    const wrapped = toSqliteNativeBindingError(new Error(BINDINGS_NOT_FOUND_MESSAGE));
+    expect(wrapped.code).toBe(SqliteNativeBindingErrorCode.BINDINGS_NOT_FOUND);
+  });
+
+  it('classifies an ABI mismatch as ABI_MISMATCH', () => {
+    const wrapped = toSqliteNativeBindingError(new Error(ABI_MISMATCH_MESSAGE));
+    expect(wrapped.code).toBe(SqliteNativeBindingErrorCode.ABI_MISMATCH);
+  });
+
+  it('produces actionable, cross-platform remediation', () => {
+    const wrapped = toSqliteNativeBindingError(new Error(BINDINGS_NOT_FOUND_MESSAGE));
+
+    // Names the failing module and the primary fix command.
+    expect(wrapped.remediation).toContain('better-sqlite3');
+    expect(wrapped.remediation).toContain('npm rebuild');
+    // Mentions the running Node version so users can spot ABI churn.
+    expect(wrapped.remediation).toContain(process.version);
+  });
+
+  it('gives a concise, human-readable headline as the message', () => {
+    const wrapped = toSqliteNativeBindingError(new Error(BINDINGS_NOT_FOUND_MESSAGE));
+    expect(wrapped.message.toLowerCase()).toContain('native');
+    // The headline stays short — the detail lives in `remediation`.
+    expect(wrapped.message).not.toContain('\n');
+  });
+});

--- a/tests/unit/infrastructure/persistence/sqlite/connection-native-binding.test.ts
+++ b/tests/unit/infrastructure/persistence/sqlite/connection-native-binding.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { SqliteNativeBindingError } from '@/infrastructure/errors/sqlite-native-binding-error.js';
+
+// Simulate better-sqlite3's native addon failing to load, exactly as it does
+// when the compiled binary is missing for the running Node ABI.
+vi.mock('better-sqlite3', () => ({
+  default: class {
+    constructor() {
+      throw new Error('Could not locate the bindings file. Tried:\n → .../better_sqlite3.node');
+    }
+  },
+}));
+
+// Keep the connection off the real filesystem — the failure we care about
+// happens at `new Database()`, before any pragma runs.
+vi.mock('@/infrastructure/services/filesystem/shep-directory.service.js', () => ({
+  ensureShepDirectory: vi.fn().mockResolvedValue(undefined),
+  getShepDbPath: vi.fn(() => ':memory:'),
+}));
+
+describe('getSQLiteConnection with a missing native binding', () => {
+  it('translates the raw bindings failure into a SqliteNativeBindingError', async () => {
+    const { getSQLiteConnection } = await import(
+      '@/infrastructure/persistence/sqlite/connection.js'
+    );
+
+    await expect(getSQLiteConnection()).rejects.toBeInstanceOf(SqliteNativeBindingError);
+  });
+});


### PR DESCRIPTION
better-sqlite3 is a native addon whose compiled binary can be missing on a
global install — install scripts skipped, no prebuilt for the running Node
ABI, or a stale binary after a Node upgrade. The CLI crashed at bootstrap
with a raw "Could not locate the bindings file" stack trace.

- Detect and wrap the native-binding failure in a typed
  SqliteNativeBindingError carrying concise, cross-platform remediation
  (infrastructure/errors/sqlite-native-binding-error.ts + connection.ts).
- Render the remediation instead of a stack trace at CLI bootstrap.
- Add a best-effort postinstall guard (scripts/verify-native-bindings.mjs)
  that probes the addon, attempts one npm rebuild, and never fails install.

A shep-doctor check was intentionally omitted: bootstrap opens the database
before any command (including doctor) is parsed, so such a check can never
run in the exact failure it targets.

Claude-Session: https://claude.ai/code/session_014kwPxavnjwgs3QqL7iSbMn

Co-Authored-By: Shep Bot <shep-agent@users.noreply.github.com>