### PR TITLE
feat(agents): add shep-workstreams skill for parallel execution planning

### DIFF
--- a/.claude/skills/shep-workstreams/SKILL.md
+++ b/.claude/skills/shep-workstreams/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: shep-workstreams
+description: Use when a large body of work (a version milestone, an epic, a roadmap, a set of PRDs/design docs) needs to be broken into parallel workstreams and executed with the shep CLI. Triggers include "break this down", "split into workstreams", "plan V6", "what should we build first", "run these in parallel", "dependency graph", "merge order", "worktree split", or any request to turn planning docs into running shep features. Produces a workstream plan first, then drives `shep feat new` / `shep feat start` wave by wave. Part of the Shep autonomous SDLC platform — https://shep.bot
+metadata:
+  version: '1.0.0'
+  author: Shep AI (https://shep.bot)
+  homepage: https://shep.bot
+  repository: https://github.com/shep-ai/shep
+---
+
+# Workstream Breakdown & Parallel Execution with Shep
+
+Turn a large, vague body of work into a small set of **parallel workstreams**, then execute
+each one as an isolated shep feature. One workstream = one feature = one worktree = one agent.
+
+## The rule this skill exists to enforce
+
+**Never tell an agent "work on all of it."** That produces context loss, jumping between
+unrelated tasks, dozens of touched files, giant commits, and merge conflicts.
+
+Act like a tech lead: partition first, then run one focused agent per partition.
+
+## Two phases, hard separated
+
+```
+PHASE 1 — PLAN            PHASE 2 — EXECUTE
+(read-only, no shep       (shep feat new / start,
+ mutations, produces      wave by wave, monitored)
+ WORKSTREAMS.md)
+```
+
+**Do not create a single feature until Phase 1 is written down and the user has approved it.**
+The plan is cheap. Rework across six half-merged branches is not.
+
+---
+
+## Phase 1 — Produce the workstream plan
+
+### Step 1: Read every source doc, in full
+
+Read all the input material (PRDs, design docs, roadmap, existing specs, issue lists) before
+writing anything. Then inventory the **deliverables** — not the docs, the actual things that
+must exist when this is done.
+
+### Step 2: Answer the five tech-lead questions
+
+Answer these explicitly in the plan. They are the whole point of the exercise:
+
+1. **What is on the critical path?** Which deliverables block everything else, and which are
+   genuinely independent?
+2. **What does the dependency graph look like?** Which files and components are shared between
+   deliverables? Which subtrees are touched by exactly one deliverable?
+3. **What is the right worktree split?** Group deliverables into the *smallest set* of parallel
+   branches that minimises merge conflicts. Estimate merge risk for each.
+4. **What are the integration milestones?** Replace "finish V6" with contract-level checkpoints
+   ("backend contract frozen", "design system frozen", "CRUD complete", "QA").
+5. **Which decisions are irreversible?** What should be decided *now* because changing it later
+   is expensive — and what should be *deliberately delayed* behind a flag?
+
+### Step 3: Partition on file ownership, not on feature semantics
+
+This is the single highest-leverage rule, and the one most often gotten wrong:
+
+> Two deliverables that both edit the same file belong in the **same** workstream,
+> no matter how unrelated they sound. Two deliverables that touch disjoint subtrees belong in
+> **different** workstreams, no matter how related they sound.
+
+For the full partitioning rubric — the foundation-first rule, ship-the-small-thing-first rule,
+merge-risk scoring, concurrency caps, and the common failure modes — read
+`references/partitioning.md`.
+
+### Step 4: Write `WORKSTREAMS.md`
+
+Use `templates/workstream-plan.md`. Every workstream gets, without exception:
+
+| Field | Meaning |
+| --- | --- |
+| `scope` | What is in it — and an explicit **not in scope** line |
+| `blocked_by` / `blocks` | Edges of the dependency graph, by workstream id |
+| `expected_files` | Globs. If two workstreams share a glob, one of them is mis-cut |
+| `merge_risk` | Low / Medium / High, with the reason |
+| `branch` | Recommended branch name |
+| `completion_criteria` | Observable, checkable — not "done" |
+| `shep_command` | The exact `shep feat new` invocation that starts it |
+
+Then add, at the plan level: the **merge order**, the **integration milestones**, the
+**irreversible decisions**, and any work that should be **pulled earlier** into the current
+release (small, high-impact, zero-dependency items usually should be).
+
+### Step 5: Stop and get approval
+
+Present the plan. Ask specifically about: the workstream count, the merge order, and anything
+recommended for pull-forward. Do not proceed to Phase 2 unapproved.
+
+---
+
+## Phase 2 — Execute with the shep CLI
+
+### The mechanics that matter
+
+Shep already does worktree-per-workstream. **Do not hand-roll `git worktree add`.**
+
+- `shep feat new "<description>"` creates a branch **and an isolated worktree off the repo's
+  default branch**, then spawns an agent in it.
+- `--pending` creates the feature *without* spawning. `shep feat start <id>` spawns it later.
+  This is how you stage waves.
+- `--parent <feature-id>` records a real dependency. The child starts `Blocked`. When the parent
+  reaches `Implementation`, `Review`, or `Maintain`, shep **automatically rebases the child's
+  branch onto the parent's branch and spawns its agent**. Only *direct* children unblock — a
+  chain A → B → C cascades one link at a time, which is what you want.
+- `--attach <path>` is repeatable. Attach the source PRDs/design docs to every feature so each
+  agent has the context without you pasting it.
+
+Full flag reference, monitoring commands, and the PM/work-item commands are in
+`references/cli-reference.md`. Read it before composing commands.
+
+### Step 1: Encode the graph, do not improvise it
+
+Create features in dependency order so `--parent` ids exist when you need them.
+
+```bash
+# Wave 0 — foundation. Nothing else can start until this reaches Implementation.
+shep feat new "Foundation: shared types, API contracts, routing, feature flags, design tokens" \
+  --repo /path/to/project \
+  --attach docs/v6-overview.md --attach docs/v6-api.md \
+  --push --pr
+
+# Note the returned feature id (or: shep feat ls)
+```
+
+```bash
+# Wave 1 — dependents. Blocked until foundation hits Implementation, then auto-rebased + spawned.
+shep feat new "Creator storefront: creator page, claim flow, generated profile" \
+  --repo /path/to/project --parent <foundation-id> \
+  --attach docs/v6-storefront.md --push --pr
+
+shep feat new "Listings: listing page, CRUD, publish flow, ownership badges" \
+  --repo /path/to/project --parent <foundation-id> \
+  --attach docs/v6-listings.md --push --pr
+```
+
+```bash
+# Truly independent, zero shared files — start it immediately, in parallel with foundation.
+shep feat new "Attribution: deep links, ?via= params, tracking, creator analytics" \
+  --repo /path/to/project --attach docs/v6-attribution.md --push --pr
+```
+
+```bash
+# Later waves you want held back for capacity, not dependencies — stage them.
+shep feat new "Collections: object model, relationships, recommendation surfaces" \
+  --repo /path/to/project --parent <foundation-id> --pending
+# release when you have the reviewer bandwidth:
+shep feat start <collections-id>
+```
+
+### Step 2: Choose the dependency mechanism deliberately
+
+| Situation | Use |
+| --- | --- |
+| B needs A's code | `--parent <A>` — auto-rebase onto A's branch, auto-start |
+| B is independent but you lack review capacity now | `--pending`, then `shep feat start` |
+| B is independent and you have capacity | plain `shep feat new` — run it now |
+| B and A edit the same files | **Not two workstreams.** Merge them into one feature |
+
+`--parent` is not a substitute for good partitioning. If everything is a child of everything,
+you have built a sequential pipeline with extra steps.
+
+### Step 3: Respect the concurrency cap
+
+Run at most as many in-flight features as you have **disjoint file sets** — and no more than you
+can actually review. Six agents producing six unreviewed PRs is not parallelism, it is a queue
+with a worse failure mode. Stage the rest with `--pending`.
+
+### Step 4: Monitor and drive to merge order
+
+```bash
+shep feat ls                 # tree: repo → feature → children, with lifecycle + phase
+shep feat show <id>          # detail, including what it is waiting on
+shep feat logs <id>          # agent output
+shep feat approve <id>       # clear an approval gate
+shep feat reject <id>        # send it back with feedback
+shep feat resume <id>        # resume a stopped or failed feature agent
+```
+
+Merge in the plan's stated order. After each merge, re-check `shep feat ls` — a parent reaching
+`Implementation` will have unblocked its children automatically, and their rebases may have
+surfaced conflicts worth looking at before the next wave.
+
+### Step 5: Track the graph as work items (optional, for larger efforts)
+
+When the effort is big enough that the plan needs to outlive the terminal session, mirror it in
+shep's PM layer — `shep project new`, `shep item new`, `shep item relate --type blocking`,
+`shep cycle new`, `shep cycle add-items`. See `references/cli-reference.md`.
+
+---
+
+## Anti-patterns — reject these when you see them
+
+- **One mega-feature.** "Implement V6" is not a workstream. If the description needs the word
+  "and" three times, split it.
+- **Workstreams cut along team or doc boundaries.** Cut along *file* boundaries. The doc
+  structure has no idea what shares a schema file.
+- **Everything parented to everything.** That is a sequential pipeline. Find the genuinely
+  independent slice and run it now.
+- **Foundation that keeps growing.** Foundation is contracts, types, routing, flags, tokens —
+  and nothing else. The moment it grows a UI, it stops being mergeable and blocks five streams.
+- **Deferring the small high-impact slice.** If something is small, near-zero-dependency, and
+  valuable, ship it *first*. It validates the pipeline end to end while foundation is in flight.
+- **Hand-rolled `git worktree add` alongside shep features.** Shep owns the worktrees. Mixing
+  the two loses tracking, gates, auto-rebase, and unblocking.

--- a/.claude/skills/shep-workstreams/references/cli-reference.md
+++ b/.claude/skills/shep-workstreams/references/cli-reference.md
@@ -1,0 +1,168 @@
+# Shep CLI Reference for Workstream Execution
+
+Only the commands relevant to planning and running parallel workstreams. Run `shep <group> --help`
+for the authoritative surface on the installed version.
+
+---
+
+## `shep feat new <description>` — create a workstream
+
+Creates a git branch **and an isolated worktree off the repository's default branch**, then spawns
+an agent in that worktree. This is shep's worktree-per-workstream primitive — never hand-roll
+`git worktree add` next to it.
+
+| Flag | Effect |
+| --- | --- |
+| `-r, --repo <path>` | Repository path (defaults to current directory) |
+| `--remote <url>` | GitHub URL or `owner/repo` — clones (or forks) first. Conflicts with `--repo` |
+| `--parent <fid>` | Parent feature id, full or partial prefix. See **Dependencies** below |
+| `--pending` | Create the feature **without** spawning the agent. Release later with `feat start` |
+| `--attach <path>` | Attach a file to the feature. **Repeatable** — use it for every source doc |
+| `--push` | Push the branch to remote after implementation |
+| `--pr` | Open a PR on implementation complete (implies `--push`) |
+| `--no-pr` | Do not open a PR |
+| `--allow-prd` | Auto-approve through requirements, pause after |
+| `--allow-plan` | Auto-approve through planning, pause at implementation |
+| `--allow-merge` | Auto-approve the merge phase |
+| `--allow-all` | Fully autonomous — no approval pauses |
+| `--fast` / `--no-fast` | `--fast` (default on) implements directly from the prompt. `--no-fast` runs the full SDLC: analyze → requirements → plan → implement |
+| `--explore` | Exploration/prototyping session for iterative design. Conflicts with `--fast` |
+| `--model <model>` | LLM model identifier for this run |
+| `--no-rebase` | Skip syncing the default branch from remote before branching |
+| `--inject-skills` / `--no-inject-skills` | Copy curated skills into the worktree |
+
+### Mode selection for workstreams
+
+- **Foundation and contract work** → `--no-fast`. Getting shared types and API contracts wrong is
+  the expensive mistake; make the agent go through requirements and planning.
+- **Well-specified leaf workstreams** → `--fast` (default). The plan already did the thinking.
+- **Genuinely unknown shape** → `--explore` first, then `shep feat promote <id>` to convert the
+  prototype into an implementation feature.
+
+### Approval gates for workstreams
+
+Leaving gates closed means the agent pauses and waits for you. With five in-flight workstreams
+that is five things queued on your attention. Set gates by merge risk:
+
+- **Low risk, disjoint subtree** → `--allow-all` and review at the PR.
+- **Medium risk** → `--allow-plan`, so you see the plan before implementation begins.
+- **High risk / foundation** → no auto-approval flags. Review every gate.
+
+---
+
+## Dependencies: `--parent`
+
+`--parent <fid>` is a first-class dependency edge, not just metadata:
+
+1. The child is created in the `Blocked` lifecycle and no agent spawns.
+2. When the parent reaches `Implementation`, `Review`, or `Maintain`, shep automatically
+   **rebases the child's branch onto the parent's branch** and **spawns the child's agent**.
+3. Only **direct** children are evaluated. In a chain A → B → C, C stays blocked until B itself
+   reaches the gate — the cascade is one link at a time.
+4. Cycles are rejected at creation time.
+5. A child inherits the parent's repository path.
+
+`--parent` combined with `--pending` defers the gate check to `shep feat start` — use it when you
+want a dependency edge *and* manual release control.
+
+`Pending` and `Exploring` parents never unblock children.
+
+---
+
+## Staging waves: `--pending` + `shep feat start`
+
+```bash
+shep feat new "<workstream>" --repo <path> --pending    # created, not running
+shep feat start <id>                                    # spawn now
+```
+
+Use this when a workstream is *technically* unblocked but you lack review capacity. It keeps the
+plan encoded in shep rather than in your head.
+
+---
+
+## Monitoring
+
+| Command | Use |
+| --- | --- |
+| `shep feat ls` | Tree view: repo → feature → children, with lifecycle and current phase |
+| `shep feat ls -r, --repo <path>` | Scope to one repository |
+| `shep feat ls --show-archived` | Include archived features |
+| `shep feat show <id>` | Full detail, including what the feature is waiting on |
+| `shep feat logs <id>` | Agent output |
+| `shep feat logs <id> -f` | Follow. `-n, --lines <count>` to limit history |
+| `shep status` | Overall status |
+| `shep agent ls` / `shep agent show <id>` | Agent-run level detail |
+
+Feature ids accept partial prefixes (the 8-character prefix shown in `feat ls` is enough).
+
+---
+
+## Driving features forward
+
+| Command | Use |
+| --- | --- |
+| `shep feat approve [id]` | Clear the current approval gate |
+| `shep feat reject [id]` | Send the phase back |
+| `shep feat feedback <id> <feedback>` | Give the agent corrective direction |
+| `shep feat review [id]` | Trigger merge review |
+| `shep feat resume <id>` | Resume a stopped or failed feature agent |
+| `shep feat promote <id> [--fast]` | Promote an exploration into an implementation feature |
+| `shep feat adopt <branch> [-r <path>]` | Bring an existing branch under shep management |
+| `shep feat archive <id>` / `shep feat unarchive <id>` | Park a finished workstream |
+| `shep feat del <id> [-f] [--no-cleanup] [--no-close-pr]` | Delete a feature and its worktree |
+
+---
+
+## Lifecycle values
+
+`Started` · `Analyze` · `Requirements` · `Research` · `Planning` · `Implementation` · `Review` ·
+`Maintain` · `Blocked` · `Pending` · `Exploring` · `Deleting` · `AwaitingUpstream` · `Archived`
+
+The unblock gate is `Implementation` / `Review` / `Maintain`.
+
+---
+
+## Repositories
+
+```bash
+shep repo ls                          # tracked repositories
+shep repo show <id>
+shep repo add --url <url> [--dest <path>]
+shep repo init-remote [name]          # create a GitHub repo and wire the remote
+```
+
+---
+
+## Tracking the plan as work items
+
+For efforts large enough that the plan must outlive the terminal session, mirror the workstream
+graph in shep's PM layer. The blocking relation is the durable form of your dependency graph.
+
+```bash
+shep project new -n "V6" -p V6 -d "V6 milestone"
+shep project ls
+shep project show <slug>
+
+shep item new <project> -t "Foundation: contracts + shared types" -p urgent \
+  -d "See WORKSTREAMS.md#foundation"
+shep item new <project> -t "Creator storefront" -p high
+shep item ls <project>
+
+# Dependency edges — source blocks target
+shep item relate V6-1 V6-2 --type blocking
+```
+
+Relation types: `blocking`, `relates-to`, `duplicate`, `starts-before`, `finishes-before`.
+
+Sub-items: `shep item new <project> --parent PROJ-42`.
+
+Waves map cleanly onto cycles:
+
+```bash
+shep cycle new <project> -n "Wave 1 — Foundation" -s 2026-01-06 -e 2026-01-17
+shep cycle add-items <cycle-id> <item-id> <item-id>
+shep cycle show <cycle-id>
+shep cycle transfer <source> [target] # move incomplete items to another cycle
+shep item export <project> -o <file>  # export work items as CSV
+```

--- a/.claude/skills/shep-workstreams/references/partitioning.md
+++ b/.claude/skills/shep-workstreams/references/partitioning.md
@@ -1,0 +1,133 @@
+# Partitioning Rubric
+
+How to cut a large body of work into the smallest set of parallel workstreams that minimises
+merge conflicts. Read this during Phase 1, before writing `WORKSTREAMS.md`.
+
+---
+
+## 1. Build the file-ownership map first
+
+Before grouping anything, for each deliverable list the files and directories it will touch. Be
+concrete — globs, not prose. Then compute the overlaps.
+
+```
+deliverable                    expected files
+─────────────────────────────  ────────────────────────────────────
+creator page                   app/creators/**, components/creator/**, lib/api/creators.ts
+claim flow                     app/creators/claim/**, lib/api/creators.ts   ← overlap
+listing CRUD                   app/listings/**, lib/api/listings.ts
+publish flow                   app/listings/**, lib/api/listings.ts         ← overlap
+deep links / ?via=             lib/attribution/**, middleware.ts
+shared types                   types/**, lib/api/*.ts                       ← overlaps everything
+```
+
+The overlaps *are* the partition. Read them, don't guess at them.
+
+## 2. The cutting rules, in priority order
+
+**Rule 1 — Same file, same workstream.**
+Two deliverables that edit the same file belong in one workstream, however unrelated they sound.
+This rule wins over every other consideration. Violating it is what produces the conflict-heavy
+merges that make parallel agents worse than sequential ones.
+
+**Rule 2 — Anything that overlaps everything becomes foundation, and goes first.**
+Shared types, API contracts, routing, feature flags, design tokens. These are the file-overlap
+hubs. They belong in a single small workstream that merges before the streams that depend on them.
+
+**Rule 3 — Foundation stays small and mergeable.**
+Foundation is contracts and shared primitives. Nothing else. The moment it grows a UI or a
+migration or a feature, it stops being a quick merge and it blocks every downstream stream while
+it drags. If foundation would take more than a day or two of agent time, split the contracts out
+from the implementation and merge the contracts alone.
+
+**Rule 4 — Ship the small, high-impact, zero-dependency slice first.**
+If something is small, touches nothing else, and delivers real value, it goes out *before*
+foundation lands — in parallel with it. It validates the whole pipeline end to end (branch →
+agent → PR → review → merge → deploy) while the risk is low, and often belongs in the current
+release rather than the one being planned.
+
+**Rule 5 — Mostly-backend and mostly-frontend work usually separate cleanly.**
+Different directories, different tests, different review reflexes. Split them unless they share
+a contract file — in which case the contract goes to foundation (Rule 2) and both halves become
+independent.
+
+**Rule 6 — Prefer fewer, larger workstreams over many small ones.**
+The cost of a workstream is not agent time, it is your review attention and one more branch
+drifting from the default branch. Split only when the split buys real parallelism.
+
+## 3. Merge-risk scoring
+
+Score each workstream against the *other workstreams that will be in flight at the same time*.
+Risk is a property of a pair, not of a workstream in isolation.
+
+| Risk | Test | Mitigation |
+| --- | --- | --- |
+| **Low** | Disjoint subtree. No file glob overlaps any concurrent workstream | Run it concurrently. `--allow-all` is reasonable |
+| **Medium** | Same directory, different files. Or shares a file that is append-only (a barrel export, a route table, a registry) | Run it concurrently, merge it earlier rather than later. `--allow-plan` |
+| **High** | Shares an edited file with a concurrent workstream. Or edits a migration / schema / lockfile another stream also edits | **Re-cut it.** If it genuinely cannot be re-cut, sequence it with `--parent` and keep gates closed |
+
+A plan where most workstreams are High risk has not been partitioned — it has been labelled.
+Go back to the file-ownership map.
+
+## 4. Concurrency cap
+
+The number of workstreams to have in flight at once is the **smaller** of:
+
+- the number of mutually disjoint file sets, and
+- the number of PRs you can actually review in the same window.
+
+Everything beyond that is staged with `--pending` and released with `shep feat start`. Six
+in-flight agents producing six unreviewed PRs is a queue, not parallelism — and every unreviewed
+branch drifts further from the default branch while it waits.
+
+## 5. Integration milestones
+
+Replace "finish the milestone" with contract-level checkpoints that can be observed and declared:
+
+- **Backend contract frozen** — API shapes and shared types merged; downstream streams may start.
+- **Design system frozen** — tokens and primitives merged; UI streams may start.
+- **CRUD complete** — core entity create/read/update/delete paths merged and exercised.
+- **<Domain> complete** — one per major workstream.
+- **QA** — cross-stream integration testing, after the last merge.
+
+Each milestone should name the workstreams it unblocks. A milestone that unblocks nothing is a
+status update, not a milestone.
+
+## 6. Irreversible decisions
+
+Two lists, both required in the plan.
+
+**Decide now** — cheap today, expensive later. Typically: data model and relationships, URL and
+routing structure, public API shapes, auth and permission model, ID and slug schemes, anything
+that will end up in a database or a published URL. These belong in foundation.
+
+**Deliberately delay** — put it behind a flag or an interface and decide when the information is
+better. Typically: ranking and recommendation logic, pricing rules, exact visual design,
+third-party vendor choices, caching strategy, anything where the first real usage data will
+change the answer.
+
+For each "delay" item, name the flag or seam that makes the delay possible. A deferred decision
+with no seam is not deferred — it is just undecided.
+
+## 7. Completion criteria
+
+Every workstream needs criteria that someone other than the author can check:
+
+- Bad: "Collections done"
+- Good: "A collection can be created, have listings added and removed, and render at
+  `/collections/[slug]`; the collections API is covered by integration tests; the collection card
+  has a Storybook story"
+
+If the criteria cannot be written concretely, the workstream's scope is still vague — fix the
+scope, not the criteria.
+
+## 8. Common failure modes
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Constant rebase conflicts between two streams | Cut on feature semantics, not file ownership | Merge the two streams into one |
+| Foundation never lands | Foundation grew implementation | Split contracts out, merge them alone |
+| Everything is `--parent` of everything | Dependency graph never actually computed | Build the file-ownership map, find the disjoint sets |
+| Agents produce huge unfocused diffs | Workstream scope has no "not in scope" line | Add explicit exclusions to every scope |
+| Five PRs waiting on review, none merging | Concurrency cap ignored | Stage the rest with `--pending` |
+| Late discovery that two streams assumed different API shapes | Contract was not frozen before dependents started | Enforce the "backend contract frozen" milestone as a real gate |

--- a/.claude/skills/shep-workstreams/templates/workstream-plan.md
+++ b/.claude/skills/shep-workstreams/templates/workstream-plan.md
@@ -1,0 +1,134 @@
+# <Milestone> — Workstream Execution Plan
+
+> Source documents: `<doc>`, `<doc>`, `<doc>`
+> Repository: `<path>` · Default branch: `<branch>`
+
+---
+
+## 1. Critical path
+
+<What blocks everything else, in one paragraph. Name the single workstream that, if it slips,
+slips the milestone.>
+
+## 2. Dependency graph
+
+```
+main
+ │
+ ├── A. foundation ──┬── B. <stream>
+ │                   ├── C. <stream>
+ │                   └── D. <stream>
+ │
+ └── E. <independent stream — no dependencies, runs immediately>
+```
+
+| Workstream | Blocked by | Blocks |
+| --- | --- | --- |
+| A. Foundation | — | B, C, D |
+| B. <name> | A | — |
+| C. <name> | A | — |
+| D. <name> | A | — |
+| E. <name> | — | — |
+
+## 3. Workstreams
+
+### A. Foundation
+
+- **Scope:** <what is in it>
+- **Not in scope:** <explicit exclusions — required, not optional>
+- **Blocked by:** —
+- **Blocks:** B, C, D
+- **Expected files:** `types/**`, `lib/api/*.ts`, `app/routes.ts`, `lib/flags.ts`, `styles/tokens.css`
+- **Merge risk:** Low — no other stream may touch these files while it is open
+- **Branch:** `foundation`
+- **Completion criteria:**
+  - <observable, checkable>
+  - <observable, checkable>
+- **Shep command:**
+  ```bash
+  shep feat new "Foundation: <scope summary>" \
+    --repo <path> --no-fast \
+    --attach <doc> --attach <doc> \
+    --push --pr
+  ```
+
+### B. <Name>
+
+- **Scope:**
+- **Not in scope:**
+- **Blocked by:** A
+- **Blocks:** —
+- **Expected files:**
+- **Merge risk:** <Low/Medium/High> — <reason, naming the concurrent stream it is measured against>
+- **Branch:**
+- **Completion criteria:**
+- **Shep command:**
+  ```bash
+  shep feat new "<description>" \
+    --repo <path> --parent <A-feature-id> \
+    --attach <doc> --allow-plan --push --pr
+  ```
+
+<Repeat per workstream.>
+
+## 4. Merge order
+
+```
+A. Foundation
+      ↓
+B. <stream>
+      ↓
+C. <stream>
+      ↓
+D. <stream>
+```
+
+E is independent and merges whenever it is ready — ideally first.
+
+**Rationale:** <why this order minimises rework, one or two sentences>
+
+## 5. Execution waves
+
+| Wave | Workstreams | Launch | Gate to next wave |
+| --- | --- | --- | --- |
+| 0 | A, E | `shep feat new` immediately | A reaches `Implementation` |
+| 1 | B, C | auto-start via `--parent A` | reviewer capacity |
+| 2 | D | staged `--pending`, released with `shep feat start` | — |
+
+**Concurrency cap:** <N> in flight — <the binding constraint: disjoint file sets or review capacity>
+
+## 6. Integration milestones
+
+| Milestone | Definition of done | Unblocks |
+| --- | --- | --- |
+| Backend contract frozen | <observable> | B, C, D |
+| Design system frozen | <observable> | B, C |
+| <Domain> complete | <observable> | — |
+| QA | <observable> | release |
+
+## 7. Irreversible decisions
+
+**Decide now (expensive to change later):**
+
+| Decision | Why now | Owner workstream |
+| --- | --- | --- |
+| <e.g. slug scheme for creator URLs> | Ends up in public URLs | A |
+
+**Deliberately delay (and the seam that allows it):**
+
+| Decision | Why delay | Seam |
+| --- | --- | --- |
+| <e.g. recommendation ranking> | No usage data yet | `RecommendationStrategy` interface behind flag `<name>` |
+
+## 8. Pull forward
+
+<Work that should ship in the current release rather than this milestone — typically small,
+zero-dependency, high-impact. State the reason for each.>
+
+| Item | Why earlier | Effort |
+| --- | --- | --- |
+| | | |
+
+## 9. Out of scope for this milestone
+
+<Explicitly listed, so no agent picks it up opportunistically.>

--- a/packages/core/src/domain/factories/settings-defaults.factory.ts
+++ b/packages/core/src/domain/factories/settings-defaults.factory.ts
@@ -190,6 +190,12 @@ export function createDefaultSettings(): Settings {
         remoteSkillName: 'shadcn-ui',
       },
       {
+        name: 'shep-workstreams',
+        type: SkillSourceType.Remote,
+        source: 'shep-ai/shep',
+        remoteSkillName: 'shep-workstreams',
+      },
+      {
         name: 'tsp-model',
         type: SkillSourceType.Remote,
         source: 'shep-ai/shep',

--- a/tests/unit/domain/factories/settings-defaults.factory.test.ts
+++ b/tests/unit/domain/factories/settings-defaults.factory.test.ts
@@ -408,6 +408,12 @@ describe('createDefaultSettings', () => {
               remoteSkillName: 'shadcn-ui',
             },
             {
+              name: 'shep-workstreams',
+              type: SkillSourceType.Remote,
+              source: 'shep-ai/shep',
+              remoteSkillName: 'shep-workstreams',
+            },
+            {
               name: 'tsp-model',
               type: SkillSourceType.Remote,
               source: 'shep-ai/shep',
@@ -448,9 +454,9 @@ describe('createDefaultSettings', () => {
       expect(settings.workflow.skillInjection!.enabled).toBe(false);
     });
 
-    it('should have 9 default skills', () => {
+    it('should have 10 default skills', () => {
       const settings = createDefaultSettings();
-      expect(settings.workflow.skillInjection!.skills).toHaveLength(9);
+      expect(settings.workflow.skillInjection!.skills).toHaveLength(10);
     });
 
     it('should have all skills as remote type', () => {
@@ -458,7 +464,7 @@ describe('createDefaultSettings', () => {
       const remoteSkills = settings.workflow.skillInjection!.skills.filter(
         (s) => s.type === SkillSourceType.Remote
       );
-      expect(remoteSkills).toHaveLength(9);
+      expect(remoteSkills).toHaveLength(10);
     });
 
     it('should have each remote skill with a remoteSkillName matching its name', () => {
@@ -488,6 +494,7 @@ describe('createDefaultSettings', () => {
         'mermaid-diagrams',
         'react-flow',
         'shadcn-ui',
+        'shep-workstreams',
         'tsp-model',
         'vercel-react-best-practices',
         'frontend-design',


### PR DESCRIPTION
## What

Adds the `shep-workstreams` skill — a comprehensive guide for breaking large bodies of work (milestones, epics, roadmaps) into parallel workstreams and executing them with the shep CLI. Includes the skill definition, CLI reference, partitioning rubric, and an executable workstream plan template. Registers the skill in default settings.

## Why

The shep platform's core value is parallel execution of isolated agents in worktrees. This skill codifies the tech-lead discipline required to make that work: partition on file ownership (not feature semantics), encode dependencies with `--parent`, respect concurrency caps, and drive to a merge order. Without this guidance, users default to sequential pipelines or conflict-heavy concurrent work.

The skill is part of the Shep autonomous SDLC platform (https://shep.bot) and triggers on requests like "break this down", "split into workstreams", "plan V6", "run these in parallel", or "dependency graph".

## Screenshots / Recording

N/A — non-UI change.

## Testing

- Updated `settings-defaults.factory.test.ts` to expect 10 default skills (was 9); test now passes with the new skill registered.
- Updated `settings-defaults.factory.ts` to include the `shep-workstreams` skill in the default skill injection list.
- Skill files are documentation and templates; no runtime logic to test.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (updated test expectations for skill count)
- [x] `pnpm build` succeeds
- [x] No `application/` or `presentation/` file imports anything from `infrastructure/`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_013szhaWYCa6PhbcF69mn1sx